### PR TITLE
fix(Popover): fix display-issue-with-popover-arrow

### DIFF
--- a/packages/react/src/components/Popover/Popover.module.css
+++ b/packages/react/src/components/Popover/Popover.module.css
@@ -40,6 +40,7 @@
 
 .arrow {
   position: absolute;
+  box-sizing: content-box;
   z-index: -1;
   transform: rotate(45deg);
   background-color: inherit;


### PR DESCRIPTION
We have a dependency in our project that sets the default `box-sizing` for all divs to `border-box`. 
This ensures that the arrow of the popover has `box-sizing` `content-box`so that it is displayed correctly.
before:
<img width="164" alt="image" src="https://user-images.githubusercontent.com/32294735/219016175-5e9db893-5357-40cb-a833-7e7039704080.png">
after:
<img width="173" alt="image" src="https://user-images.githubusercontent.com/32294735/219016306-0129536a-8bba-4b07-97ec-d227b47f199a.png">
