### PR TITLE
fix(RadioButton): RadioButton looks wrong when zoming in browser

### DIFF
--- a/packages/react/src/components/RadioButton/RadioButton.module.css
+++ b/packages/react/src/components/RadioButton/RadioButton.module.css
@@ -43,10 +43,11 @@
 
 .visibleButton {
   background-color: var(--radio-background_color);
-  border-color: var(--radio-border_color);
   border-radius: 50%;
-  border-style: solid;
-  border-width: var(--radio-border_width);
+  outline-color: var(--radio-border_color);
+  outline-style: solid;
+  outline-offset: calc(-1 * var(--radio-border_width));
+  outline-width: var(--radio-border_width);
   box-sizing: border-box;
   display: inline-block;
   height: var(--radio-size);
@@ -54,15 +55,11 @@
 }
 
 .checkmark {
-  --radio-checkmark-size: 80%;
-
-  background-color: var(--radio-checkmark-color);
+  box-shadow: 0 0 0 calc(2 * var(--radio-border_width))
+      var(--radio-background_color) inset,
+    0 0 0 var(--radio-size) var(--radio-checkmark-color) inset;
   border-radius: 50%;
   display: var(--radio-checkmark-display);
-  height: var(--radio-checkmark-size);
-  margin: calc(
-    (var(--radio-size) - var(--radio-checkmark-size)) / 2 -
-      var(--radio-border_width)
-  );
-  width: var(--radio-checkmark-size);
+  height: 100%;
+  width: 100%;
 }

--- a/packages/react/src/components/RadioButton/RadioButton.stories.mdx
+++ b/packages/react/src/components/RadioButton/RadioButton.stories.mdx
@@ -104,15 +104,6 @@ Radioknappene kan ha flere forskjellige statuser:
     {Template.bind({})}
   </Story>
   <Story
-    name='Avkrysset'
-    args={{
-      checked: true,
-      label: 'Avkrysset',
-    }}
-  >
-    {Template.bind({})}
-  </Story>
-  <Story
     name='Hjelpetekst'
     args={{
       label: 'Hjelpetekst',
@@ -143,6 +134,50 @@ Radioknappene kan ha flere forskjellige statuser:
   <Story
     name='Deaktivert'
     args={{
+      disabled: true,
+      label: 'Deaktivert',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+I avkrysset tilstand
+
+<Canvas>
+  <Story
+    name='Normal Avkrysset'
+    args={{
+      checked: true,
+      label: 'Normal',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+  <Story
+    name='Feil Avkrysset'
+    args={{
+      checked: true,
+      error: true,
+      label: 'Feil',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+  <Story
+    name='Kompakt Avkrysset'
+    args={{
+      size: RadioButtonSize.Xsmall,
+      label: 'Kompakt',
+      checked: true,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+  <Story
+    name='Deaktivert Avkrysset'
+    args={{
+      checked: true,
       disabled: true,
       label: 'Deaktivert',
     }}


### PR DESCRIPTION
The issue is caused by rounding errors for the inner checkmark when the outer box uses a border that gets scaled by small fractions of a px.

Fixed by using outline instead of border

Also changed the checkmark from background-collor to box-shaddow so that it is visible in print mode. It's also way less likely to get roundoff errors when drawing a shaddow than when

I also updated the storybook to show all the relevant variants in checked mode (missing ones was compact, error, and disabled)

### Samples of previous render artifacts
From https://digdir.github.io/designsystem/?path=/docs/kjernekomponenter-radiobutton--normal

- Compact view without any zoom (added this to storybook default view so that it becomes more obvious in case of a regression)

![image](https://user-images.githubusercontent.com/131616/227891675-21190a82-1a20-4e83-8b75-4770d07291ae.png)

- 90 % zoom in chrome
![image](https://user-images.githubusercontent.com/131616/227892316-fb307564-ec1a-427d-85d2-cf1ac6cb9a69.png)

- 125% zoom in chrome
![image](https://user-images.githubusercontent.com/131616/227893741-468df3dd-efbc-4241-af66-6883aea24a9c.png)
