### PR TITLE
chore: :wrench: Remove tsconfig linter rules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,12 +12,6 @@
     // match output dir to input dir. e.g. dist/index instead of dist/src/index
     // stricter type-checking for stronger correctness. Recommended by TS
     "strict": true,
-    // linter checks for common issues
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    // noUnused* overlap with @typescript-eslint/no-unused-vars, can disable if duplicative
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
     // transpile JSX to React.createElement


### PR DESCRIPTION
fixes: #138

Remove tsconfig linting rules as its causing unwanted consquences and we use eslint for linting.