### PR TITLE
fix(Select): fix aria-activedecendant attribute

### DIFF
--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -379,7 +379,9 @@ const Select = (props: SelectProps) => {
                 </>
               )}
               <input
-                aria-activedescendant={`${id}-${activeOption}`}
+                {...(activeOption && {
+                  'aria-activedescendant': `${id}-${activeOption}`,
+                })}
                 aria-autocomplete='list'
                 aria-controls={listboxId}
                 aria-expanded={expanded}


### PR DESCRIPTION
I got a WCAG error on the aria-activedescendant attribute in the cypress tests for app-frontend-react. Since activeOption can be undefined, this attribute can become "<id>-" and I believe I also saw "<id>-undefined". These IDs do not exist in the DOM which caused the error.