### PR TITLE
fix(Select): Support dynamically changing options

### DIFF
--- a/packages/react/src/components/Select/Select.test.tsx
+++ b/packages/react/src/components/Select/Select.test.tsx
@@ -325,6 +325,25 @@ describe('Select', () => {
         ),
       ).toBeInTheDocument();
     };
+
+    it('Rerenders with new options when the "options" property changes', async () => {
+      const options = singleSelectOptions;
+      const newOptions: SingleSelectOption[] = [
+        { label: 'Test 4', value: 'test4' },
+        { label: 'Test 5', value: 'test5' },
+        { label: 'Test 6', value: 'test6' },
+      ];
+      const { rerender } = renderSingleSelect({ options: options });
+      rerender(
+        <Select
+          {...defaultSingleSelectProps}
+          options={newOptions}
+        />,
+      );
+      await act(() => user.click(screen.getByRole('combobox')));
+      await act(() => user.click(screen.getAllByRole('option')[1]));
+      expectSelectedValue(newOptions[1]);
+    });
   });
 
   describe('Multiple select', () => {
@@ -707,6 +726,27 @@ describe('Select', () => {
       const keyword = 'abc';
       await act(() => user.type(screen.getByRole('textbox'), keyword));
       expect(screen.getByRole('textbox')).toHaveValue(keyword);
+    });
+
+    it('Rerenders with new options when the "options" property changes', async () => {
+      const options = multiSelectOptions;
+      const newOptions: Required<
+        Omit<MultiSelectOption, 'keywords' | 'formattedLabel'>
+      >[] = [
+        { label: 'Test 4', value: 'test4', deleteButtonLabel: 'Delete test 4' },
+        { label: 'Test 5', value: 'test5', deleteButtonLabel: 'Delete test 5' },
+        { label: 'Test 6', value: 'test6', deleteButtonLabel: 'Delete test 6' },
+      ];
+      const { rerender } = renderSingleSelect({ options: options });
+      rerender(
+        <Select
+          {...defaultSingleSelectProps}
+          options={newOptions}
+        />,
+      );
+      await act(() => user.click(screen.getByRole('combobox')));
+      await act(() => user.click(screen.getAllByRole('option')[1]));
+      expectSelectedValues([newOptions[1].value]);
     });
 
     const getFocusedOption = (container: HTMLElement) =>

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -88,6 +88,11 @@ const Select = (props: SelectProps) => {
   const resetKeyword = () => keyword && setKeyword('');
 
   const [sortedOptions, setSortedOptions] = useState(options);
+  // Enable dynamic change of options by resetting sortedOptions
+  useUpdate(() => {
+    setSortedOptions(options);
+    setSelectedValues(multiple ? value ?? [] : []);
+  }, [options]);
 
   const numberOfOptions = options.length;
 

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -7,9 +7,10 @@ import { InputWrapper } from '../_InputWrapper';
 import {
   useEventListener,
   useKeyboardEventListener,
+  usePrevious,
   useUpdate,
 } from '../../hooks';
-import { arraysEqual } from '../../utils';
+import { arraysEqual, objectValuesEqual } from '../../utils';
 
 import { MultiSelectItem } from './MultiSelectItem';
 import classes from './Select.module.css';
@@ -41,12 +42,12 @@ interface SelectPropsBase {
   searchLabel?: string;
 }
 
-export interface SingleSelectOption {
+export type SingleSelectOption = {
   keywords?: string[];
   label: string;
   value: string;
   formattedLabel?: ReactNode;
-}
+};
 
 export type MultiSelectOption = SingleSelectOption & {
   deleteButtonLabel?: string;
@@ -89,10 +90,19 @@ const Select = (props: SelectProps) => {
 
   const [sortedOptions, setSortedOptions] = useState(options);
   // Enable dynamic change of options by resetting sortedOptions
+  const prevOptions = usePrevious([...options]);
   useUpdate(() => {
-    setSortedOptions(options);
-    setSelectedValues(multiple ? value ?? [] : []);
-  }, [options]);
+    // Update not on changed reference but on changed values inside the object
+    if (
+      options.length !== prevOptions?.length ||
+      options.some(
+        (option, index) => !objectValuesEqual(option, prevOptions[index])
+      )
+    ) {
+      setSortedOptions(options);
+      setSelectedValues(multiple ? value ?? [] : []);
+    }
+  });
 
   const numberOfOptions = options.length;
 

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -96,7 +96,7 @@ const Select = (props: SelectProps) => {
     if (
       options.length !== prevOptions?.length ||
       options.some(
-        (option, index) => !objectValuesEqual(option, prevOptions[index])
+        (option, index) => !objectValuesEqual(option, prevOptions[index]),
       )
     ) {
       setSortedOptions(options);


### PR DESCRIPTION
This suggests a fix for the Select component, enabling it to once again to accept changes to its option prop and updating the options displayed to the user as a result. This functionality was present before but was likely crippled at some point.

Tests for this dynamic change in options have been added.

[Related issue](https://github.com/Altinn/altinn-access-management-frontend/issues/217)