### PR TITLE
fix(Table/RadioGroup/CheckboxGroup/FieldSet): Multiple minor accessibility improvements

### DIFF
--- a/packages/react/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.test.tsx
@@ -58,7 +58,7 @@ describe('Checkbox', () => {
   it('Should not display label text, but still make it accessible, when hideLabel is true', () => {
     const label = 'Lorem ipsum';
     render({ hideLabel: true, label });
-    expect(screen.queryByText(label)).toBeFalsy();
+    expect(screen.getByText(label).style.display).toEqual('none');
     expect(screen.getByLabelText(label)).toBeTruthy();
   });
 

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -12,7 +12,13 @@ import classes from './CheckboxGroup.module.css';
 
 export type CheckboxGroupItem = Pick<
   CheckboxProps,
-  'checked' | 'description' | 'disabled' | 'checkboxId' | 'label' | 'helpText'
+  | 'checked'
+  | 'description'
+  | 'disabled'
+  | 'checkboxId'
+  | 'label'
+  | 'helpText'
+  | 'hideLabel'
 > &
   Required<Pick<CheckboxProps, 'name'>>;
 
@@ -108,6 +114,7 @@ const CheckboxGroup = ({
           error={!!error}
           helpText={item.helpText}
           key={item.name}
+          hideLabel={item.hideLabel}
           label={item.label}
           name={item.name}
           onChange={(event) => {

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -3,6 +3,7 @@ import React, { useReducer } from 'react';
 import cn from 'classnames';
 
 import { Checkbox } from '../Checkbox';
+import type { FieldSetProps } from '../FieldSet';
 import { FieldSet } from '../FieldSet';
 import { areItemsUnique, arraysEqual, objectValuesEqual } from '../../utils';
 import { usePrevious, useUpdate } from '../../hooks';
@@ -35,6 +36,7 @@ export interface CheckboxGroupProps {
   onChange?: (names: CheckedNames) => void;
   presentation?: boolean;
   variant?: 'vertical' | 'horizontal';
+  fieldSetProps?: Partial<FieldSetProps>;
 }
 
 type ReducerAction =
@@ -65,6 +67,7 @@ const CheckboxGroup = ({
   onChange,
   presentation,
   variant = 'vertical',
+  fieldSetProps,
 }: CheckboxGroupProps) => {
   if (!areItemsUnique(items.map((item) => item.name))) {
     throw Error('Each name in the checkbox group must be unique.');
@@ -103,6 +106,7 @@ const CheckboxGroup = ({
       helpText={helpText}
       legend={legend}
       size={compact ? 'xsmall' : 'small'}
+      {...fieldSetProps}
     >
       {items.map((item) => (
         <Checkbox

--- a/packages/react/src/components/FieldSet/FieldSet.tsx
+++ b/packages/react/src/components/FieldSet/FieldSet.tsx
@@ -6,7 +6,11 @@ import { ErrorMessage, HelpText } from '../';
 
 import classes from './FieldSet.module.css';
 
-export interface FieldSetProps {
+export interface FieldSetProps
+  extends React.DetailedHTMLProps<
+    React.FieldsetHTMLAttributes<HTMLFieldSetElement>,
+    HTMLFieldSetElement
+  > {
   children: ReactNode;
   className?: string;
   contentClassName?: string;
@@ -28,11 +32,13 @@ const FieldSet = ({
   helpText,
   legend,
   size = 'small',
+  ...rest
 }: FieldSetProps) => {
   return (
     <fieldset
       className={cn(classes.fieldSet, classes[size], className)}
       disabled={disabled}
+      {...rest}
     >
       {legend && (
         <legend className={classes.legend}>

--- a/packages/react/src/components/FieldSet/FieldSet.tsx
+++ b/packages/react/src/components/FieldSet/FieldSet.tsx
@@ -15,7 +15,6 @@ export interface FieldSetProps
   className?: string;
   contentClassName?: string;
   description?: ReactNode;
-  disabled?: boolean;
   error?: ReactNode;
   helpText?: ReactNode;
   legend?: ReactNode;
@@ -27,7 +26,6 @@ const FieldSet = ({
   className,
   contentClassName,
   description,
-  disabled,
   error,
   helpText,
   legend,
@@ -36,9 +34,8 @@ const FieldSet = ({
 }: FieldSetProps) => {
   return (
     <fieldset
-      className={cn(classes.fieldSet, classes[size], className)}
-      disabled={disabled}
       {...rest}
+      className={cn(classes.fieldSet, classes[size], className)}
     >
       {legend && (
         <legend className={classes.legend}>

--- a/packages/react/src/components/RadioButton/RadioButton.test.tsx
+++ b/packages/react/src/components/RadioButton/RadioButton.test.tsx
@@ -66,7 +66,7 @@ describe('RadioButton', () => {
   it('Does not display label text, but still makes it accessible, when hideLabel is true', () => {
     const label = 'All we hear is radio ga ga';
     render({ hideLabel: true, label });
-    expect(screen.queryByText(label)).toBeFalsy();
+    expect(screen.getByText(label).style.display).toEqual('none');
     expect(screen.getByLabelText(label)).toBeTruthy();
   });
 

--- a/packages/react/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.tsx
@@ -2,6 +2,7 @@ import type { ChangeEvent, ReactNode } from 'react';
 import React, { useEffect, useState } from 'react';
 
 import { RadioButton } from '../RadioButton';
+import type { FieldSetProps } from '../FieldSet';
 import { FieldSet } from '../FieldSet';
 import { usePrevious, useUpdate } from '../../hooks';
 import { areItemsUnique } from '../../utils';
@@ -27,6 +28,7 @@ export interface RadioGroupProps {
   size?: 'small' | 'xsmall';
   value?: string;
   variant?: 'vertical' | 'horizontal';
+  fieldSetProps?: Partial<FieldSetProps>;
 }
 
 const RadioGroup = ({
@@ -42,6 +44,7 @@ const RadioGroup = ({
   size = 'small',
   value,
   variant = 'vertical',
+  fieldSetProps,
 }: RadioGroupProps) => {
   if (!areItemsUnique(items.map((item) => item.value))) {
     throw Error('Each value in the radio group must be unique.');
@@ -73,6 +76,7 @@ const RadioGroup = ({
       helpText={helpText}
       legend={legend}
       size={size}
+      {...fieldSetProps}
     >
       <div
         className={[classes.radioGroup, classes[variant], classes[size]].join(

--- a/packages/react/src/components/Table/TableCell.tsx
+++ b/packages/react/src/components/Table/TableCell.tsx
@@ -51,7 +51,8 @@ export function TableCell({
   return (
     <>
       {isVariant('header') && (
-        <th
+        <TableHeaderCell
+          useTd={!children}
           {...tableCellProps}
           className={cn(
             radiobutton
@@ -97,7 +98,7 @@ export function TableCell({
               />
             )}
           </div>
-        </th>
+        </TableHeaderCell>
       )}
       {isVariant('body') && (
         <td
@@ -124,4 +125,27 @@ export function TableCell({
       )}
     </>
   );
+}
+
+type TableHeaderCellProps = React.PropsWithChildren<{ useTd?: boolean }> &
+  React.DetailedHTMLProps<
+    React.TdHTMLAttributes<HTMLTableDataCellElement>,
+    HTMLTableDataCellElement
+  >;
+
+/**
+ * Table headers should not have empty cells, so we wrap the cell in this
+ * component to conditionally render a td or th element. According to WCAG
+ * rules, it's OK for a td element to be empty.
+ * @see https://webaim.org/techniques/tables/data#th
+ */
+function TableHeaderCell({
+  useTd = false,
+  children,
+  ...tableCellProps
+}: TableHeaderCellProps) {
+  if (useTd) {
+    return <td {...tableCellProps}>{children}</td>;
+  }
+  return <th {...tableCellProps}>{children}</th>;
 }

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -53,7 +53,7 @@ export const CheckboxRadioTemplate = ({
   const finalInputId = inputId ?? 'input-' + randomId;
   const labelId = label ? `${finalInputId}-label` : undefined;
   const descriptionId = description ? `${finalInputId}-description` : undefined;
-  const showLabel = label && !hideLabel;
+  const showLabel = !!(label && !hideLabel);
   const shouldHaveClickableLabel =
     !presentation ||
     (typeof label !== 'object' && typeof description !== 'object');
@@ -68,12 +68,14 @@ export const CheckboxRadioTemplate = ({
       )}
       htmlFor={finalInputId}
       isLabel={shouldHaveClickableLabel}
+      showLabel={showLabel}
     >
       {!hideInput && (
         <Wrapper
           className={classes.inputWrapper}
           htmlFor={finalInputId}
           isLabel={!shouldHaveClickableLabel}
+          showLabel={showLabel}
         >
           <input
             aria-describedby={descriptionId}
@@ -135,10 +137,17 @@ interface WrapperProps {
   className: string;
   htmlFor?: string;
   isLabel: boolean;
+  showLabel: boolean;
 }
 
-const Wrapper = ({ children, className, htmlFor, isLabel }: WrapperProps) =>
-  isLabel ? (
+const Wrapper = ({
+  children,
+  className,
+  htmlFor,
+  isLabel,
+  showLabel,
+}: WrapperProps) =>
+  isLabel && showLabel ? (
     <label
       className={className + ' ' + classes.clickable}
       htmlFor={htmlFor}

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -53,7 +53,7 @@ export const CheckboxRadioTemplate = ({
   const finalInputId = inputId ?? 'input-' + randomId;
   const labelId = label ? `${finalInputId}-label` : undefined;
   const descriptionId = description ? `${finalInputId}-description` : undefined;
-  const showLabel = !!(label && !hideLabel);
+  const showLabel = label && !hideLabel;
   const shouldHaveClickableLabel =
     !presentation ||
     (typeof label !== 'object' && typeof description !== 'object');
@@ -68,21 +68,16 @@ export const CheckboxRadioTemplate = ({
       )}
       htmlFor={finalInputId}
       isLabel={shouldHaveClickableLabel}
-      showLabel={showLabel}
     >
       {!hideInput && (
         <Wrapper
           className={classes.inputWrapper}
           htmlFor={finalInputId}
           isLabel={!shouldHaveClickableLabel}
-          showLabel={showLabel}
         >
           <input
             aria-describedby={descriptionId}
-            aria-label={
-              !showLabel && typeof label === 'string' ? label : undefined
-            }
-            aria-labelledby={showLabel ? labelId : undefined}
+            aria-labelledby={label ? labelId : undefined}
             checked={checked ?? false}
             className={classes.input}
             disabled={disabled}
@@ -96,28 +91,29 @@ export const CheckboxRadioTemplate = ({
           <span className={classes.visibleBox}>{children}</span>
         </Wrapper>
       )}
-      {(showLabel || description) && (
+      {(label || description) && (
         <span className={classes.labelAndDescription}>
-          {showLabel && (
-            <span className={classes.labelAndHelpText}>
+          <span className={classes.labelAndHelpText}>
+            {label && (
               <span
                 className={classes.label}
                 id={labelId}
+                style={{ display: showLabel ? 'inline' : 'none' }}
               >
                 {label}
               </span>
-              {helpText && (
-                <HelpText
-                  size={size}
-                  title={
-                    typeof label === 'string' ? `Help text for ${label}` : ''
-                  }
-                >
-                  {helpText}
-                </HelpText>
-              )}
-            </span>
-          )}
+            )}
+            {helpText && (
+              <HelpText
+                size={size}
+                title={
+                  typeof label === 'string' ? `Help text for ${label}` : ''
+                }
+              >
+                {helpText}
+              </HelpText>
+            )}
+          </span>
           {description && (
             <span
               className={classes.description}
@@ -137,17 +133,10 @@ interface WrapperProps {
   className: string;
   htmlFor?: string;
   isLabel: boolean;
-  showLabel: boolean;
 }
 
-const Wrapper = ({
-  children,
-  className,
-  htmlFor,
-  isLabel,
-  showLabel,
-}: WrapperProps) =>
-  isLabel && showLabel ? (
+const Wrapper = ({ children, className, htmlFor, isLabel }: WrapperProps) =>
+  isLabel ? (
     <label
       className={className + ' ' + classes.clickable}
       htmlFor={htmlFor}


### PR DESCRIPTION
In relation to this task:
- https://github.com/Altinn/app-frontend-react/issues/583

We have the need to display some form components inside a table, for this to work nicely with screen readers we need to include `aria-label` to describe the inputs even when there is no description of them visible to normal users (where the visual position in the table is description enough).

Descriptions of what I did and why:
- Radio options had the option of hiding the label, but that prop was not accepted for checkbox options. I found that option useful, as it could render `aria-label` while not displaying the option label in the table.
- When the `hideLabel` option was used for radio/checkbox options, a `<label>` element still wrapped the element, but that label did not contain any text, which made Wave complain about an empty label (even if it had `aria-label` instead). Hiding the text in the label instead allows for hiding the label without any errors from Wave.
- Table header cells that are empty makes Wave complain, because `th` cells should not be empty (then they're not not a header). Making the table automatically use a `td` for an empty header cell fixes this.
- To inject `aria-label` into the `FieldSet` I needed to pass on that property. I simply added a property that allows me to override/extend every property here.