### PR TITLE
fix(popover): retain focus on trigger when opening popover

### DIFF
--- a/packages/react/src/components/HelpText/HelpText.stories.mdx
+++ b/packages/react/src/components/HelpText/HelpText.stories.mdx
@@ -49,7 +49,7 @@ HelpText er et felt med en hjelpetekst som plasseres over annet innhold og kan v
     <Story
         name="HelpText"
         args={{
-            placement: 'top',
+            placement: 'right',
         }}
     >
         {Template.bind({})}

--- a/packages/react/src/components/Popover/Popover.stories.mdx
+++ b/packages/react/src/components/Popover/Popover.stories.mdx
@@ -11,8 +11,9 @@ import {ArgsTable} from "@storybook/addon-docs";
     parameters={{
         status: {
             type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-            url: 'http://www.url.com/status'
-        }
+            url: 'http://www.url.com/status',
+        },
+        docs: { inlineStories: false, iframeHeight: '200px' },
     }}
     argTypes={{
         trigger: {
@@ -65,6 +66,29 @@ export const Template = (args) => {
         </Popover>
 )};
 
+export const ComplexTemplate = (args) => {
+    return (
+        <Popover 
+            placement={args.placement} 
+            variant={args.variant}
+            arrow={args.arrow}
+            offset={args.offset}
+            {...defaultArgs}
+        >
+            <div style={{display: 'flex', 'align-items': 'center', gap: '1rem'}}>
+                Hallo!
+                <ul>
+                    <li>Coffee</li>
+                    <li>Tea</li>
+                    <li>Milk</li>
+                </ul>
+                <Button>
+                    Click me!
+                </Button>
+            </div>
+        </Popover>
+)};
+
 # Popover
 
 <BetaBlock />
@@ -79,11 +103,25 @@ Popover er et felt som plasseres over annet innhold og kan vises og skjules ved 
     <Story
         name="Popover"
         args={{
-            placement: 'top',
+            placement: 'top-start',
             variant: PopoverVariant.Default,
         }}
     >
         {Template.bind({})}
+    </Story>
+</Canvas>
+
+### Mer komplekst innhold
+
+<Canvas>
+    <Story
+        name="Mer komplekst innhold"
+        args={{
+            placement: 'right',
+            variant: PopoverVariant.Warning,
+        }}
+    >
+        {ComplexTemplate.bind({})}
     </Story>
 </Canvas>
 

--- a/packages/react/src/components/Popover/Popover.stories.mdx
+++ b/packages/react/src/components/Popover/Popover.stories.mdx
@@ -59,7 +59,6 @@ export const Template = (args) => {
             variant={args.variant}
             arrow={args.arrow}
             offset={args.offset}
-            modal={args.modal}
             {...defaultArgs}
         >
             Lorem ipsum dolor sit amet...

--- a/packages/react/src/components/Popover/Popover.test.tsx
+++ b/packages/react/src/components/Popover/Popover.test.tsx
@@ -7,7 +7,12 @@ import { PopoverVariant, Popover } from './Popover';
 
 const render = (props: Partial<PopoverProps> = {}) => {
   const allProps = {
-    children: <div>Popover text</div>,
+    children: (
+      <div>
+        <button>My button</button>
+        Popover text
+      </div>
+    ),
     trigger: <button>Open</button>,
     ...props,
   };
@@ -85,6 +90,34 @@ describe('popover', () => {
     render({ initialOpen: false });
 
     expect(screen.queryByText('Popover text')).not.toBeInTheDocument();
+  });
+
+  it('should retain focus on trigger when popover opens', async () => {
+    render();
+
+    const popoverTrigger = screen.getByRole('button', { name: 'Open' });
+    expect(screen.queryByText('Popover text')).not.toBeInTheDocument();
+    popoverTrigger.focus();
+    await act(async () => {
+      await user.keyboard('[Space]');
+    });
+    expect(popoverTrigger).toHaveFocus();
+  });
+
+  it('should focus focasable content on tab', async () => {
+    render();
+
+    const popoverTrigger = screen.getByRole('button', { name: 'Open' });
+    expect(screen.queryByText('Popover text')).not.toBeInTheDocument();
+    popoverTrigger.focus();
+    await act(async () => {
+      await user.keyboard('[Space]');
+    });
+    const contentButton = screen.getByRole('button', { name: 'My button' });
+    await act(async () => {
+      await user.keyboard('[Tab]');
+    });
+    expect(contentButton).toHaveFocus();
   });
 
   test.each(Object.values(PopoverVariant))(

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -23,7 +23,6 @@ import {
   useInteractions,
   useMergeRefs,
   FloatingPortal,
-  FloatingFocusManager,
 } from '@floating-ui/react';
 import cn from 'classnames';
 
@@ -42,7 +41,6 @@ interface IPopoverOptions extends HTMLAttributes<HTMLDivElement> {
   offset?: number;
   initialOpen?: boolean;
   placement?: Placement;
-  modal?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -59,7 +57,6 @@ export function usePopover({
   arrow,
   initialOpen,
   placement,
-  modal,
   offset: offset,
   open: controlledOpen,
   onOpenChange: setControlledOpen,
@@ -104,22 +101,11 @@ export function usePopover({
       ...interactions,
       ...data,
       ...restOptions,
-      modal,
       arrow,
       arrowRef,
       variant,
     }),
-    [
-      open,
-      setOpen,
-      interactions,
-      data,
-      restOptions,
-      modal,
-      arrow,
-      arrowRef,
-      variant,
-    ],
+    [open, setOpen, interactions, data, restOptions, arrow, arrowRef, variant],
   );
 }
 
@@ -140,7 +126,6 @@ export const usePopoverContext = () => {
 export function Popover({
   children,
   trigger,
-  modal = false,
   arrow = true,
   initialOpen = false,
   ...restOptions
@@ -148,7 +133,6 @@ export function Popover({
   const popover = usePopover({
     arrow,
     initialOpen,
-    modal,
     ...restOptions,
   });
 
@@ -201,31 +185,25 @@ const PopoverContent = forwardRef<
   return (
     <FloatingPortal>
       {context.open && (
-        <FloatingFocusManager
-          context={context.context}
-          modal={context.modal}
-          visuallyHiddenDismiss={true}
+        <div
+          ref={ref}
+          style={{
+            position: context.strategy,
+            top: context.y ?? 0,
+            left: context.x ?? 0,
+            width: 'max-content',
+          }}
+          data-placement={context.placement}
+          className={cn(
+            classes.popover,
+            classes[context.variant],
+            context.className,
+          )}
+          {...context.getFloatingProps(props)}
+          role={'dialog'}
         >
-          <div
-            ref={ref}
-            style={{
-              position: context.strategy,
-              top: context.y ?? 0,
-              left: context.x ?? 0,
-              width: 'max-content',
-            }}
-            data-placement={context.placement}
-            className={cn(
-              classes.popover,
-              classes[context.variant],
-              context.className,
-            )}
-            {...context.getFloatingProps(props)}
-            role={'dialog'}
-          >
-            {props.children}
-          </div>
-        </FloatingFocusManager>
+          {props.children}
+        </div>
       )}
     </FloatingPortal>
   );


### PR DESCRIPTION
Focus will not be shifted to popover content on opening popover using keyboard. Tabbing will not enter popover unless there are interactive elements within the popover content.