### PR TITLE
chore: Add CSS modules addon to Storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,6 +9,17 @@ module.exports = {
     'storybook-addon-designs',
     '@storybook/preset-scss',
     '@etchteam/storybook-addon-status',
+    {
+      name: 'storybook-css-modules',
+      options: {
+        cssModulesLoaderOptions: {
+          importLoaders: 1,
+          modules: {
+            localIdentName: '[name]_[local]__[hash:base64:5]',
+          },
+        },
+      },
+    },
   ],
   staticDirs: ['../assets'],
   framework: '@storybook/react',

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "sass": "^1.54.9",
     "sass-loader": "^13.0.2",
     "storybook-addon-designs": "^6.3.1",
+    "storybook-css-modules": "^1.0.8",
     "ts-jest": "^29.0.1",
     "tslib": "^2.4.1",
     "@storybook/addon-actions": "^6.5.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16814,6 +16814,11 @@ storybook-addon-designs@^6.3.1:
   dependencies:
     "@figspec/react" "^1.0.0"
 
+storybook-css-modules@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/storybook-css-modules/-/storybook-css-modules-1.0.8.tgz#19392c07a31849dbcd2753ae6331e7f8c0f2ec69"
+  integrity sha512-anITwllH6nLw0quPElVBLRrE8QDbcRv0Dgl8sKLOc4uiqw+g1GE2l21Stjx3Wyv2O6ZKJScbyOpOuuz3SmeaOQ==
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"


### PR DESCRIPTION
Added CSS modules addon to make class names of components recognizable when they are rendered in Storybook. This makes debugging easier.