### PR TITLE
fix(popover): popover screen reader ordering

### DIFF
--- a/packages/react/src/components/HelpText/HelpText.stories.mdx
+++ b/packages/react/src/components/HelpText/HelpText.stories.mdx
@@ -11,7 +11,7 @@ import {ArgsTable} from "@storybook/addon-docs";
         status: {
             type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
             url: 'http://www.url.com/status'
-        }
+        },
     }}
     argTypes={{
         children: {
@@ -28,7 +28,7 @@ import {ArgsTable} from "@storybook/addon-docs";
 
 export const Template = (args) => {
     return (
-        <HelpText 
+        <HelpText
             {...args}
         >
             Lorem ipsum dolor sit amet...
@@ -47,7 +47,17 @@ HelpText er et felt med en hjelpetekst som plasseres over annet innhold og kan v
 
 <Canvas>
     <Story
-        name="HelpText"
+        name='HelpText'
+        decorators={[
+            (Story) => (
+            <div style={{ margin: '3em' }}>
+                <Story />
+            </div>
+            ),
+        ]}
+        parameters={{
+            layout: 'centered',
+        }}
         args={{
             placement: 'right',
         }}

--- a/packages/react/src/components/HelpText/HelpText.tsx
+++ b/packages/react/src/components/HelpText/HelpText.tsx
@@ -49,7 +49,6 @@ export const HelpText = ({
             setOpen((isOpen) => !isOpen);
             onClick?.(event);
           }}
-          aria-expanded={open}
         >
           <HelptextFilled
             className={cn(

--- a/packages/react/src/components/Popover/Popover.module.css
+++ b/packages/react/src/components/Popover/Popover.module.css
@@ -1,6 +1,6 @@
 .popover {
   width: max-content;
-  z-index: 0;
+  z-index: 1;
   padding: 12px;
   max-width: calc(100vw - 20px);
   border: 1px solid gray;

--- a/packages/react/src/components/Popover/Popover.stories.mdx
+++ b/packages/react/src/components/Popover/Popover.stories.mdx
@@ -13,7 +13,6 @@ import {ArgsTable} from "@storybook/addon-docs";
             type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
             url: 'http://www.url.com/status',
         },
-        docs: { inlineStories: false, iframeHeight: '200px' },
     }}
     argTypes={{
         trigger: {
@@ -102,8 +101,18 @@ Popover er et felt som plasseres over annet innhold og kan vises og skjules ved 
 <Canvas>
     <Story
         name="Popover"
+        decorators={[
+            (Story) => (
+            <div style={{ margin: '3em' }}>
+                <Story />
+            </div>
+            ),
+        ]}
+        parameters={{
+            layout: 'centered',
+        }}
         args={{
-            placement: 'top-start',
+            placement: 'top',
             variant: PopoverVariant.Default,
         }}
     >
@@ -116,6 +125,16 @@ Popover er et felt som plasseres over annet innhold og kan vises og skjules ved 
 <Canvas>
     <Story
         name="Mer komplekst innhold"
+          decorators={[
+            (Story) => (
+            <div style={{ margin: '3em' }}>
+                <Story />
+            </div>
+            ),
+        ]}
+        parameters={{
+            layout: 'centered',
+        }}
         args={{
             placement: 'right',
             variant: PopoverVariant.Warning,

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -22,7 +22,6 @@ import {
   useRole,
   useInteractions,
   useMergeRefs,
-  FloatingPortal,
 } from '@floating-ui/react';
 import cn from 'classnames';
 
@@ -182,31 +181,28 @@ const PopoverContent = forwardRef<
   const context = usePopoverContext();
   const ref = useMergeRefs([context.floating, propRef]);
 
-  return (
-    <FloatingPortal>
-      {context.open && (
-        <div
-          ref={ref}
-          style={{
-            position: context.strategy,
-            top: context.y ?? 0,
-            left: context.x ?? 0,
-            width: 'max-content',
-          }}
-          data-placement={context.placement}
-          className={cn(
-            classes.popover,
-            classes[context.variant],
-            context.className,
-          )}
-          {...context.getFloatingProps(props)}
-          role={'dialog'}
-        >
-          {props.children}
-        </div>
+  return context.open ? (
+    <div
+      ref={ref}
+      style={{
+        position: context.strategy,
+        top: context.y ?? 0,
+        left: context.x ?? 0,
+        width: 'max-content',
+      }}
+      data-placement={context.placement}
+      className={cn(
+        classes.popover,
+        classes[context.variant],
+        context.className,
       )}
-    </FloatingPortal>
-  );
+      {...context.getFloatingProps(props)}
+      tabIndex={-1}
+      role={'dialog'}
+    >
+      {props.children}
+    </div>
+  ) : null;
 });
 
 const PopoverArrow = forwardRef<
@@ -220,7 +216,7 @@ const PopoverArrow = forwardRef<
   const arrowY = context.middlewareData.arrow?.y;
 
   // Get the placement of the popover arrow independent of alignment, which is opposite of popover content placement.
-  // Used to align the arrow to the edge of the content
+  // Used to align the arrow to the edge of the content.
   const staticSide: string | undefined = {
     top: 'bottom',
     right: 'left',


### PR DESCRIPTION
Use z-index and positioning: absolute instead of portaling to handle layering.
This is done in order to get the screenreader to read the content in the popover, when opened, directly after the trigger-element. The portal worked by appending the content to the end of the dom, which would always be read last.

Also update the docs with better canvases for displaying positioning abilities.