### PR TITLE
fix(CheckboxGroup): fix state handling problem

### DIFF
--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { CheckboxGroup } from './';
+import { CheckboxGroup, CheckboxGroupItem } from './';
 
 import type { CheckboxGroupProps } from './';
 
@@ -83,15 +83,15 @@ describe('CheckboxGroup', () => {
   });
 
   it('Checkboxes should update their "checked" state if the component rerenders with another configuration', () => {
-    const { rerender } = render();
-    rerender(
-      <CheckboxGroup
-        items={[
-          { checked: true, label: 'Test 1', name: 'test1' },
-          { checked: false, label: 'Test 2', name: 'test2' },
-        ]}
-      />,
-    );
+    const items: CheckboxGroupItem[] = [
+      { label: 'Test 1', name: 'test1' },
+      { label: 'Test 2', name: 'test2' },
+    ];
+    const { rerender } = render({ items });
+    items[0] = { checked: true, label: 'Test 1', name: 'test1' };
+    items[1] = { checked: false, label: 'Test 2', name: 'test2' };
+    rerender(<CheckboxGroup items={items} />);
+
     const checkboxes = screen.queryAllByRole('checkbox');
     expect(checkboxes[0]).toBeChecked();
     expect(checkboxes[1]).not.toBeChecked();

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useReducer } from 'react';
+import React, { ReactNode, useReducer } from 'react';
 import cn from 'classnames';
 
 import { Checkbox } from '../Checkbox';
@@ -73,9 +73,9 @@ const CheckboxGroup = ({
 
   const itemsAsString = JSON.stringify(items);
 
-  useEffect(
+  useUpdate(
     () => dispatch({ type: 'reset', state: checkedItems(items) }),
-    [itemsAsString, items],
+    [itemsAsString],
   );
 
   const prevCheckedNames = usePrevious(checkedNames);

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -71,9 +71,11 @@ const CheckboxGroup = ({
 
   const [checkedNames, dispatch] = useReducer(reducer, checkedItems(items));
 
+  const itemsAsString = JSON.stringify(items);
+
   useEffect(
     () => dispatch({ type: 'reset', state: checkedItems(items) }),
-    [items],
+    [itemsAsString, items],
   );
 
   const prevCheckedNames = usePrevious(checkedNames);


### PR DESCRIPTION
Handling state externally and updating the list of CheckboxOptions given to the component potentially caused an infinite render loop. 

Changing the useEffect to the custom hook useUpdate and passing a stringified version of the items instead of the items themselves. 

The useUpdate will now only run if the content of the items have changed, and not if only the object reference has changed.