### PR TITLE
fix(Select): Make event listeners local

### DIFF
--- a/packages/react/src/components/Select/Select.test.tsx
+++ b/packages/react/src/components/Select/Select.test.tsx
@@ -310,7 +310,7 @@ describe('Select', () => {
 
     it('Updates the search field with the best match when the user presses the Enter key', async () => {
       renderSingleSelect();
-      await user.type(getCombobox(), 'abc{Enter}');
+      await act(() => user.type(getCombobox(), 'abc{Enter}'));
       expect(getCombobox()).toHaveValue(sortedOptions[0].label);
     });
 
@@ -328,10 +328,10 @@ describe('Select', () => {
         </>,
       );
       expect(onFocus).not.toHaveBeenCalled();
-      await user.click(getCombobox());
+      await act(() => user.click(getCombobox()));
       expect(onFocus).toHaveBeenCalledTimes(1);
       expect(onFocus).toHaveBeenCalledWith(value);
-      await user.click(screen.getByTestId(outsideButtonTestid));
+      await act(() => user.click(screen.getByTestId(outsideButtonTestid)));
       expect(onFocus).toHaveBeenCalledTimes(1);
     });
 
@@ -349,9 +349,9 @@ describe('Select', () => {
         </>,
       );
       expect(onBlur).not.toHaveBeenCalled();
-      await user.click(getCombobox());
+      await act(() => user.click(getCombobox()));
       expect(onBlur).not.toHaveBeenCalled();
-      await user.click(screen.getByTestId(outsideButtonTestid));
+      await act(() => user.click(screen.getByTestId(outsideButtonTestid)));
       expect(onBlur).toHaveBeenCalledTimes(1);
       expect(onBlur).toHaveBeenCalledWith(value);
     });
@@ -360,9 +360,9 @@ describe('Select', () => {
       const onBlur = jest.fn();
       const value = singleSelectOptions[0].value;
       renderSingleSelect({ onBlur, value });
-      await user.click(getCombobox());
+      await act(() => user.click(getCombobox()));
       expect(onBlur).not.toHaveBeenCalled();
-      await user.click(document.body);
+      await act(() => user.click(document.body));
       expect(onBlur).toHaveBeenCalledTimes(1);
       expect(onBlur).toHaveBeenCalledWith(value);
     });
@@ -822,10 +822,10 @@ describe('Select', () => {
         </>,
       );
       expect(onFocus).not.toHaveBeenCalled();
-      await user.click(getCombobox());
+      await act(() => user.click(getCombobox()));
       expect(onFocus).toHaveBeenCalledTimes(1);
       expect(onFocus).toHaveBeenCalledWith(value);
-      await user.click(screen.getByTestId(outsideButtonTestid));
+      await act(() => user.click(screen.getByTestId(outsideButtonTestid)));
       expect(onFocus).toHaveBeenCalledTimes(1);
     });
 
@@ -843,9 +843,9 @@ describe('Select', () => {
         </>,
       );
       expect(onBlur).not.toHaveBeenCalled();
-      await user.click(getCombobox());
+      await act(() => user.click(getCombobox()));
       expect(onBlur).not.toHaveBeenCalled();
-      await user.click(screen.getByTestId(outsideButtonTestid));
+      await act(() => user.click(screen.getByTestId(outsideButtonTestid)));
       expect(onBlur).toHaveBeenCalledTimes(1);
       expect(onBlur).toHaveBeenCalledWith(value);
     });
@@ -854,9 +854,9 @@ describe('Select', () => {
       const onBlur = jest.fn();
       const value = [multiSelectOptions[0].value];
       renderMultiSelect({ onBlur, value });
-      await user.click(getCombobox());
+      await act(() => user.click(getCombobox()));
       expect(onBlur).not.toHaveBeenCalled();
-      await user.click(document.body);
+      await act(() => user.click(document.body));
       expect(onBlur).toHaveBeenCalledTimes(1);
       expect(onBlur).toHaveBeenCalledWith(value);
     });
@@ -867,10 +867,11 @@ describe('Select', () => {
       const selectedOption = multiSelectOptions[0];
       const value = [selectedOption.value];
       renderMultiSelect({ onBlur, onFocus, value });
-      await user.click(getCombobox());
+      await act(() => user.click(getCombobox()));
       expect(onFocus).toHaveBeenCalledTimes(1);
       expect(onBlur).not.toHaveBeenCalled();
-      await user.click(screen.getByLabelText(selectedOption.deleteButtonLabel));
+      const delButton = screen.getByLabelText(selectedOption.deleteButtonLabel);
+      await act(() => user.click(delButton));
       expect(onFocus).toHaveBeenCalledTimes(1);
       expect(onBlur).not.toHaveBeenCalled();
     });

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, ReactNode, RefObject } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
 import React, { useCallback, useEffect, useId, useState } from 'react';
 import cn from 'classnames';
 import { autoUpdate, useFloating } from '@floating-ui/react';
@@ -161,7 +161,7 @@ const Select = (props: SelectProps) => {
   const selectField = elements.reference as HTMLSpanElement;
 
   const [usingKeyboard, setUsingKeyboard] = useState<boolean>(false);
-  const hasFocus = useFocusWithin(refs.reference as RefObject<HTMLSpanElement>);
+  const hasFocus = useFocusWithin(selectField);
   useEventListener('click', () => setUsingKeyboard(false));
   useEventListener('keydown', () => setUsingKeyboard(true));
 

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, ReactNode } from 'react';
+import type { ChangeEvent, ReactNode, RefObject } from 'react';
 import React, { useCallback, useEffect, useId, useState } from 'react';
 import cn from 'classnames';
 import { autoUpdate, useFloating } from '@floating-ui/react';
@@ -11,6 +11,7 @@ import {
   useUpdate,
 } from '../../hooks';
 import { arraysEqual, objectValuesEqual } from '../../utils';
+import { useFocusWithin } from '../../hooks/useFocusWithin';
 
 import { MultiSelectItem } from './MultiSelectItem';
 import classes from './Select.module.css';
@@ -160,15 +161,9 @@ const Select = (props: SelectProps) => {
   const selectField = elements.reference as HTMLSpanElement;
 
   const [usingKeyboard, setUsingKeyboard] = useState<boolean>(false);
-  const [hasFocus, setHasFocus] = useState<boolean>(false);
+  const hasFocus = useFocusWithin(refs.reference as RefObject<HTMLSpanElement>);
   useEventListener('click', () => setUsingKeyboard(false));
   useEventListener('keydown', () => setUsingKeyboard(true));
-  const updateHasFocus = () => {
-    const { activeElement } = document;
-    setHasFocus(selectField?.contains(activeElement) ?? false);
-  };
-  useEventListener('focusin', updateHasFocus);
-  useEventListener('focusout', updateHasFocus);
 
   useUpdate(() => {
     if (!multiple && !hasFocus) {
@@ -295,23 +290,31 @@ const Select = (props: SelectProps) => {
     numberOfOptions,
   ]);
 
-  useKeyboardEventListener(eventListenerKeys.ArrowDown, () => {
-    expanded ? moveFocusDown() : setExpanded(true);
-  });
+  useKeyboardEventListener(
+    eventListenerKeys.ArrowDown,
+    () => (expanded ? moveFocusDown() : setExpanded(true)),
+    selectField,
+  );
 
-  useKeyboardEventListener(eventListenerKeys.ArrowUp, () => {
-    expanded ? moveFocusUp() : setExpanded(true);
-  });
+  useKeyboardEventListener(
+    eventListenerKeys.ArrowUp,
+    () => (expanded ? moveFocusUp() : setExpanded(true)),
+    selectField,
+  );
 
-  useKeyboardEventListener(eventListenerKeys.Enter, () => {
-    if (expanded) {
-      if (activeOption) {
-        addOrRemoveSelectedValue(activeOption);
-      } else {
-        setExpanded(false);
+  useKeyboardEventListener(
+    eventListenerKeys.Enter,
+    () => {
+      if (expanded) {
+        if (activeOption) {
+          addOrRemoveSelectedValue(activeOption);
+        } else {
+          setExpanded(false);
+        }
       }
-    }
-  });
+    },
+    selectField,
+  );
 
   const keywordChangeHandler = (e: ChangeEvent<HTMLInputElement>) => {
     const newKeyword = e.target.value;

--- a/packages/react/src/hooks/useEventListener.test.ts
+++ b/packages/react/src/hooks/useEventListener.test.ts
@@ -7,7 +7,7 @@ import { useEventListener } from './';
 const user = userEvent.setup();
 
 const renderUseEventListener = (eventType: string, action: () => void) =>
-  renderHook(() => useEventListener(eventType, action), {
+  renderHook(() => useEventListener(eventType, action, document.body), {
     initialProps: { eventType, action },
   });
 
@@ -27,7 +27,10 @@ describe('useEventListener', () => {
   });
 
   it('Removes event listener on unmount', () => {
-    const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+    const removeEventListenerSpy = jest.spyOn(
+      document.body,
+      'removeEventListener',
+    );
     const { unmount } = renderUseEventListener('click', jest.fn());
     expect(removeEventListenerSpy).not.toHaveBeenCalled();
     unmount();

--- a/packages/react/src/hooks/useEventListener.ts
+++ b/packages/react/src/hooks/useEventListener.ts
@@ -8,7 +8,7 @@ type Element = HTMLElement | null | undefined;
  * @param action The action to perform when the event is triggered.
  * @param element The element to add the event listener to. Defaults to the document body.
  */
-export function useEventListener<T extends Element = undefined>(
+export function useEventListener<T extends Element>(
   eventType: string,
   action: () => void,
   element?: T,

--- a/packages/react/src/hooks/useEventListener.ts
+++ b/packages/react/src/hooks/useEventListener.ts
@@ -1,8 +1,21 @@
 import { useEffect } from 'react';
 
-export function useEventListener(eventType: string, action: () => void) {
+type Element = HTMLElement | null | undefined;
+
+/**
+ * Adds an event listener to the given element or the document body if no element is given. The listener is removed on unmount.
+ * @param eventType The event type to listen for.
+ * @param action The action to perform when the event is triggered.
+ * @param element The element to add the event listener to. Defaults to the document body.
+ */
+export function useEventListener<T extends Element = undefined>(
+  eventType: string,
+  action: () => void,
+  element?: T,
+) {
   useEffect(() => {
-    document.addEventListener(eventType, action);
-    return () => document.removeEventListener(eventType, action);
-  }, [eventType, action]);
+    const targetElement = element ?? document.body;
+    targetElement.addEventListener(eventType, action);
+    return () => targetElement.removeEventListener(eventType, action);
+  }, [eventType, action, element]);
 }

--- a/packages/react/src/hooks/useFocusWithin.test.tsx
+++ b/packages/react/src/hooks/useFocusWithin.test.tsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { useFocusWithin } from './useFocusWithin';
+
+const user = userEvent.setup();
+
+const outsideButtonTestId = 'outside-button';
+const insideButtonTestId = 'inside-button';
+const focusWithinChangeFn = jest.fn();
+
+const TestComponent = () => {
+  const ref = useRef<HTMLSpanElement>(null);
+  const hasFocus = useFocusWithin<HTMLSpanElement>(ref);
+  useEffect(() => {
+    focusWithinChangeFn(hasFocus);
+  }, [hasFocus]);
+  return (
+    <>
+      <button data-testid={outsideButtonTestId}>Outside</button>
+      <span ref={ref}>
+        <button data-testid={insideButtonTestId}>Inside</button>
+      </span>
+    </>
+  );
+};
+
+test('useFocusWithin', async () => {
+  render(<TestComponent />);
+  expect(focusWithinChangeFn).toHaveBeenLastCalledWith(false);
+  await user.click(screen.getByTestId(insideButtonTestId));
+  expect(focusWithinChangeFn).toHaveBeenLastCalledWith(true);
+  await user.click(screen.getByTestId(outsideButtonTestId));
+  expect(focusWithinChangeFn).toHaveBeenLastCalledWith(false);
+});

--- a/packages/react/src/hooks/useFocusWithin.test.tsx
+++ b/packages/react/src/hooks/useFocusWithin.test.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -12,7 +12,13 @@ const focusWithinChangeFn = jest.fn();
 
 const TestComponent = () => {
   const ref = useRef<HTMLSpanElement>(null);
-  const hasFocus = useFocusWithin<HTMLSpanElement>(ref);
+  const [element, setElement] = useState(ref.current);
+  useEffect(() => {
+    setElement(ref.current);
+  }, [ref, setElement]);
+
+  const hasFocus = useFocusWithin<HTMLSpanElement>(element);
+
   useEffect(() => {
     focusWithinChangeFn(hasFocus);
   }, [hasFocus]);

--- a/packages/react/src/hooks/useFocusWithin.ts
+++ b/packages/react/src/hooks/useFocusWithin.ts
@@ -1,0 +1,22 @@
+import type { RefObject } from 'react';
+import { useState } from 'react';
+
+import { useEventListener } from './useEventListener';
+
+/**
+ * Returns true if the given ref is currently focused or contains the currently focused element.
+ * @param ref Reference to the element to check.
+ * @returns True if the given ref is currently focused or contains the currently focused element.
+ */
+export function useFocusWithin<T extends HTMLElement>(
+  ref: RefObject<T>,
+): boolean {
+  const [hasFocus, setHasFocus] = useState<boolean>(false);
+  const updateHasFocus = () => {
+    const { activeElement } = document;
+    setHasFocus(ref.current?.contains(activeElement) ?? false);
+  };
+  useEventListener('focusin', updateHasFocus, ref.current);
+  useEventListener('focusout', updateHasFocus, ref.current);
+  return hasFocus;
+}

--- a/packages/react/src/hooks/useFocusWithin.ts
+++ b/packages/react/src/hooks/useFocusWithin.ts
@@ -1,22 +1,21 @@
-import type { RefObject } from 'react';
 import { useState } from 'react';
 
 import { useEventListener } from './useEventListener';
 
 /**
- * Returns true if the given ref is currently focused or contains the currently focused element.
- * @param ref Reference to the element to check.
- * @returns True if the given ref is currently focused or contains the currently focused element.
+ * Returns true if the given element is currently focused or contains the currently focused element.
+ * @param element The element to check.
+ * @returns True if the given element is currently focused or contains the currently focused element.
  */
 export function useFocusWithin<T extends HTMLElement>(
-  ref: RefObject<T>,
+  element: T | null,
 ): boolean {
   const [hasFocus, setHasFocus] = useState<boolean>(false);
   const updateHasFocus = () => {
     const { activeElement } = document;
-    setHasFocus(ref.current?.contains(activeElement) ?? false);
+    setHasFocus(element?.contains(activeElement) ?? false);
   };
-  useEventListener('focusin', updateHasFocus, ref.current);
-  useEventListener('focusout', updateHasFocus, ref.current);
+  useEventListener('focusin', updateHasFocus, element);
+  useEventListener('focusout', updateHasFocus, element);
   return hasFocus;
 }

--- a/packages/react/src/hooks/useKeyboardEventListener.test.ts
+++ b/packages/react/src/hooks/useKeyboardEventListener.test.ts
@@ -7,7 +7,7 @@ import { useKeyboardEventListener } from './';
 const user = userEvent.setup();
 
 const renderUseKeyboardEventListener = (key: string, onKeyDown: () => void) =>
-  renderHook(() => useKeyboardEventListener(key, onKeyDown), {
+  renderHook(() => useKeyboardEventListener(key, onKeyDown, document.body), {
     initialProps: { key, onKeyDown },
   });
 
@@ -27,7 +27,10 @@ describe('useKeyboardEventListener', () => {
   });
 
   it('Removes event listener on unmount', () => {
-    const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+    const removeEventListenerSpy = jest.spyOn(
+      document.body,
+      'removeEventListener',
+    );
     const { unmount } = renderUseKeyboardEventListener('Enter', jest.fn());
     expect(removeEventListenerSpy).not.toHaveBeenCalled();
     unmount();

--- a/packages/react/src/hooks/useKeyboardEventListener.ts
+++ b/packages/react/src/hooks/useKeyboardEventListener.ts
@@ -1,11 +1,24 @@
 import { useEffect } from 'react';
 
-export function useKeyboardEventListener(key: string, onKeyDown: () => void) {
+type Element = HTMLElement | null | undefined;
+
+/**
+ * Adds a keyboard event listener to the given element. The listener is removed on unmount.
+ * @param key The keyboard key to listen for.
+ * @param onKeyDown The action to perform when the key is pressed. Accepts the KeyboardEvent as a parameter.
+ * @param element The element to add the event listener to. No event listener is added if no element is given.
+ */
+export function useKeyboardEventListener<T extends Element = undefined>(
+  key: string,
+  onKeyDown: () => void,
+  element?: T,
+) {
   useEffect(() => {
+    if (!element) return;
     const keyDownEvent = (event: KeyboardEvent) => {
       if (event.key === key) onKeyDown();
     };
-    document.addEventListener('keydown', keyDownEvent);
-    return () => document.removeEventListener('keydown', keyDownEvent);
-  }, [key, onKeyDown]);
+    element.addEventListener('keydown', keyDownEvent);
+    return () => element.removeEventListener('keydown', keyDownEvent);
+  }, [key, onKeyDown, element]);
 }

--- a/packages/react/src/hooks/useKeyboardEventListener.ts
+++ b/packages/react/src/hooks/useKeyboardEventListener.ts
@@ -8,7 +8,7 @@ type Element = HTMLElement | null | undefined;
  * @param onKeyDown The action to perform when the key is pressed. Accepts the KeyboardEvent as a parameter.
  * @param element The element to add the event listener to. No event listener is added if no element is given.
  */
-export function useKeyboardEventListener<T extends Element = undefined>(
+export function useKeyboardEventListener<T extends Element>(
   key: string,
   onKeyDown: () => void,
   element?: T,


### PR DESCRIPTION
- Added an element parameter to the event listener hooks, so that event listeners may be created locally, and applied this in the `Select` component.
- Moved the `hasFocus` functionality out to a separate hook to make the code a little bit cleaner. This will also be useful to the `InputWrapper` component as it may fix the last task of #129.