### PR TITLE
fix(Select): Accept empty list of options

### DIFF
--- a/packages/react/src/components/Select/Select.test.tsx
+++ b/packages/react/src/components/Select/Select.test.tsx
@@ -221,6 +221,10 @@ describe('Select', () => {
       expectSelectedValue(singleSelectOptions[newValueIndex]);
     });
 
+    it('Renders without errors when option list is empty', () => {
+      expect(() => renderSingleSelect({ options: [] })).not.toThrow();
+    });
+
     const expectSelectedValue = (option: SingleSelectOption) => {
       expect(getCombobox()).toHaveValue(option.value);
       expect(getCombobox()).toHaveTextContent(option.label);
@@ -544,6 +548,10 @@ describe('Select', () => {
       rerender(<Select {...defaultMultiSelectProps} value={newValues} />);
       expectSelectedValues(newValues);
       expectSelectedOptions((i) => newValueIndices.includes(i));
+    });
+
+    it('Renders without errors when option list is empty', () => {
+      expect(() => renderMultiSelect({ options: [] })).not.toThrow();
     });
 
     const getFocusedOption = (container: HTMLElement) =>

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -107,8 +107,9 @@ export const Select = (props: SelectProps) => {
     const listboxElement = listboxRef.current;
     if (listboxElement) {
       const listboxHeight = listboxElement.offsetHeight;
-      const itemHeight =
-        listboxElement.getElementsByTagName('li')[0].offsetHeight;
+      const items = listboxElement.querySelectorAll('li');
+      if (!items.length) return;
+      const itemHeight = items[0].offsetHeight;
       const scrollPositionTop = listboxElement.scrollTop;
       const scrollPositionBottom = scrollPositionTop + listboxHeight;
       const activeOptionPositionTop = activeOptionIndex * itemHeight;


### PR DESCRIPTION
Select component should not throw errors if option list is empty.