### PR TITLE
chore: Added yarn pack script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "storybook:clean": "start-storybook -p 6006 --no-manager-cache",
     "build": "npx lerna run build",
     "build-react": "cd packages/react && yarn build",
-    "pack-react": "cd packages/react && yarn pack",
+    "pack:react": "yarn workspace @digdir/design-system-react pack",
     "build-storybook": "build-storybook -o ./docs",
     "test": "jest",
     "add-component-core": "node scripts/add-component.mjs",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "storybook:clean": "start-storybook -p 6006 --no-manager-cache",
     "build": "npx lerna run build",
     "build-react": "cd packages/react && yarn build",
+    "pack-react": "cd packages/react && yarn pack",
     "build-storybook": "build-storybook -o ./docs",
     "test": "jest",
     "add-component-core": "node scripts/add-component.mjs",


### PR DESCRIPTION
I usually test the designsystem on app-frontend-react when making changes, and the only good way of doing that seems to be creating a local package and importing it into app-frontend-react (unless someone has found a way to link them without react self-destructing).

This is just a simple command to make it more convenient to package the react-package locally.