### PR TITLE
fix(InputWrapper): Change outline style to solid from auto to make outline-offset work

### DIFF
--- a/packages/react/src/components/_InputWrapper/InputWrapper.module.css
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.module.css
@@ -17,7 +17,7 @@
 }
 
 .inputWrapper.withFocusEffect:focus-within {
-  outline: var(--outline-color) auto var(--semantic-tab_focus-outline-width);
+  outline: var(--outline-color) solid var(--semantic-tab_focus-outline-width);
   outline-offset: var(--semantic-tab_focus-outline-offset);
 }
 


### PR DESCRIPTION
Change outline style of inputWrapper to `solid`. The `auto` style was making the ouline-offset calculate distance from the div and not the divs border.
Old:
<img width="230" alt="image" src="https://user-images.githubusercontent.com/32294735/217578812-752aaafb-34e7-4d3a-a78f-02671009ed08.png">
New:
<img width="180" alt="image" src="https://user-images.githubusercontent.com/32294735/217577867-7a1d00e8-6d35-4214-905d-913e83a7fece.png">
