### PR TITLE
style: changed focus style tokens

### DIFF
--- a/design-tokens/$themes.json
+++ b/design-tokens/$themes.json
@@ -193,7 +193,6 @@
       "semantic.border.success.default": "S:d42bc7bbcff1aa4a0ed05bafad450b3b937f062d,",
       "semantic.border.warning.default": "S:184f244593a781b9b80ee0c018a00fbd9844ac30,",
       "semantic.border.danger.default": "S:af4cecc3564bb13c1f1b27ed9214420fd45c9a7c,",
-      "semantic.border.tab-focus.default": "S:35a815edf0e45139df01ea7c4caabd7020d889d1,",
       "semantic.border.primary.default": "S:babf87cf996c769566406133cbacf5e99e1e31ce,",
       "semantic.border.primary.hover": "S:6d6e7ed2f16ebb63da60c5a66ea260d5d98edc26,",
       "semantic.border.primary.active": "S:55c444d5d3fca8d8f8ab6188ddce633401e2865a,",
@@ -265,7 +264,8 @@
       "typography.detail.medium": "S:fb988c084a81e5b2ea93fd72599431052c5f2d75,",
       "typography.interactive.large": "S:efaba827bd73dfebc088bf78c027461b78284186,",
       "typography.interactive.medium": "S:7e6c6654a48cb79121f57e4d4357a21249b14846,",
-      "typography.interactive.small": "S:c8dfd777051d57443937819c1560b31c0843c39b,"
+      "typography.interactive.small": "S:c8dfd777051d57443937819c1560b31c0843c39b,",
+      "semantic.border.tab-focus.outline": "S:35a815edf0e45139df01ea7c4caabd7020d889d1,"
     }
   },
   {

--- a/design-tokens/Base/Semantic.json
+++ b/design-tokens/Base/Semantic.json
@@ -311,8 +311,12 @@
         }
       },
       "tab-focus": {
-        "default": {
-          "value": "{colors.purple.600}",
+        "outline": {
+          "value": "{colors.yellow.500}",
+          "type": "color"
+        },
+        "boxshadow": {
+          "value": "{semantic.border.neutral.strong}",
           "type": "color"
         }
       },

--- a/design-tokens/Base/Semantic.json
+++ b/design-tokens/Base/Semantic.json
@@ -310,7 +310,7 @@
           "type": "color"
         }
       },
-      "tab-focus": {
+      "focus": {
         "outline": {
           "value": "{colors.yellow.500}",
           "type": "color"
@@ -738,14 +738,6 @@
     "disabled": {
       "value": "30%",
       "type": "opacity"
-    }
-  },
-  "tab_focus": {
-    "outline": {
-      "offset": {
-        "value": "2px",
-        "type": "spacing"
-      }
     }
   },
   "border_radius": {


### PR DESCRIPTION
- Changed focus-token from purple to yellow (outline)
- Added box-shadow-color 
- Deleted old tab-focus spacing token
- Changed name from "tab-focus" to "focus" since this will be visible as standard focus, not only when using a keyboard to navigate. 

![image](https://user-images.githubusercontent.com/1464915/236791997-1e32cf5c-3fef-4b48-acd5-8722bf827049.png)

Related to https://github.com/digdir/designsystem/issues/269
