### PR TITLE
fix(CheckboxRadioTemplate): Fix perceived WAVE accessibility error

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.test.tsx
@@ -58,7 +58,9 @@ describe('Checkbox', () => {
   it('Should not display label text, but still make it accessible, when hideLabel is true', () => {
     const label = 'Lorem ipsum';
     render({ hideLabel: true, label });
-    expect(screen.queryByText(label)).toBeFalsy();
+    expect(
+      screen.queryByText(label)?.parentElement?.parentElement?.classList,
+    ).toContain('visuallyHidden');
     expect(screen.getByLabelText(label)).toBeTruthy();
   });
 

--- a/packages/react/src/components/RadioButton/RadioButton.test.tsx
+++ b/packages/react/src/components/RadioButton/RadioButton.test.tsx
@@ -66,7 +66,9 @@ describe('RadioButton', () => {
   it('Does not display label text, but still makes it accessible, when hideLabel is true', () => {
     const label = 'All we hear is radio ga ga';
     render({ hideLabel: true, label });
-    expect(screen.queryByText(label)).toBeFalsy();
+    expect(
+      screen.queryByText(label)?.parentElement?.parentElement?.classList,
+    ).toContain('visuallyHidden');
     expect(screen.getByLabelText(label)).toBeTruthy();
   });
 
@@ -179,7 +181,7 @@ describe('RadioButton', () => {
   it('Has clickable radio button even if the "presentation" property is true and the label is a React node', async () => {
     const name = 'Label';
     render({
-      label: <span>{name}</span>,
+      label: <span>{'Label'}</span>,
       presentation: true,
     });
     await act(() => user.click(screen.getByRole('presentation', { name })));

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
@@ -62,7 +62,6 @@
 .labelAndDescription {
   display: inline-flex;
   flex-direction: column;
-  gap: var(--description-margin_top);
 
   /* Center-align input box with the first line in the label */
   margin-top: calc(
@@ -86,6 +85,7 @@
 
 .description {
   color: var(--description-color);
+  margin-top: var(--description-margin_top);
 }
 
 @supports not selector(:has(:focus-visible)) {

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -9,6 +9,7 @@ import cn from 'classnames';
 
 import { HelpText } from '../HelpText';
 import { HelpTextSize } from '../HelpText/HelpText';
+import accessibility from '../../utils/utility.module.css';
 
 import classes from './CheckboxRadioTemplate.module.css';
 
@@ -90,7 +91,6 @@ export const CheckboxRadioTemplate = ({
             aria-label={
               !showLabel && typeof label === 'string' ? label : undefined
             }
-            aria-labelledby={showLabel ? labelId : undefined}
             checked={checked ?? false}
             className={classes.input}
             disabled={disabled}
@@ -104,9 +104,14 @@ export const CheckboxRadioTemplate = ({
           <span className={classes.visibleBox}>{children}</span>
         </Wrapper>
       )}
-      {(showLabel || description) && (
-        <span className={classes.labelAndDescription}>
-          {showLabel && (
+      {
+        <span
+          className={cn(
+            classes.labelAndDescription,
+            !showLabel && accessibility.visuallyHidden,
+          )}
+        >
+          {
             <span className={classes.labelAndHelpText}>
               <span
                 className={classes.label}
@@ -114,7 +119,7 @@ export const CheckboxRadioTemplate = ({
               >
                 {label}
               </span>
-              {helpText && (
+              {helpText && showLabel && (
                 <HelpText
                   size={helpTextSize}
                   title={`Help text for ${label}`}
@@ -123,7 +128,7 @@ export const CheckboxRadioTemplate = ({
                 </HelpText>
               )}
             </span>
-          )}
+          }
           {description && (
             <span
               className={classes.description}
@@ -133,7 +138,7 @@ export const CheckboxRadioTemplate = ({
             </span>
           )}
         </span>
-      )}
+      }
     </Wrapper>
   );
 };

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -91,6 +91,7 @@ export const CheckboxRadioTemplate = ({
             aria-label={
               !showLabel && typeof label === 'string' ? label : undefined
             }
+            aria-labelledby={showLabel ? labelId : undefined}
             checked={checked ?? false}
             className={classes.input}
             disabled={disabled}

--- a/packages/react/src/utils/utility.module.css
+++ b/packages/react/src/utils/utility.module.css
@@ -2,12 +2,13 @@
  * Visually hide an element, but leave it available for screen readers
  */
 .visuallyHidden {
-	border: 0;
-	clip: rect(0 0 0 0);
+	width: 1px;
 	height: 1px;
-	overflow: hidden;
+	border: 0;
 	padding: 0;
+	clip: rect(0 0 0 0);
+	overflow: hidden;
 	position: absolute;
 	white-space: nowrap;
-	width: 1px;
+	opacity: 0;
 }

--- a/packages/react/src/utils/utility.module.css
+++ b/packages/react/src/utils/utility.module.css
@@ -10,5 +10,4 @@
 	overflow: hidden;
 	position: absolute;
 	white-space: nowrap;
-	opacity: 0;
 }


### PR DESCRIPTION
Replaces accessibility solution for labels for screen-readers with using `visually hidden` css to make WAVE happy when the labels are hidden for a checkbox / radiobutton.

NB!
It is important to note that even though WAVE complains of missing labels for the inputs when the labels are set to hidden, screen readers that have been tested (mac VoiceOver) works as intended and reads the correct labels set with `aria-labeledby`. Other accessibility tools like axe DevTools and Siteimprove have been tested and give no warning.