### PR TITLE
fix(Accordion): Fix subtitle placement issues

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.stories.mdx
+++ b/packages/react/src/components/Accordion/Accordion.stories.mdx
@@ -10,7 +10,8 @@ import {
     ButtonVariant,
 } from "../";
 import {BetaBlock, TokensTable} from "../../../../../docs-components";
-import {ArgsTable} from "@storybook/addon-docs"; import {useState} from "react";
+import {ArgsTable} from "@storybook/addon-docs";
+import {useState} from "react";
 
 <Meta
     title="Kjernekomponenter/Accordion"
@@ -49,22 +50,25 @@ export const Template = (args) => {
     const onClick = () => setOpen(!open);
     return (
         <Accordion {...args} onClick={onClick} open={open}>
-            <AccordionHeader actions={<>
-                <Button
-                    variant={ButtonVariant.Filled}
-                    color={ButtonColor.Primary}
-                    size={ButtonSize.Small}
-                >
-                    Separat knapp 1
-                </Button>
-                <Button
-                    variant={ButtonVariant.Outline}
-                    color={ButtonColor.Primary}
-                    size={ButtonSize.Small}
-                >
-                    Separat knapp 2
-                </Button>
-            </>}>
+            <AccordionHeader
+                actions={<>
+                    <Button
+                        variant={ButtonVariant.Filled}
+                        color={ButtonColor.Primary}
+                        size={ButtonSize.Small}
+                    >
+                        Separat knapp 1
+                    </Button>
+                    <Button
+                        variant={ButtonVariant.Outline}
+                        color={ButtonColor.Primary}
+                        size={ButtonSize.Small}
+                    >
+                        Separat knapp 2
+                    </Button>
+                </>}
+                subtitle='Valgfri undertittel'
+            >
                 Klikk her for å åpne
             </AccordionHeader>
             <AccordionContent>

--- a/packages/react/src/components/Accordion/AccordionHeader.module.css
+++ b/packages/react/src/components/Accordion/AccordionHeader.module.css
@@ -3,6 +3,7 @@
   --component-accordion_header-border_top_style: solid;
   --component-accordion_header-border_top_width: var(--border_width-thin);
   --component-accordion_header-color-background: var(--colors-white);
+  align-items: center;
   background-color: var(--component-accordion_header-color-background);
   border-top-color: var(--component-accordion_header-border_top_color);
   border-top-style: var(--component-accordion_header-border_top_style);
@@ -19,13 +20,16 @@
 
 /* breakpoints-sm */
 @media only screen and (min-width: 540px) {
+  .accordionHeader.withSubtitle {
+    padding-bottom: 0.2rem;
+    padding-right: 0.2rem;
+    padding-top: 0.2rem;
+  }
+
   .subtitle {
     display: inline-block;
     font-size: 0.9rem;
     opacity: 60%;
-    padding-bottom: 0.2rem;
-    padding-right: 0.2rem;
-    padding-top: 0.2rem;
   }
 }
 
@@ -44,7 +48,9 @@
   border-right-style: var(--component-accordion_header_title-border_right_style);
   border-top-style: var(--component-accordion_header_title-border_top_style);
   cursor: pointer;
+  display: inline-flex;
   flex: 1 1 auto;
+  flex-direction: column;
   font-family: inherit;
   font-size: var(--component-accordion_header_title-font_size);
   font-weight: var(--component-accordion_header_title-font_weight);

--- a/packages/react/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/react/src/components/Accordion/AccordionHeader.tsx
@@ -21,7 +21,7 @@ const AccordionHeader = ({
   return (
     <div
       className={cn(classes.accordionHeader, {
-        [classes.subtitle]: subtitle,
+        [classes.withSubtitle]: subtitle,
       })}
     >
       <AccordionIcon />


### PR DESCRIPTION
Fixed some errors that appeared when moving the component.
- The `subtitle` class should be two different classes; `subtitle` and `withSubtitle`.
- The subtitle wrapper was changed from `div` to `span` because it was inside a button. This made it appear at the same line as the main title, while it should appear below it. Fixed by setting `display: inline-flex` on the `title` class.