### PR TITLE
fix(Table): Omitting `aria-sort` when no sort order is in effect

### DIFF
--- a/packages/react/src/components/Table/TableCell.tsx
+++ b/packages/react/src/components/Table/TableCell.tsx
@@ -65,7 +65,7 @@ export function TableCell({
               ? 'ascending'
               : sortDirection === 'desc'
               ? 'descending'
-              : 'none'
+              : undefined
           }
         >
           <div


### PR DESCRIPTION
Our automated a11y tester found a problem with the `aria-sort` attribute, as it used an invalid value of `none` when the column was not sorted. Although [MDN says this value is valid](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) (and the default), omitting it should have the same effect as using the default value, and the a11y stops complaining when this is not set.