### PR TITLE
fix(Table): Sort-arrows fix

### DIFF
--- a/packages/react/src/components/Table/TableCell.tsx
+++ b/packages/react/src/components/Table/TableCell.tsx
@@ -87,10 +87,13 @@ export function TableCell({
               <SortIcon
                 aria-label='Sortering' // Todo: Texts should be provided by the consumer
                 data-testid='sort-icon'
-                className={cn(classes['icon'], {
-                  [classes.iconAsc]: sortDirection === 'asc',
-                  [classes.iconDesc]: sortDirection === 'desc',
-                })}
+                className={
+                  sortDirection == 'notActive'
+                    ? classes.icon
+                    : sortDirection == 'asc'
+                    ? classes.iconAsc
+                    : classes.iconDesc
+                }
               />
             )}
           </div>


### PR DESCRIPTION
In the frontendrepo the arrows colors don't work as they should. The arrows should be grey when not active and black when the sorting is Active. Fixed this in the old designsystem with a PR and got it to work, but I have not tested this but it is the same as I did in the old designsystem :)