### PR TITLE
fix(HelpText): hide helptext button in pdfs

### DIFF
--- a/packages/react/src/components/HelpText/HelpText.module.css
+++ b/packages/react/src/components/HelpText/HelpText.module.css
@@ -8,6 +8,12 @@
   border: none;
 }
 
+@media print {
+  .helpTextButton {
+    display: none;
+  }
+}
+
 .helpTextButton:focus-visible {
   outline: var(--semantic-tab_focus-outline-color) solid
     var(--semantic-tab_focus-outline-width);


### PR DESCRIPTION
When printing, or generating pdf, the helptext is not interacteble and therefore it does not make sense to display it, as its content will be hidden.