### PR TITLE
fix(Select): Update selected on option change

### DIFF
--- a/packages/react/src/components/Select/Select.test.tsx
+++ b/packages/react/src/components/Select/Select.test.tsx
@@ -382,6 +382,22 @@ describe('Select', () => {
       await act(() => user.click(screen.getByRole('combobox')));
       await act(() => user.click(screen.getAllByRole('option')[1]));
       expectSelectedValue(newOptions[1]);
+      expect(getCombobox()).toHaveValue(newOptions[1].label);
+    });
+
+    it('Rerenders with the correct value and keyword when "options" are loaded late', async () => {
+      const value = 'test2';
+      const options = singleSelectOptions;
+      const { rerender } = renderSingleSelect({ options: [], value });
+      rerender(
+        <Select
+          {...defaultSingleSelectProps}
+          options={options}
+          value={value}
+        />,
+      );
+      expectSelectedValue(options[1]);
+      expect(getCombobox()).toHaveValue(options[1].label);
     });
   });
 

--- a/packages/react/src/components/Select/Select.test.tsx
+++ b/packages/react/src/components/Select/Select.test.tsx
@@ -386,8 +386,8 @@ describe('Select', () => {
     });
 
     it('Rerenders with the correct value and keyword when "options" are loaded late', async () => {
-      const value = 'test2';
       const options = singleSelectOptions;
+      const value = options[1].value;
       const { rerender } = renderSingleSelect({ options: [], value });
       rerender(
         <Select

--- a/packages/react/src/components/Select/Select.test.tsx
+++ b/packages/react/src/components/Select/Select.test.tsx
@@ -123,6 +123,14 @@ describe('Select', () => {
       expect(getCombobox()).toHaveAttribute('aria-expanded', 'false');
     });
 
+    it('Sets the keyword to the selected value onBlur', async () => {
+      renderSingleSelect();
+      await act(() => user.type(getCombobox(), 'a'));
+      expect(getCombobox()).toHaveValue('a');
+      await act(() => user.tab());
+      expect(getCombobox()).toHaveValue(sortedOptions[0].label);
+    });
+
     it('Changes value when user clicks on another option', async () => {
       renderSingleSelect();
       await act(() => user.click(screen.getByRole('combobox')));
@@ -284,7 +292,7 @@ describe('Select', () => {
     it('Sets keyword to the selected option label when the user starts browsing the list', async () => {
       renderSingleSelect();
       await act(() => user.type(getCombobox(), 'a{ArrowDown}'));
-      expect(getCombobox()).toHaveValue(sortedOptions[0].label);
+      expect(getCombobox()).toHaveValue(sortedOptions[1].label);
     });
 
     it('Does not reset keyword while user is writing', async () => {

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -123,7 +123,8 @@ const Select = (props: SelectProps) => {
 
     if (
       (!multiple && value !== prevValue) ||
-      (multiple && !arraysEqual(value, prevValue as string[])) ||
+      (multiple &&
+        (typeof prevValue === 'string' || !arraysEqual(value, prevValue))) ||
       shouldSetValue
     ) {
       if (multiple) {

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -138,12 +138,6 @@ const Select = (props: SelectProps) => {
 
   const numberOfOptions = options.length;
 
-  // When order of sorted options changes (due to change of search keyword), select first option.
-  const firstOptionValue = sortedOptions[0]?.value;
-  useUpdate(() => {
-    firstOptionValue !== undefined && setActiveOption(firstOptionValue);
-  }, [firstOptionValue]);
-
   // If multiselect, activeOption defines which option that has focus.
   // If single select, it defines the selected value.
   // These are supposed to behave similarly regarding keyboard events, hence why it's the same variable.
@@ -174,6 +168,9 @@ const Select = (props: SelectProps) => {
   useEventListener('focusout', updateHasFocus);
 
   useUpdate(() => {
+    if (!multiple && !hasFocus) {
+      setKeyword(findOptionFromValue(activeOption)?.label ?? '');
+    }
     if (hasFocus && onFocus)
       multiple ? onFocus(selectedValues) : onFocus(activeOption || '');
     else if (!hasFocus && onBlur)
@@ -318,7 +315,16 @@ const Select = (props: SelectProps) => {
     const newKeyword = e.target.value;
     if (newKeyword) {
       // Update sorted options only if keyword has a non-empty value
-      setSortedOptions(optionSearch(options, newKeyword));
+      const newSortedOptions = optionSearch(options, newKeyword);
+      setSortedOptions(newSortedOptions);
+
+      // When order of sorted options changes (due to change of search keyword), select first option.
+      const firstOptionValue = sortedOptions[0]?.value;
+      const newFirstOptionValue = newSortedOptions[0]?.value;
+      if (newSortedOptions && firstOptionValue != newFirstOptionValue) {
+        setActiveOption(newFirstOptionValue);
+      }
+
       !expanded && setExpanded(true);
     }
     setKeyword(newKeyword);

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -96,8 +96,10 @@ const Select = (props: SelectProps) => {
   const [sortedOptions, setSortedOptions] = useState(options);
   // Enable dynamic change of options by resetting sortedOptions
   const prevOptions = usePrevious([...options]);
+  const prevValue = usePrevious(value);
   useUpdate(() => {
     // Update not on changed reference but on changed values inside the object
+    let shouldSetValue = false;
     if (
       options.length !== prevOptions?.length ||
       options.some(
@@ -105,7 +107,21 @@ const Select = (props: SelectProps) => {
       )
     ) {
       setSortedOptions(options);
-      setSelectedValues(multiple ? value ?? [] : []);
+      shouldSetValue = true;
+    }
+
+    if (
+      (!multiple && value !== prevValue) ||
+      (multiple &&
+        (!Array.isArray(prevValue) || !arraysEqual(value, prevValue))) ||
+      shouldSetValue
+    ) {
+      if (multiple) {
+        setSelectedValues(value ?? []);
+      } else {
+        setActiveOption(value);
+        setKeyword(findOptionFromValue(value)?.label ?? '');
+      }
     }
   });
 
@@ -163,16 +179,6 @@ const Select = (props: SelectProps) => {
       },
     [options],
   );
-
-  useEffect(() => {
-    // Rerender when the value property changes
-    if (!multiple) {
-      setActiveOption(value);
-      setKeyword(findOptionFromValue(value)?.label ?? '');
-    } else if (!arraysEqual(value, selectedValues)) {
-      setSelectedValues(value ?? []);
-    }
-  }, [findOptionFromValue, multiple, selectedValues, value]);
 
   useEffect(() => {
     // Ensure that active option is always visible when using keyboard

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -86,12 +86,23 @@ const Select = (props: SelectProps) => {
     throw Error('Each value in the option list must be unique.');
   }
 
+  const findOptionFromValue = useCallback(
+    (v?: string) =>
+      options.find((option) => option.value === v) ?? {
+        label: '',
+        value: '',
+      },
+    [options],
+  );
+
   // List of selected values if multiselect.
   const [selectedValues, setSelectedValues] = useState<string[]>(
     multiple ? value ?? [] : [],
   );
 
-  const [keyword, setKeyword] = useState('');
+  const [keyword, setKeyword] = useState(
+    !multiple ? findOptionFromValue(value)?.label ?? '' : '',
+  );
 
   const [sortedOptions, setSortedOptions] = useState(options);
   // Enable dynamic change of options by resetting sortedOptions
@@ -112,8 +123,7 @@ const Select = (props: SelectProps) => {
 
     if (
       (!multiple && value !== prevValue) ||
-      (multiple &&
-        (!Array.isArray(prevValue) || !arraysEqual(value, prevValue))) ||
+      (multiple && !arraysEqual(value, prevValue as string[])) ||
       shouldSetValue
     ) {
       if (multiple) {
@@ -170,15 +180,6 @@ const Select = (props: SelectProps) => {
   }, [hasFocus]);
 
   const [expanded, setExpanded] = useState<boolean>(false);
-
-  const findOptionFromValue = useCallback(
-    (v?: string) =>
-      options.find((option) => option.value === v) ?? {
-        label: '',
-        value: '',
-      },
-    [options],
-  );
 
   useEffect(() => {
     // Ensure that active option is always visible when using keyboard

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -155,6 +155,15 @@ const Select = (props: SelectProps) => {
 
   const [expanded, setExpanded] = useState<boolean>(false);
 
+  const findOptionFromValue = useCallback(
+    (v?: string) =>
+      options.find((option) => option.value === v) ?? {
+        label: '',
+        value: '',
+      },
+    [options],
+  );
+
   useEffect(() => {
     // Rerender when the value property changes
     if (!multiple) {
@@ -163,7 +172,7 @@ const Select = (props: SelectProps) => {
     } else if (!arraysEqual(value, selectedValues)) {
       setSelectedValues(value ?? []);
     }
-  }, [value, options]);
+  }, [findOptionFromValue, multiple, selectedValues, value]);
 
   useEffect(() => {
     // Ensure that active option is always visible when using keyboard
@@ -193,12 +202,6 @@ const Select = (props: SelectProps) => {
       }
     }
   }, [activeOptionIndex]);
-
-  const findOptionFromValue = (v?: string) =>
-    options.find((option) => option.value === v) ?? {
-      label: '',
-      value: '',
-    };
 
   const multipleChangeHandler = (newValues: string[], addedValue?: string) => {
     if (!selectedValues?.length) {

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -163,7 +163,7 @@ const Select = (props: SelectProps) => {
     } else if (!arraysEqual(value, selectedValues)) {
       setSelectedValues(value ?? []);
     }
-  }, [value]);
+  }, [value, options]);
 
   useEffect(() => {
     // Ensure that active option is always visible when using keyboard


### PR DESCRIPTION
When setting an initial value to a select, it currently does not work if the options are loaded after the initial value is, since it will already have run the useEffect without finding the option and is not run again once the options are loaded. In app-fronten-react, this led to select-boxes always showing up empty on refresh even if they had been previously filled out, because option-loading happens later than formData-loading in app-frontend-react.