### PR TITLE
chore: :bug: Fixed token transformation for global hack

### DIFF
--- a/packages/tokens/build.ts
+++ b/packages/tokens/build.ts
@@ -126,6 +126,17 @@ const getStyleDictionaryConfig = (
     ],
     source: [`${tokensPath}/Base/Core.json`],
     platforms: {
+      hack: {
+        prefix,
+        basePxFontSize,
+        transforms: ['ts/resolveMath', 'name/cti/hierarchical-kebab'],
+        files: [
+          {
+            format: 'global-values-hack',
+            destination: 'ignore/hack',
+          },
+        ],
+      },
       css: {
         prefix,
         basePxFontSize,
@@ -139,10 +150,6 @@ const getStyleDictionaryConfig = (
           'ts/shadow/css/shorthand',
         ],
         files: [
-          {
-            format: 'global-values-hack',
-            destination: 'ignore/hack',
-          },
           {
             destination: `${destinationPath}/tokens.css`,
             format: 'css/variables',


### PR DESCRIPTION
Found a bug where the first "brand" that was processed didn't have the correct font scale available due to transformation and order of files being decided by style dictionary due to token references