### PR TITLE
fix(FieldSet): Fixing typo in font size

### DIFF
--- a/packages/react/src/components/FieldSet/FieldSet.module.css
+++ b/packages/react/src/components/FieldSet/FieldSet.module.css
@@ -20,7 +20,7 @@
   --description-margin_top: var(--component-field_description-space-top-small);
   --error_message-margin_top: var(--component-fieldset-space-gap-y-small);
   --help_text-gap: var(--component-field_description-space-top-small);
-  --font_size: var(--component-checkbox-font_size-xs);
+  --font_size: var(--component-checkbox-font_size-sm);
 }
 
 .xsmall {


### PR DESCRIPTION
This mistakenly overwrote every usage of FieldSet that either set size to small or set not size at all

See quickfix in app-frontend-react:
- https://github.com/Altinn/app-frontend-react/pull/1145