### PR TITLE
fix(List): remove margin block

### DIFF
--- a/packages/react/src/components/List/List.module.css
+++ b/packages/react/src/components/List/List.module.css
@@ -6,6 +6,8 @@
   border-top-width: var(--component-list-border_width);
   list-style-type: none;
   padding-left: 0;
+  margin-block-start: 0;
+  margin-block-end: 0;
 }
 
 .list.solid {


### PR DESCRIPTION
The List component automatically sets margin-block-start and margin-block-end to 16px from default stylesheet which causes problems like in picture below. This fix sets this margin to 0.

<img width="883" alt="image" src="https://user-images.githubusercontent.com/31471142/233610598-84ed06d1-a789-428d-8d9b-8926dda7c244.png">
