### PR TITLE
chore: :lipstick: Synchronize viewports between Figma and Storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,6 +3,29 @@ import '@altinn/figma-design-tokens/dist/tokens.css';
 import '@digdir/design-system-tokens/dist/digdir/tokens.css';
 import './inter.css';
 import customTheme from './customTheme';
+import metadata from '../design-tokens/$metadata.json';
+
+type Viewport = {
+  name: string;
+  styles: {
+    width: string;
+    height: string;
+  };
+};
+
+const viewports: Viewport[] = metadata.tokenSetOrder
+  .filter((name) => name.toLowerCase().includes('viewport'))
+  .map((name) => {
+    const width = name.replace(/\D/g, '');
+
+    return {
+      name: `@${width}`,
+      styles: {
+        width: `${width}px`,
+        height: '100%',
+      },
+    };
+  });
 
 const preview: Preview = {
   parameters: {
@@ -36,6 +59,9 @@ const preview: Preview = {
       storySort: {
         order: ['Komponentoversikt', 'Kjernekomponenter'],
       },
+    },
+    viewport: {
+      viewports,
     },
   },
 };


### PR DESCRIPTION
Added support for using the same viewports defined in Figma to be used in Storybook. This is done by reading the `$metadata.json` file from figma token studio and using sets containing "viewport" as width is defined in the name :)