### PR TITLE
fix(HelpText): fix help-text width

### DIFF
--- a/packages/react/src/components/HelpText/HelpText.module.css
+++ b/packages/react/src/components/HelpText/HelpText.module.css
@@ -40,6 +40,8 @@
 .helpTextContent {
   font-size: var(--font_size-300);
   line-height: var(--typography-default-line-height);
+  width: fit-content;
+  max-width: 700px;
 }
 
 .helpTextIcon.small {

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -192,7 +192,6 @@ const PopoverContent = forwardRef<
         position: context.strategy,
         top: context.y ?? 0,
         left: context.x ?? 0,
-        width: 'max-content',
       }}
       data-placement={context.placement}
       className={cn(


### PR DESCRIPTION
Fixed problem noticed when implementing help-text.
<img width="915" alt="image" src="https://user-images.githubusercontent.com/32294735/218508064-7be1cddd-df3b-4cde-9406-c5c14da27d9f.png">
after:
<img width="884" alt="image" src="https://user-images.githubusercontent.com/32294735/218508176-22cfe28c-7444-4894-8f2e-39a06b472ad5.png">
Also helps for displaying helpTexts for smaller screens:
before: 
<img width="292" alt="image" src="https://user-images.githubusercontent.com/32294735/218508778-7ca64804-9482-4aa8-b13d-2bfcea6db623.png">
after:
<img width="280" alt="image" src="https://user-images.githubusercontent.com/32294735/218508638-e09688b1-83f6-473c-b04e-38e7c2b202a3.png">
