### PR TITLE
fix(Select): Set higher z-index on option list

### DIFF
--- a/packages/react/src/components/Select/Select.module.css
+++ b/packages/react/src/components/Select/Select.module.css
@@ -60,7 +60,7 @@
   );
   --option_list-number_of_visible_options: 7;
   --option_list-shadow: 1px 1px 3px #00000040;
-  --option_list-z_index: 1;
+  --option_list-z_index: 2;
   --option-outline-focus: none;
   --option-padding_horizontal: 12px;
   --singleselect_field-padding_left: 12px;


### PR DESCRIPTION
Z-index must be larger than the one used on `Tabs`.