### PR TITLE
feat(Button): Added support for aria-disabled to button and loading button example in storybook

### DIFF
--- a/packages/react/src/components/Button/Button.module.css
+++ b/packages/react/src/components/Button/Button.module.css
@@ -32,7 +32,7 @@
     outline: none;
 }
 
-.button:disabled {
+.button:disabled, .button[aria-disabled="true"] {
     cursor: auto;
     opacity: var(--opacity-disabled);
 }
@@ -96,11 +96,11 @@
     background: var(--component-button-filled-primary-color-background-default);
 }
 
-.button.filled.primary:not(:disabled):hover {
+.button.filled.primary:not([aria-disabled="true"]):not(:disabled):hover {
     background: var(--component-button-filled-primary-color-background-hover);
 }
 
-.button.filled.primary:not(:disabled):active {
+.button.filled.primary:not([aria-disabled="true"]):not(:disabled):active {
     background: var(--component-button-filled-primary-color-background-pressed);
 }
 
@@ -108,11 +108,11 @@
     background: var(--component-button-filled-primary-color-background-pressed);
 }
 
-.button.filled.secondary:not(:disabled):hover {
+.button.filled.secondary:not([aria-disabled="true"]):not(:disabled):hover {
     background: var(--colors-blue-800);
 }
 
-.button.filled.secondary:not(:disabled):active {
+.button.filled.secondary:not([aria-disabled="true"]):not(:disabled):active {
     background: var(--colors-blue-900);
 }
 
@@ -120,11 +120,11 @@
     background: var(--component-button-filled-success-color-background-default);
 }
 
-.button.filled.success:not(:disabled):hover {
+.button.filled.success:not([aria-disabled="true"]):not(:disabled):hover {
     background: var(--component-button-filled-success-color-background-hover);
 }
 
-.button.filled.success:not(:disabled):active {
+.button.filled.success:not([aria-disabled="true"]):not(:disabled):active {
     background: var(--component-button-filled-success-color-background-pressed);
 }
 
@@ -132,11 +132,11 @@
     background: var(--component-button-filled-danger-color-background-default);
 }
 
-.button.filled.danger:not(:disabled):hover {
+.button.filled.danger:not([aria-disabled="true"]):not(:disabled):hover {
     background: var(--component-button-filled-danger-color-background-hover);
 }
 
-.button.filled.danger:not(:disabled):active {
+.button.filled.danger:not([aria-disabled="true"]):not(:disabled):active {
     background: var(--colors-red-800);
 }
 
@@ -145,12 +145,12 @@
     background: var(--colors-white);
 }
 
-.button.filled.inverted:not(:disabled):hover {
+.button.filled.inverted:not([aria-disabled="true"]):not(:disabled):hover {
     --font-and-icon-color: var(--colors-blue-900);
     background: rgba(255, 255, 255, 0.9);
 }
 
-.button.filled.inverted:not(:disabled):active {
+.button.filled.inverted:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--colors-white);
     background: rgba(255, 255, 255, 0.1);
 }
@@ -166,13 +166,13 @@
     background: var(--component-button-outline-primary-color-background-default);
 }
 
-.button.outline.primary:not(:disabled):hover {
+.button.outline.primary:not([aria-disabled="true"]):not(:disabled):hover {
     --font-and-icon-color: var(--colors-blue-800);
     background: var(--component-button-outline-primary-color-background-hover);
     border-color: var(--component-button-outline-primary-color-border-hover);
 }
 
-.button.outline.primary:not(:disabled):active {
+.button.outline.primary:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--component-button-outline-primary-color-text-pressed);
     background: var(--component-button-outline-primary-color-background-pressed);
 }
@@ -183,11 +183,11 @@
     border-color: var(--colors-blue-900);
 }
 
-.button.outline.secondary:not(:disabled):hover {
+.button.outline.secondary:not([aria-disabled="true"]):not(:disabled):hover {
     background: var(--colors-blue-100);
 }
 
-.button.outline.secondary:not(:disabled):active {
+.button.outline.secondary:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--colors-white);
     background: var(--colors-blue-900);
 }
@@ -198,12 +198,12 @@
     border-color: var(--colors-green-700);
 }
 
-.button.outline.success:not(:disabled):hover {
+.button.outline.success:not([aria-disabled="true"]):not(:disabled):hover {
     --font-and-icon-color: var(--colors-green-800);
     background: var(--colors-green-200);
 }
 
-.button.outline.success:not(:disabled):active {
+.button.outline.success:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--colors-white);
     background: var(--colors-green-700);
 }
@@ -214,13 +214,13 @@
     border-color: var(--colors-red-500);
 }
 
-.button.outline.danger:not(:disabled):hover {
+.button.outline.danger:not([aria-disabled="true"]):not(:disabled):hover {
     --font-and-icon-color: var(--colors-red-700);
     background: var(--colors-red-100);
     border-color: var(--colors-red-700);
 }
 
-.button.outline.danger:not(:disabled):active {
+.button.outline.danger:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--colors-white);
     background: var(--colors-red-500);
 }
@@ -231,11 +231,11 @@
     background: transparent;
 }
 
-.button.outline.inverted:not(:disabled):hover {
+.button.outline.inverted:not([aria-disabled="true"]):not(:disabled):hover {
     background: rgba(255, 255, 255, 0.1);
 }
 
-.button.outline.inverted:not(:disabled):active {
+.button.outline.inverted:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--colors-blue-900);
     background: var(--colors-white);
 }
@@ -249,12 +249,12 @@
     --font-and-icon-color: var(--component-button-quiet-primary-color-text-default);
 }
 
-.button.quiet.primary:not(:disabled):hover {
+.button.quiet.primary:not([aria-disabled="true"]):not(:disabled):hover {
     --font-and-icon-color: var(--colors-blue-800);
     background: var(--component-button-quiet-primary-color-background-hover);
 }
 
-.button.quiet.primary:not(:disabled):active {
+.button.quiet.primary:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--component-button-filled-color-text-all);
     background: var(--component-button-quiet-primary-color-background-pressed);
 }
@@ -263,11 +263,11 @@
     --font-and-icon-color: var(--colors-blue-900);
 }
 
-.button.quiet.secondary:not(:disabled):hover {
+.button.quiet.secondary:not([aria-disabled="true"]):not(:disabled):hover {
     background: var(--colors-grey-300);
 }
 
-.button.quiet.secondary:not(:disabled):active {
+.button.quiet.secondary:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--component-button-filled-color-text-all);
     background: var(--colors-blue-900);
 }
@@ -276,12 +276,12 @@
     --font-and-icon-color: var(--colors-green-700);
 }
 
-.button.quiet.success:not(:disabled):hover {
+.button.quiet.success:not([aria-disabled="true"]):not(:disabled):hover {
     --font-and-icon-color: var(--colors-green-800);
     background: var(--colors-green-200);
 }
 
-.button.quiet.success:not(:disabled):active {
+.button.quiet.success:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--component-button-filled-color-text-all);
     background: var(--colors-green-900);
 }
@@ -290,12 +290,12 @@
     --font-and-icon-color: var(--colors-red-600);
 }
 
-.button.quiet.danger:not(:disabled):hover {
+.button.quiet.danger:not([aria-disabled="true"]):not(:disabled):hover {
     --font-and-icon-color: var(--colors-red-800);
     background: var(--colors-red-100);
 }
 
-.button.quiet.danger:not(:disabled):active {
+.button.quiet.danger:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--component-button-filled-color-text-all);
     background: var(--colors-red-800);
 }
@@ -305,12 +305,12 @@
     background: transparent;
 }
 
-.button.quiet.inverted:not(:disabled):hover {
+.button.quiet.inverted:not([aria-disabled="true"]):not(:disabled):hover {
     --font-and-icon-color: var(--colors-blue-900);
     background: rgba(255, 255, 255, 0.9);
 }
 
-.button.quiet.inverted:not(:disabled):active {
+.button.quiet.inverted:not([aria-disabled="true"]):not(:disabled):active {
     --font-and-icon-color: var(--colors-blue-900);
     background: var(--colors-white);
 }

--- a/packages/react/src/components/Button/Button.stories.mdx
+++ b/packages/react/src/components/Button/Button.stories.mdx
@@ -1,5 +1,6 @@
 import {Meta, Canvas, Story} from '@storybook/addon-docs'
 import {Button, ButtonColor, ButtonSize, ButtonVariant} from "./index";
+import { Spinner } from '../Spinner';
 import {ComponentUsage, BetaBlock, TokensTable} from "../../../../../docs-components";
 import {ArgsTable} from "@storybook/addon-docs";
 
@@ -34,9 +35,12 @@ import {ArgsTable} from "@storybook/addon-docs";
         disabled: {
             control: { type: 'boolean'}
         },
+        ariaDisabled: {
+            control: { type: 'boolean'}
+        },
         onClick: { action: 'onClick' },
         children: {
-            control: { type: 'text' }
+            control: { type: 'text' },
         },
         fullWidth: {
             control: { type: 'boolean' }
@@ -80,6 +84,19 @@ export const defaultArgs = {
 };
 
 export const Template = (args) => <Button {...args} />;
+
+export const LoadingTemplate = (args) => {
+    return (
+        <Button 
+            ariaDisabled={args.ariaDisabled} 
+            variant={args.variant} 
+            size={args.size}
+            color={args.color}
+        >
+            <Spinner size={args.size} variant='interaction'/>
+            Laster...
+        </Button>
+)};
 
 # Button
 
@@ -191,6 +208,52 @@ On through of which no the your phase more know anyone tried he when line me wha
         }}
     >
         {Template.bind({})}
+    </Story>
+</Canvas>
+
+### Bruk av Spinner til å lage en knapp som laster
+Dersom du ønsker å vise brukeren at knappen laster noe kan du gjøre det ved å kombinere den med en spinner.
+
+OBS: I dette eksempelet er det brukt aria-disabled (på denne komponenten kalt ariaDisabled) til å deaktivere knappene.
+Dette er den anbefalte metoden for å vise at en knapp er deaktivert da det gjør at den fremdeles kan fokuseres på, f.eks. ved navigasjon med tab.
+Slik vil bl.a. skjermlesere bli informert om at knappen eksisterer (men ikke er aktiv) noe som ofte ikke er tilfellet ved bruk av kun disabled.
+
+Det er imidlertid viktig å vite at denne prop-en ikke automatisk stopper knappen fra å trigge sin onClick metode.
+Det er opp til deg som programmerer å passe på at ikke callback-funksjonen din kjører når knappen ikke skal være aktiv.
+<Canvas>
+    <Story
+        name="Fylt med tekst og spinner"
+        args={{
+            size: ButtonSize.Small,
+            variant: ButtonVariant.Filled,
+            ariaDisabled: true
+        }}
+    >
+        {LoadingTemplate.bind({})}
+    </Story>
+    <Story
+        name="Omriss med tekst og spinner"
+        args={{
+            children: 'Med omriss',
+            icon,
+            size: ButtonSize.Small,
+            variant: ButtonVariant.Outline,
+            ariaDisabled: true
+        }}
+    >
+        {LoadingTemplate.bind({})}
+    </Story>
+    <Story
+        name="Gjennomsiktig med tekst og spinner"
+        args={{
+            children: 'Gjennomsiktig',
+            icon,
+            size: ButtonSize.Small,
+            variant: ButtonVariant.Quiet,
+            ariaDisabled: true
+        }}
+    >
+        {LoadingTemplate.bind({})}
     </Story>
 </Canvas>
 

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -87,6 +87,19 @@ describe('Button', () => {
     ).toEqual(icon);
   });
 
+  it('should render as aria-disabled when aria-disabled is true regardless of variant', () => {
+    render({
+      variant: ButtonVariant.Outline,
+      color: ButtonColor.Primary,
+      size: ButtonSize.Small,
+      ariaDisabled: true,
+    });
+
+    const button = screen.getByRole('button');
+
+    expect(button).toHaveAttribute('aria-disabled');
+  });
+
   it('should render as disabled when disabled is true regardless of variant', () => {
     render({
       variant: ButtonVariant.Outline,

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -38,6 +38,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   dashedBorder?: boolean;
   icon?: ReactNode;
   iconPlacement?: 'right' | 'left';
+  ariaDisabled?: boolean;
 }
 
 const Button = (
@@ -51,6 +52,7 @@ const Button = (
     iconPlacement = 'left',
     icon,
     type = 'button',
+    ariaDisabled,
     className,
     ...restHTMLProps
   }: PropsWithChildren<ButtonProps>,
@@ -70,6 +72,7 @@ const Button = (
       className,
     )}
     type={type}
+    aria-disabled={ariaDisabled}
   >
     {icon && iconPlacement === 'left' && (
       <SvgIcon


### PR DESCRIPTION
These are suggested changes to the button component related to issue #204

It includes:
Using aria-disabled to enable more accessible use of button.
Added loading button example to storybook
