### PR TITLE
fix(CheckboxRadioTemplate): whitespace in label id breaks aria-labelledby

### DIFF
--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -56,7 +56,8 @@ export const CheckboxRadioTemplate = ({
   value,
 }: CheckboxRadioTemplateProps) => {
   const randomId = useId();
-  const finalInputId = inputId ?? 'input-' + randomId;
+  const finalInputIdString = inputId ?? 'input-' + randomId;
+  const finalInputId = finalInputIdString.replace(/\s/g, '-');
   const labelId = label ? `${finalInputId}-label` : undefined;
   const descriptionId = description ? `${finalInputId}-description` : undefined;
   const showLabel = label && !hideLabel;


### PR DESCRIPTION
Having whitespace in aria-labelledby indicates that several fields, separated by whitespace, are labelling the input. 
Replacing whitespace in the id with `'-'` fixes this issue.