### PR TITLE
Fix(help text): add title to helptext tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@
 module.exports = {
   moduleNameMapper: {
     '.(css|less|scss)$': 'identity-obj-proxy',
+    '\\.svg$': '<rootDir>/test/__mocks__/svg.ts',
   },
   preset: 'ts-jest',
   testEnvironment: 'jsdom',

--- a/packages/react/src/components/HelpText/HelpText.test.tsx
+++ b/packages/react/src/components/HelpText/HelpText.test.tsx
@@ -9,7 +9,14 @@ const render = (props: Partial<HelpTextProps> = {}) => {
   const allProps = {
     ...props,
   };
-  renderRtl(<HelpText {...allProps}>Help</HelpText>);
+  renderRtl(
+    <HelpText
+      title={'Helptext for test'}
+      {...allProps}
+    >
+      Help
+    </HelpText>,
+  );
 };
 
 const user = userEvent.setup();

--- a/test/__mocks__/svg.ts
+++ b/test/__mocks__/svg.ts
@@ -1,0 +1,2 @@
+export default 'SvgrURL';
+export const ReactComponent = 'div';


### PR DESCRIPTION
Fix tests that failed after making title required for HelpText component.
Also add svg mock to fix failing SvgIcon component tests.