### PR TITLE
Fix/187 too small buttons with icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ coverage/
 
 # Storybook build files
 docs/docs
+.vscode/settings.json

--- a/packages/react/src/components/Button/Button.module.css
+++ b/packages/react/src/components/Button/Button.module.css
@@ -89,7 +89,7 @@
 
 .button.onlyIcon {
     padding: 0.5rem;
-    width: var(--button-size);
+    height: var(--button-size);
 }
 
 /* Filled button colors */


### PR DESCRIPTION
Change css to set height instead of width in buttons that has no text, only icons.