### PR TITLE
fix(Button): Only icon padding

### DIFF
--- a/packages/react/src/components/Button/Button.module.css
+++ b/packages/react/src/components/Button/Button.module.css
@@ -74,10 +74,6 @@
     border-style: dashed;
 }
 
-.button.onlyIcon {
-    padding: 0.5rem;
-}
-
 .button.outline {
     background-color: transparent;
 }
@@ -86,6 +82,10 @@
     --border-radius: 50px;
     padding: 0 calc(var(--button-vertical-padding) * 2 / 3);
     background-color: transparent;
+}
+
+.button.onlyIcon {
+    padding: 0.5rem;
 }
 
 /* Filled button colors */


### PR DESCRIPTION
Moved the `onlyIcon` class further down in the CSS file, so that its `padding` property is not overridden by the one defined for the `quiet` class.

# Related issue
- https://github.com/Altinn/altinn-studio/issues/9691