### PR TITLE
fix(HelpText): helptext´s content not reachable with NVDA screenreader

### DIFF
--- a/packages/react/src/components/HelpText/HelpText.tsx
+++ b/packages/react/src/components/HelpText/HelpText.tsx
@@ -49,6 +49,7 @@ const HelpText = ({
       open={open}
       onOpenChange={setOpen}
       className={classes.helpTextContent}
+      role={'tooltip'}
       trigger={
         <button
           {...rest}

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -201,7 +201,7 @@ const PopoverContent = forwardRef<
       )}
       {...context.getFloatingProps(props)}
       tabIndex={-1}
-      role={context.role ? context.role : 'dialog'}
+      role={context.role || 'dialog'}
     >
       {props.children}
     </div>

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -201,7 +201,7 @@ const PopoverContent = forwardRef<
       )}
       {...context.getFloatingProps(props)}
       tabIndex={-1}
-      role={'dialog'}
+      role={context.role ? context.role : 'dialog'}
     >
       {props.children}
     </div>


### PR DESCRIPTION
Changed role to tooltip for help-text in order to make its content accessible for NVDA screenreader when the content does not contain interactable elements.