### PR TITLE
feat(HelpText): take reactnode instead of string

### DIFF
--- a/packages/react/src/components/HelpText/HelpText.tsx
+++ b/packages/react/src/components/HelpText/HelpText.tsx
@@ -14,7 +14,7 @@ export enum HelpTextSize {
 }
 
 export interface HelpTextProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  children: string;
+  children: React.ReactNode;
   title: string;
   size?: HelpTextSize;
   placement?:


### PR DESCRIPTION
Change the type of helptext children from string to ReactNode.