### PR TITLE
fix(Button): adjust padding to make icon round

### DIFF
--- a/packages/react/src/components/Button/Button.module.css
+++ b/packages/react/src/components/Button/Button.module.css
@@ -92,7 +92,10 @@
 }
 
 .button.onlyIcon {
-  padding: calc((var(--button-size) - var(--icon-size)) / 2 - var(--component-button-border_width-default));
+  padding: calc(
+    (var(--button-size) - var(--icon-size)) / 2 -
+      var(--component-button-border_width-default)
+  );
 }
 
 /* Filled button colors */

--- a/packages/react/src/components/Button/Button.module.css
+++ b/packages/react/src/components/Button/Button.module.css
@@ -92,7 +92,7 @@
 }
 
 .button.onlyIcon {
-  padding: 0.5rem;
+  padding: 0.3125rem;
 }
 
 /* Filled button colors */

--- a/packages/react/src/components/Button/Button.module.css
+++ b/packages/react/src/components/Button/Button.module.css
@@ -92,7 +92,7 @@
 }
 
 .button.onlyIcon {
-  padding: 0.3125rem;
+  padding: calc((var(--button-size) - var(--icon-size)) / 2 - var(--component-button-border_width-default));
 }
 
 /* Filled button colors */


### PR DESCRIPTION
Adjusted padding to make quiet button with only icon completely round. Related to #187 