### PR TITLE
build: added vercel config for storybook branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
   "git": {
     "deploymentEnabled": {
-      "github-pages-deployment": false
+      "github-pages-deployment": false,
+      "silent": true
     }
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,10 @@
 {
   "git": {
     "deploymentEnabled": {
-      "github-pages-deployment": false,
-      "silent": true
+      "github-pages-deployment": false
     }
+  },
+  "github": {
+    "silent": true
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "github-pages-deployment": false
+    }
+  }
+}


### PR DESCRIPTION
Added Vercel config that disable vercel auto-deployment for the `github-pages-deployment` branch used for storybook.
There is also an option to disable Vercel from commenting on PRs. Seems like the bot is also commenting on ignored deployments... I turned off Vercel bot comments by setting silent to true. Those comments might be nice if you are working on a repo that only contains a Next.js application. But for a monorepo this just becomes an annoyance (?).

Documentation: https://vercel.com/docs/concepts/projects/project-configuration/git-configuration