### PR TITLE
ci: storefront hosting

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-sea-05af68a03.yml
+++ b/.github/workflows/azure-static-web-apps-mango-sea-05af68a03.yml
@@ -24,13 +24,16 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_SEA_05AF68A03 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
-          action: "upload"
+          action: 'upload'
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "/" # App source code path
-          api_location: "" # Api source code path - optional
-          output_location: "" # Built app content directory - optional
+          app_location: '/storefront' # App source code path
+          api_location: '' # Api source code path - optional
+          output_location: '' # Built app content directory - optional
+          app_build_command: 'npm run building'
           ###### End of Repository/Build Configurations ######
+        env:
+          NPM_CONFIG_LEGACY_PEER_DEPS: true
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
@@ -42,4 +45,4 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_SEA_05AF68A03 }}
-          action: "close"
+          action: 'close'

--- a/.github/workflows/azure-static-web-apps-mango-sea-05af68a03.yml
+++ b/.github/workflows/azure-static-web-apps-mango-sea-05af68a03.yml
@@ -29,7 +29,7 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: '/storefront' # App source code path
           api_location: '' # Api source code path - optional
-          output_location: '.next' # Built app content directory - optional
+          output_location: '' # Built app content directory - optional
           app_build_command: 'npm run building'
           ###### End of Repository/Build Configurations ######
         env:

--- a/.github/workflows/azure-static-web-apps-mango-sea-05af68a03.yml
+++ b/.github/workflows/azure-static-web-apps-mango-sea-05af68a03.yml
@@ -30,7 +30,6 @@ jobs:
           app_location: '/storefront' # App source code path
           api_location: '' # Api source code path - optional
           output_location: '' # Built app content directory - optional
-          app_build_command: 'npm run building'
           ###### End of Repository/Build Configurations ######
         env:
           NPM_CONFIG_LEGACY_PEER_DEPS: true

--- a/.github/workflows/azure-static-web-apps-mango-sea-05af68a03.yml
+++ b/.github/workflows/azure-static-web-apps-mango-sea-05af68a03.yml
@@ -29,7 +29,7 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: '/storefront' # App source code path
           api_location: '' # Api source code path - optional
-          output_location: '' # Built app content directory - optional
+          output_location: '.next' # Built app content directory - optional
           app_build_command: 'npm run building'
           ###### End of Repository/Build Configurations ######
         env:

--- a/.github/workflows/azure-static-web-apps-mango-sea-05af68a03.yml
+++ b/.github/workflows/azure-static-web-apps-mango-sea-05af68a03.yml
@@ -1,0 +1,45 @@
+name: Azure Static Web Apps CI/CD
+
+on:
+  push:
+    branches:
+      - chore/storefront-hosting
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - chore/storefront-hosting
+
+jobs:
+  build_and_deploy_job:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    runs-on: ubuntu-latest
+    name: Build and Deploy Job
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Build And Deploy
+        id: builddeploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_SEA_05AF68A03 }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          action: "upload"
+          ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
+          # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
+          app_location: "/" # App source code path
+          api_location: "" # Api source code path - optional
+          output_location: "" # Built app content directory - optional
+          ###### End of Repository/Build Configurations ######
+
+  close_pull_request_job:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        id: closepullrequest
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_SEA_05AF68A03 }}
+          action: "close"

--- a/storefront/next.config.mjs
+++ b/storefront/next.config.mjs
@@ -21,7 +21,6 @@ export default {
 
     return config;
   },
-  output: "standalone",
   reactStrictMode: true,
   pageExtensions: ['mdx', 'tsx', 'ts'],
   eslint: {

--- a/storefront/next.config.mjs
+++ b/storefront/next.config.mjs
@@ -21,8 +21,9 @@ export default {
 
     return config;
   },
+  output: "standalone",
   reactStrictMode: true,
-  pageExtensions: ['js', 'jsx', 'md', 'mdx', 'tsx', 'ts'],
+  pageExtensions: ['mdx', 'tsx', 'ts'],
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/storefront/package.json
+++ b/storefront/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && rm -rf ./.next/cache",
     "start": "next start",
     "lint": "next lint"
   },

--- a/storefront/package.json
+++ b/storefront/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "building": "next build",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
Have connected this repo with azure so it will now try to deploy to azure when somthing is pushed into this branch. Need to configure the workflow file to not throw the errors shown below.

It will deploy to the following URL if the deploy is successfull: https://mango-sea-05af68a03.3.azurestaticapps.net

Issues:
*  Azure uses `nmp install` to install dependencies for the repo on their end. This does not work currently with this repo and throws this error: https://github.com/digdir/designsystem/actions/runs/4893186874/jobs/8735852716

* Setting ` env: NPM_CONFIG_LEGACY_PEER_DEPS: true`  in the workflow file fixes the error above, but a new error happens at the end of the deployment: https://github.com/digdir/designsystem/actions/runs/4892802867/jobs/8734990490