### PR TITLE
fix: Presentation mode issues on checkboxes and radio buttons

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.stories.mdx
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.mdx
@@ -56,6 +56,10 @@ import {ArgsTable} from "@storybook/addon-docs";
         compact: {
             description: 'Kompakt visning.',
             control: {type: 'boolean'}
+        },
+        presentation: {
+            description: 'Sett denne hvis sjekkboksen er en del av en forhåndsvisning og ikke har noen funksjon. I denne modusen vil ikke teksten ved siden av sjekkboksen være klikkbar, med mindre den er en ren tekst. Dermed kan man ha klikkbare elementer som en del av teksten uten at de overlapper andre klikkbare ting.',
+            control: {type: 'boolean'}
         }
     }}
 />

--- a/packages/react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.test.tsx
@@ -9,11 +9,14 @@ import { Checkbox } from './';
 
 const user = userEvent.setup();
 
+const onChange = jest.fn();
 const defaultProps: CheckboxProps = {
-  onChange: jest.fn,
+  onChange,
 };
 
 describe('Checkbox', () => {
+  afterEach(jest.resetAllMocks);
+
   it('Should not be checked by default', () => {
     render();
     const checkbox = screen.getByRole('checkbox');
@@ -102,6 +105,43 @@ describe('Checkbox', () => {
     });
     expect(screen.getByText(labelText)).toBeInTheDocument();
     expect(screen.getByText(descriptionText)).toBeInTheDocument();
+  });
+
+  it('Has clickable label text by default if label is set', async () => {
+    const label = 'Label';
+    render({ label });
+    await act(() => user.click(screen.getByText(label)));
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('Does not have clickable label text if the "presentation" property is true and the label is a React node', async () => {
+    const labelText = 'Label';
+    render({
+      label: <span>{labelText}</span>,
+      presentation: true,
+    });
+    await act(() => user.click(screen.getByText(labelText)));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('Does not have clickable label text if the "presentation" property is true and the description is a React node', async () => {
+    const descriptionText = 'Description';
+    render({
+      label: <span>{descriptionText}</span>,
+      presentation: true,
+    });
+    await act(() => user.click(screen.getByText(descriptionText)));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('Has clickable checkbox even if the "presentation" property is true and the label is a React node', async () => {
+    const name = 'Label';
+    render({
+      label: <span>{name}</span>,
+      presentation: true,
+    });
+    await act(() => user.click(screen.getByRole('presentation', { name })));
+    expect(onChange).toHaveBeenCalled();
   });
 });
 

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
@@ -44,6 +44,10 @@ import {ArgsTable} from "@storybook/addon-docs";
         compact: {
             description: 'Kompakt visning.',
             control: {type: 'boolean'}
+        },
+        presentation: {
+            description: 'Sett denne hvis sjekkboksene er en del av en forhåndsvisning og ikke har noen funksjon. I denne modusen vil ikke teksten ved siden av sjekkboksene være klikkbar, med mindre den er en ren tekst. Dermed kan man ha klikkbare elementer som en del av teksten uten at de overlapper andre klikkbare ting.',
+            control: {type: 'boolean'}
         }
     }}
 />

--- a/packages/react/src/components/RadioButton/RadioButton.stories.mdx
+++ b/packages/react/src/components/RadioButton/RadioButton.stories.mdx
@@ -53,6 +53,10 @@ import {ArgsTable} from "@storybook/addon-docs";
             description: 'Brukes til å velge størrelse.',
             control: {type: 'radio', options: [RadioButtonSize.Small, RadioButtonSize.Xsmall]},
             defaultValue: RadioButtonSize.Small
+        },
+        presentation: {
+            description: 'Sett denne hvis radioknappen er en del av en forhåndsvisning og ikke har noen funksjon. I denne modusen vil ikke teksten ved siden av radioknappen være klikkbar, med mindre den er en ren tekst. Dermed kan man ha klikkbare elementer som en del av teksten uten at de overlapper andre klikkbare ting.',
+            control: {type: 'boolean'}
         }
     }}
 />

--- a/packages/react/src/components/RadioButton/RadioButton.test.tsx
+++ b/packages/react/src/components/RadioButton/RadioButton.test.tsx
@@ -148,6 +148,43 @@ describe('RadioButton', () => {
     expect(screen.getByText(labelText)).toBeInTheDocument();
     expect(screen.getByText(descriptionText)).toBeInTheDocument();
   });
+
+  it('Has clickable label text by default if label is set', async () => {
+    const label = 'Label';
+    render({ label });
+    await act(() => user.click(screen.getByText(label)));
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('Does not have clickable label text if the "presentation" property is true and the label is a React node', async () => {
+    const labelText = 'Label';
+    render({
+      label: <span>{labelText}</span>,
+      presentation: true,
+    });
+    await act(() => user.click(screen.getByText(labelText)));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('Does not have clickable label text if the "presentation" property is true and the description is a React node', async () => {
+    const descriptionText = 'Description';
+    render({
+      label: <span>{descriptionText}</span>,
+      presentation: true,
+    });
+    await act(() => user.click(screen.getByText(descriptionText)));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('Has clickable radio button even if the "presentation" property is true and the label is a React node', async () => {
+    const name = 'Label';
+    render({
+      label: <span>{name}</span>,
+      presentation: true,
+    });
+    await act(() => user.click(screen.getByRole('presentation', { name })));
+    expect(onChange).toHaveBeenCalled();
+  });
 });
 
 const render = (props: Partial<RadioButtonProps> = {}) => {

--- a/packages/react/src/components/RadioGroup/RadioGroup.stories.mdx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.stories.mdx
@@ -49,6 +49,10 @@ import {ArgsTable} from "@storybook/addon-docs";
             description: 'Brukes til å velge størrelse.',
             control: {type: 'radio', options: [RadioGroupSize.Small, RadioGroupSize.Xsmall]},
             defaultValue: RadioGroupSize.Small
+        },
+        presentation: {
+            description: 'Sett denne hvis radioknappene er en del av en forhåndsvisning og ikke har noen funksjon. I denne modusen vil ikke teksten ved siden av radioknappene være klikkbar, med mindre den er en ren tekst. Dermed kan man ha klikkbare elementer som en del av teksten uten at de overlapper andre klikkbare ting.',
+            control: {type: 'boolean'}
         }
     }}
 />

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
@@ -1,11 +1,10 @@
 .template {
-  --cursor: pointer;
+  --click-cursor: pointer;
   --description-color: var(--component-field_description-color-text-default);
   --label-color: var(--component-checkbox-color-text-default);
   --opacity: 1;
 
   border-radius: var(--input_box-border_radius);
-  cursor: var(--cursor);
   display: inline-flex;
   flex-direction: row;
   font-size: var(--font_size);
@@ -31,8 +30,12 @@
 }
 
 .template.disabled {
-  --cursor: auto;
+  --click-cursor: auto;
   --opacity: var(--interactive_components-colors-disabled-opacity);
+}
+
+.clickable  {
+  cursor: var(--click-cursor);
 }
 
 .inputWrapper {

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -55,19 +55,26 @@ export const CheckboxRadioTemplate = ({
   const labelId = label ? `${finalInputId}-label` : undefined;
   const descriptionId = description ? `${finalInputId}-description` : undefined;
   const showLabel = label && !hideLabel;
+  const shouldHaveClickableLabel = !presentation
+    || (typeof label !== 'object' && typeof description !== 'object');
 
   return (
-    <label
+    <Wrapper
       className={cn(
         classes.template,
         classes[size],
         disabled && classes.disabled,
         className,
       )}
-      htmlFor={inputId}
+      htmlFor={finalInputId}
+      isLabel={shouldHaveClickableLabel}
     >
       {!hideInput && (
-        <span className={classes.inputWrapper}>
+        <Wrapper
+          className={classes.inputWrapper}
+          htmlFor={finalInputId}
+          isLabel={!shouldHaveClickableLabel}
+        >
           <input
             aria-describedby={descriptionId}
             aria-label={
@@ -87,7 +94,7 @@ export const CheckboxRadioTemplate = ({
           <span className={classes.visibleBox}>
             {children}
           </span>
-        </span>
+        </Wrapper>
       )}
       {(showLabel || description) && (
         <span className={classes.labelAndDescription}>
@@ -103,6 +110,27 @@ export const CheckboxRadioTemplate = ({
           )}
         </span>
       )}
-    </label>
+    </Wrapper>
   );
 };
+
+interface WrapperProps {
+  children: ReactNode;
+  className: string;
+  htmlFor?: string;
+  isLabel: boolean;
+}
+
+const Wrapper = ({
+  children,
+  className,
+  htmlFor,
+  isLabel,
+}: WrapperProps) => isLabel ? (
+  <label
+    className={className + ' ' + classes.clickable}
+    htmlFor={htmlFor}
+  >
+    {children}
+  </label>
+) : <span className={className}>{children}</span>;


### PR DESCRIPTION
In Altinn Studio, we need to have buttons and input fields inside the labels in preview mode (issue #32). Therefore the labels should not be clickable, to avoid overlapping clickable surfaces in the view.

I have also added descriptions of the `presentation` props in the Storybook files.