### PR TITLE
fix: update figma-token

### DIFF
--- a/packages/react/src/components/Popover/Popover.module.css
+++ b/packages/react/src/components/Popover/Popover.module.css
@@ -1,6 +1,6 @@
 .popover {
   width: max-content;
-  z-index: 1;
+  z-index: 2;
   padding: 12px;
   max-width: calc(100vw - 20px);
   border: 1px solid gray;
@@ -43,7 +43,8 @@
   z-index: -1;
   transform: rotate(45deg);
   background-color: inherit;
-  border: 1px solid inherit;
+  border: 1px solid;
+  border-color: inherit;
   width: 12px;
   height: 12px;
 }

--- a/packages/react/src/components/Popover/Popover.module.css
+++ b/packages/react/src/components/Popover/Popover.module.css
@@ -44,6 +44,7 @@
   transform: rotate(45deg);
   background-color: inherit;
   border: 1px solid;
+  /* Set border color separately in order to make inheritance work. */
   border-color: inherit;
   width: 12px;
   height: 12px;

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
@@ -90,12 +90,12 @@
 
 @supports not selector(:has(:focus-visible)) {
   .template:not(.disabled):focus-within {
-    outline: 2px solid var(--interactive_components-colors-focus_outline);
+    outline: 2px solid var(--semantic-tab_focus-outline-color);
     outline-offset: 2px;
   }
 }
 
 .template:not(.disabled):not(:has(button:focus-visible)):has(:focus-visible) {
-  outline: 2px solid var(--interactive_components-colors-focus_outline);
+  outline: 2px solid var(--semantic-tab_focus-outline-color);
   outline-offset: 2px;
 }


### PR DESCRIPTION
Update old figma-token in CheckboxRadioTemplate.
Also fix arrow border color inheritance. Needs to be separate for some reason in order to inherit the popovers border color.