### PR TITLE
docs(Popover): Add note about trigger ref

### DIFF
--- a/packages/react/src/components/Popover/Popover.stories.mdx
+++ b/packages/react/src/components/Popover/Popover.stories.mdx
@@ -1,8 +1,8 @@
 import {Meta, Canvas, Story} from '@storybook/addon-docs'
-import { Popover, PopoverVariant, PopoverProps } from './index';
+import { Popover, PopoverVariant } from './index';
 
-import {Button, ButtonColor, ButtonSize, ButtonVariant} from "./../Button/index";
-import {ComponentUsage, BetaBlock, TokensTable} from "../../../../../docs-components";
+import {Button} from "./../Button/index";
+import {BetaBlock, TokensTable} from "../../../../../docs-components";
 import {ArgsTable} from "@storybook/addon-docs";
 
 <Meta
@@ -16,7 +16,7 @@ import {ArgsTable} from "@storybook/addon-docs";
     }}
     argTypes={{
         trigger: {
-            description: 'En ReactNode som brukes til å åpne å lukke popoveren. Fungerer også som ankringspunkt til popoverens posisjon.',
+            description: 'En `ReactNode` som brukes til å åpne og lukke popoveren. Fungerer også som ankringspunkt til popoverens posisjon. Denne komponenten må ha en `ref`. Dette er en egenskap som finnes på alle primitive React-komponenter, men dersom det er en egendefinert komponent, må man bruke `React.forwardRef` i definisjonen av komponenten til å sette `ref`-egenskapen på riktig plass.',
             control: { type: 'object' },
         },
         children: {
@@ -148,7 +148,9 @@ Popover er et felt som plasseres over annet innhold og kan vises og skjules ved 
 <ArgsTable story='Popover' />
 
 ## Tokens
-Komponenten har følgende CSS-variabler tilgjengelige som kan overstyres ved behov.
-<TokensTable jsonKey='component.popover' componentName='popover' />
-
-## Tilgjengelighet
+<TokensTable
+    componentName='popover'
+    description
+    jsonKey='component.popover'
+    showPreview={false}
+/>

--- a/packages/react/src/components/Popover/Popover.test.tsx
+++ b/packages/react/src/components/Popover/Popover.test.tsx
@@ -6,7 +6,7 @@ import type { PopoverProps } from './Popover';
 import { PopoverVariant, Popover } from './Popover';
 
 const render = (props: Partial<PopoverProps> = {}) => {
-  const allProps = {
+  const allProps: PopoverProps = {
     children: (
       <div>
         <button>My button</button>
@@ -21,7 +21,7 @@ const render = (props: Partial<PopoverProps> = {}) => {
 
 const user = userEvent.setup();
 
-describe('popover', () => {
+describe('Popover', () => {
   describe('trigger uncontrolled', () => {
     it('should render trigger', async () => {
       render();


### PR DESCRIPTION
It is not obvious that the popover trigger need to have a `ref`, so I added a couple of sentences about it.