### PR TITLE
fix(Textfield): upgrading `react-number-format`, removing workaround

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,6 +30,6 @@
     "@altinn/figma-design-tokens": "^6.0.1",
     "@floating-ui/react": "0.17.0",
     "@navikt/ds-icons": "^2.3.0",
-    "react-number-format": "^5.1.3"
+    "react-number-format": "^5.1.4"
   }
 }

--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -225,10 +225,17 @@ describe('TextField', () => {
       expect(screen.getByDisplayValue('125 000 NOK')).toBeInTheDocument();
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(lastValue).toBe('125');
+
       element.setSelectionRange(8, 11); // Select 'NOK' (v5 bug)
+      await user.keyboard('8'); // This is ignored, suffix cannot be changed
+      expect(screen.getByDisplayValue('125 000 NOK')).toBeInTheDocument();
+      expect(onChange).toHaveBeenCalledTimes(1);
+
+      element.setSelectionRange(3, 3); // Selection after the last digit
       await user.keyboard('8');
       expect(screen.getByDisplayValue('1 258 000 NOK')).toBeInTheDocument();
       expect(onChange).toHaveBeenCalledTimes(2);
+
       expect(lastValue).toBe('1258');
     });
 

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -43,42 +43,6 @@ const replaceTargetValueWithUnformattedValue = ({
     values.value.trim();
 };
 
-// Mitigates this issue: https://github.com/s-yadav/react-number-format/issues/694
-// Remove if fixed
-const numericKeyDown = (
-  e: React.KeyboardEvent<HTMLInputElement>,
-  prefix?: string,
-  suffix?: string,
-) => {
-  const el = e.target as HTMLInputElement;
-  const { key } = e;
-  const { selectionStart, selectionEnd, value = '' } = el;
-
-  if (selectionStart !== null && selectionEnd !== null) {
-    const negative = value[0] === '-';
-
-    const prefixLength = prefix?.length || 0 + (negative ? 1 : 0);
-    const suffixLength = suffix?.length || 0;
-
-    // If the number is negative, allow deleting the minus (-) sign
-    if (negative && selectionEnd <= prefixLength && key === 'Backspace') {
-      el.setSelectionRange(1, 1);
-    } else {
-      // Make sure selection is within the bounds of prefix/suffix
-      el.setSelectionRange(
-        Math.min(
-          Math.max(selectionStart, prefixLength),
-          value.length - suffixLength,
-        ),
-        Math.max(
-          Math.min(selectionEnd, value.length - suffixLength),
-          prefixLength,
-        ),
-      );
-    }
-  }
-};
-
 const TextField = ({
   id,
   onChange,
@@ -137,13 +101,6 @@ const TextField = ({
               data-testid={`${inputId}-formatted-number-${variant}`}
               onValueChange={handleNumberFormatChange}
               valueIsNumericString={true}
-              onKeyDown={(e) =>
-                numericKeyDown(
-                  e,
-                  (formatting.number as NumericFormatProps).prefix,
-                  (formatting.number as NumericFormatProps).suffix,
-                )
-              }
             />
           );
         } else if (formatting?.number && isPatternFormat(formatting.number)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2016,7 +2016,7 @@ __metadata:
     "@digdir/design-system-icons": "*"
     "@floating-ui/react": 0.17.0
     "@navikt/ds-icons": ^2.3.0
-    react-number-format: ^5.1.3
+    react-number-format: ^5.1.4
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
@@ -20626,6 +20626,18 @@ __metadata:
     react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^18.0.0
     react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^18.0.0
   checksum: 354481a3ce15520d3e786f790a84a0363a94c56034519c6e2248d8f277095b696f31204a46745d3c64869559b7a81ba39ab9ad46c6582f762255f81d5c5d2e95
+  languageName: node
+  linkType: hard
+
+"react-number-format@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "react-number-format@npm:5.1.4"
+  dependencies:
+    prop-types: ^15.7.2
+  peerDependencies:
+    react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 770a1e86cd05d9df28aa5e6a12c5731351dd4a301464edd0ac5dcbc68d2f07eae37781ff14f6153566cbb7cccb28f13f0826d1844600d25ae6e12da060814282
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #211