### PR TITLE
chore: :construction_worker: Support for fluid typography in tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Built files
 dist
+ignore
 
 # Yarn stuff; we're not using PnP/Zero installs
 .pnp.*

--- a/packages/tokens/build.ts
+++ b/packages/tokens/build.ts
@@ -89,9 +89,9 @@ StyleDictionary.registerTransform({
 });
 
 StyleDictionary.registerFormat({
-  name: 'css/global-values-hack',
+  name: 'global-values-hack',
   formatter: ({ dictionary }) => {
-    console.log('\n Setting fontScale');
+    console.info('\x1b[34m✔ Setting global values');
     fontScale = dictionary.tokens['font-scale'];
 
     return `/** Style Dictionary hack because it must write to file for some reason... */\n`;
@@ -157,8 +157,8 @@ const getStyleDictionaryConfig = (
         ],
         files: [
           {
-            format: 'css/global-values-hack',
-            destination: 'ignore/hack.css',
+            format: 'global-values-hack',
+            destination: 'ignore/hack',
           },
           {
             destination: `${destinationPath}/tokens.css`,

--- a/packages/tokens/build.ts
+++ b/packages/tokens/build.ts
@@ -86,8 +86,8 @@ StyleDictionary.registerTransform({
       const { min, max, v, r } = scale;
       const minRem = (parseFloat(min.value as string) / baseFontPx).toFixed(2);
       const maxRem = (parseFloat(max.value as string) / baseFontPx).toFixed(2);
-      const fontV = parseFloat(v.value as string).toFixed(2);
       const fontR = (parseFloat(r.value as string) / baseFontPx).toFixed(2);
+      const fontV = parseFloat(v.value as string).toFixed(2);
 
       const fluid = `clamp(${minRem}rem, calc(${fontV}vw + ${fontR}rem), ${maxRem}rem)`;
 

--- a/packages/tokens/build.ts
+++ b/packages/tokens/build.ts
@@ -26,6 +26,17 @@ StyleDictionary.registerTransform({
   },
 });
 
+StyleDictionary.registerTransform({
+  name: 'name/cti/camel_underscore',
+  type: 'name',
+  transformer: function (token, options) {
+    return noCase([options?.prefix].concat(token.path).join(' '), {
+      delimiter: '_',
+      stripRegexp: /[^A-Z0-9_]+/gi,
+    });
+  },
+});
+
 type Typgraphy = {
   fontWeight: string;
   fontSize: string;
@@ -115,34 +126,6 @@ const getStyleDictionaryConfig = (
     ],
     source: [`${tokensPath}/Base/Core.json`],
     platforms: {
-      js: {
-        basePxFontSize,
-        transformGroup: 'js',
-        transforms: [
-          'ts/resolveMath',
-          'name/cti/camel',
-          'typography/shorthand',
-          'ts/size/lineheight',
-          'ts/shadow/css/shorthand',
-        ],
-        files: [
-          {
-            destination: `${destinationPath}/tokens.cjs.js`,
-            format: 'javascript/module-flat',
-            filter: excludeSource,
-          },
-          {
-            destination: `${destinationPath}/tokens.esm.js`,
-            format: 'javascript/es6',
-            filter: excludeSource,
-          },
-          {
-            destination: `${destinationPath}/tokens.d.ts`,
-            format: 'typescript/es6-declarations',
-            filter: excludeSource,
-          },
-        ],
-      },
       css: {
         prefix,
         basePxFontSize,
@@ -169,6 +152,35 @@ const getStyleDictionaryConfig = (
         options: {
           // outputReferences: true,
         },
+      },
+      js: {
+        basePxFontSize,
+        transformGroup: 'js',
+        transforms: [
+          'ts/resolveMath',
+          'name/cti/camel_underscore',
+          'fontSizes/fluid',
+          'typography/shorthand',
+          'ts/size/lineheight',
+          'ts/shadow/css/shorthand',
+        ],
+        files: [
+          {
+            destination: `${destinationPath}/tokens.cjs.js`,
+            format: 'javascript/module-flat',
+            filter: excludeSource,
+          },
+          {
+            destination: `${destinationPath}/tokens.esm.js`,
+            format: 'javascript/es6',
+            filter: excludeSource,
+          },
+          {
+            destination: `${destinationPath}/tokens.d.ts`,
+            format: 'typescript/es6-declarations',
+            filter: excludeSource,
+          },
+        ],
       },
     },
   };

--- a/packages/tokens/build.ts
+++ b/packages/tokens/build.ts
@@ -88,7 +88,7 @@ StyleDictionary.registerFormat({
     console.log('\n Setting fontScale');
     fontScale = dictionary.tokens['font-scale'];
 
-    return `/** Style Dictionary hack because it must write to file for some reason... */ \n`;
+    return `/** Style Dictionary hack because it must write to file for some reason... */\n`;
   },
 });
 

--- a/packages/tokens/build.ts
+++ b/packages/tokens/build.ts
@@ -88,7 +88,7 @@ StyleDictionary.registerFormat({
     console.log('\n Setting fontScale');
     fontScale = dictionary.tokens['font-scale'];
 
-    return `/** Style Dictionary hack because it must write to file for some reason */`;
+    return `/** Style Dictionary hack because it must write to file for some reason... */ \n`;
   },
 });
 

--- a/packages/tokens/build.ts
+++ b/packages/tokens/build.ts
@@ -28,7 +28,7 @@ StyleDictionary.registerTransform({
 
 type Typgraphy = {
   fontWeight: string;
-  fontSize: number;
+  fontSize: string;
   lineHeight: number;
   fontFamily: string;
 };
@@ -38,9 +38,15 @@ StyleDictionary.registerTransform({
   type: 'value',
   transitive: true,
   matcher: (token) => token.type === 'typography',
-  transformer: (token) => {
+  transformer: (token, options) => {
     const typography = token.value as Typgraphy;
-    return `${typography.fontWeight} ${typography.fontSize}/${typography.lineHeight} '${typography.fontFamily}'`;
+    let fontSize = typography.fontSize;
+
+    if (!fontSize.startsWith('clamp')) {
+      const baseFontPx = options?.basePxFontSize || 1;
+      fontSize = `${parseFloat(fontSize) / baseFontPx}rem`;
+    }
+    return `${typography.fontWeight} ${fontSize}/${typography.lineHeight} '${typography.fontFamily}'`;
   },
 });
 
@@ -143,9 +149,9 @@ const getStyleDictionaryConfig = (
         transformGroup: 'css',
         transforms: [
           'ts/resolveMath',
+          'name/cti/hierarchical-kebab',
           'fontSizes/fluid',
           'typography/shorthand',
-          'name/cti/hierarchical-kebab',
           'ts/size/lineheight',
           'ts/shadow/css/shorthand',
         ],


### PR DESCRIPTION
resolves #342 

Added support for `fontSize` transformation to css [clamp](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp) functions