### PR TITLE
refactor: Improve Accordion component & stories

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,4 +2,7 @@
   html {
     font-family: 'Inter', sans-serif;
   }
+  .sbdocs-wrapper {
+    padding-bottom: 10rem !important;
+  }
 </style>

--- a/docs-components/BetaBlock/BetaBlock.module.css
+++ b/docs-components/BetaBlock/BetaBlock.module.css
@@ -13,6 +13,6 @@
   font: var(--fds-typography-heading-xxsmall) !important;
 }
 
-.desc  {
+.desc > * p  {
   font: var(--fds-typography-paragraph-short-small) !important;
 }

--- a/docs-components/BetaBlock/BetaBlock.tsx
+++ b/docs-components/BetaBlock/BetaBlock.tsx
@@ -1,26 +1,13 @@
 import React from 'react';
-import { Information } from '@navikt/ds-icons';
 
 import classes from './BetaBlock.module.css';
 
-export function BetaBlock() {
-  return (
-    <div
-      className={classes.box}
-      id='beta-tag'
-    >
-      <div className={classes.iconContainer}>
-        <Information fontSize={24} />
-      </div>
-      <div>
-        <div className={classes.title}>Beta</div>
-        <div className={classes.desc}>
-          Komponenten er under utvikling. Dette kan medføre breaking-changes i
-          patch/minor versjon av kodepakker.
-        </div>
-      </div>
+export const BetaBlock = () => (
+  <div className={classes.container}>
+    <div className={classes.title}>Beta</div>
+    <div className={classes.desc}>
+      Komponenten er under utvikling. Dette kan medføre breaking-changes i
+      patch/minor versjon av kodepakker.
     </div>
-  );
-}
-
-BetaBlock.displayName = 'BetaBlock';
+  </div>
+);

--- a/docs-components/TokenBlock/TokenBlock.module.css
+++ b/docs-components/TokenBlock/TokenBlock.module.css
@@ -8,6 +8,6 @@
   margin-bottom: 2rem !important;
 }
 
-p {
+.desc > * p {
   font: var(--fds-typography-paragraph-short-small) !important;
 }

--- a/docs-components/TokenBlock/TokenBlock.module.css
+++ b/docs-components/TokenBlock/TokenBlock.module.css
@@ -1,18 +1,13 @@
 .container {
-  background-color: #f1ecff;
-  border-left: 8px solid #6544c5;
-  padding: 1.5rem;
+  background-color: var(--fds-semantic-surface-warning-subtle);
+  border-left: 8px solid var(--fds-semantic-border-warning-default);
+  padding: 1rem;
   display: flex;
   flex-direction: column;
   width: auto;
   margin-bottom: 2rem !important;
-
 }
 
-.title {
-  font: var(--fds-typography-heading-xxsmall) !important;
-}
-
-.desc  {
+p {
   font: var(--fds-typography-paragraph-short-small) !important;
 }

--- a/docs-components/TokenBlock/TokenBlock.tsx
+++ b/docs-components/TokenBlock/TokenBlock.tsx
@@ -8,7 +8,7 @@ export const TokenBlock = () => (
     <div className={classes.desc}>
       <Markdown>
         {
-          ' Husk å importer ny tokens pakke **`@digdir/design-system-tokens/<brand>/tokens.css`** før du tar i bruk denne komponenten.\n\n Importer tokens i henhold til ditt brand; `altinn`, `digdir` eller `tilsynet`.'
+          ' Husk å importere ny tokens-pakke **`@digdir/design-system-tokens/<brand>/tokens.css`** før du tar i bruk denne komponenten.\n\n Importer tokens i henhold til ditt brand; `altinn`, `digdir` eller `tilsynet`.'
         }
       </Markdown>
     </div>

--- a/docs-components/TokenBlock/TokenBlock.tsx
+++ b/docs-components/TokenBlock/TokenBlock.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Markdown } from '@storybook/blocks';
+
+import classes from './TokenBlock.module.css';
+
+export const TokenBlock = () => (
+  <div className={classes.container}>
+    <div className={classes.desc}>
+      <Markdown>
+        {
+          ' Husk å importer ny tokens pakke **`@digdir/design-system-tokens/<brand>/tokens.css`** før du tar i bruk denne komponenten.\n\n Importer tokens i henhold til ditt brand; `altinn`, `digdir` eller `tilsynet`.'
+        }
+      </Markdown>
+    </div>
+  </div>
+);

--- a/docs-components/index.ts
+++ b/docs-components/index.ts
@@ -9,3 +9,4 @@ export {
 export { Changelog } from './Changelog/Changelog';
 export { ComponentOverview } from './ComponentOverview/component-overview';
 export { Stack } from './Stack/Stack';
+export * from './TokenBlock/TokenBlock.tsx';

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -38,12 +38,8 @@ import { Accordion } from '@digdir/design-system-react';
 
 ### Kontrollert
 
-<Canvas>
-  <Story of={AccordionStories.Controlled} />
-</Canvas>
+<Canvas of={AccordionStories.Controlled} />
 
 ### Ikke kontrollert
 
-<Canvas>
-  <Story of={AccordionStories.Uncontrolled} />
-</Canvas>
+<Canvas of={AccordionStories.Uncontrolled} />

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -1,6 +1,14 @@
-import { Meta, Canvas, Story, Controls, Primary } from '@storybook/blocks';
+import {
+  Meta,
+  Canvas,
+  Story,
+  Controls,
+  Primary,
+  ArgTypes,
+} from '@storybook/blocks';
 import { BetaBlock, TokenBlock } from '../../../../../docs-components';
 import * as AccordionStories from './Accordion.stories';
+import { Accordion } from '.';
 
 <Meta of={AccordionStories} />
 
@@ -16,6 +24,18 @@ Accordion brukes ofte for å redusere behovet for å skrolle ned når man presen
 
 <Primary />
 <Controls />
+
+### Accordion.Item
+
+<ArgTypes of={Accordion.Item} />
+
+### Accordion.Header
+
+<ArgTypes of={Accordion.Header} />
+
+### Accordion.Content
+
+<ArgTypes of={Accordion.Content} />
 
 ## Bruk
 

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -42,7 +42,7 @@ Accordion brukes ofte for å redusere behovet for å skrolle ned når man presen
 <TokenBlock />
 
 ```tsx
-import '@digdir/design-system-tokens/dist/altinn/tokens.css'; // Importeres kun en gang i appen din.
+import '@digdir/design-system-tokens/brand/altinn/tokens.css'; // Importeres kun en gang i appen din.
 import { Accordion } from '@digdir/design-system-react';
 
 <Accordion>

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -12,6 +12,11 @@ Accordion er en vertikalt stablet gruppe interaktive overskrifter som hver inneh
 en seksjon av innholdet. Overskriftene fungerer som kontroller som lar brukere vise eller skjule de tilknyttede seksjonene med innhold.
 Accordion brukes ofte for å redusere behovet for å skrolle ned når man presenterer flere seksjoner med innhold på en enkelt side.
 
+## Props
+
+<Primary />
+<Controls />
+
 ## Bruk
 
 ```tsx
@@ -20,26 +25,17 @@ import { Accordion } from '@digdir/design-system-react';
 <Accordion>
   <Accordion.Item>
     <Accordion.Header>Accordion header text</Accordion.Header>
-    <Content />
+    <Accordion.Content>Accordion content</Accordion.Content>
   </Accordion.Item>
   <Accordion.Item>
     <Accordion.Header>Accordion header text</Accordion.Header>
-    <Content />
+    <Accordion.Content>Accordion content</Accordion.Content>
   </Accordion.Item>
 </Accordion>;
 ```
-
-## Props
-
-<Primary />
-<Controls />
 
 ## Varianter
 
 ### Kontrollert
 
 <Canvas of={AccordionStories.Controlled} />
-
-### Ikke kontrollert
-
-<Canvas of={AccordionStories.Uncontrolled} />

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -1,5 +1,5 @@
 import { Meta, Canvas, Story, Controls, Primary } from '@storybook/blocks';
-import { BetaBlock } from '../../../../../docs-components';
+import { BetaBlock, TokenBlock } from '../../../../../docs-components';
 import * as AccordionStories from './Accordion.stories';
 
 <Meta of={AccordionStories} />
@@ -19,7 +19,10 @@ Accordion brukes ofte for å redusere behovet for å skrolle ned når man presen
 
 ## Bruk
 
+<TokenBlock />
+
 ```tsx
+import '@digdir/design-system-tokens/dist/altinn/tokens.css'; // Importeres kun en gang i appen din.
 import { Accordion } from '@digdir/design-system-react';
 
 <Accordion>

--- a/packages/react/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react/src/components/Accordion/Accordion.stories.tsx
@@ -47,7 +47,11 @@ export const Preview: StoryFn<typeof Accordion> = (args) => (
   </Accordion>
 );
 
-Preview.args = { border: false };
+// Default values are selected in Controls
+Preview.args = {
+  border: false,
+  color: 'neutral',
+};
 
 export const Controlled: StoryFn<typeof Accordion> = () => {
   const [open, setOpen] = useState(false);

--- a/packages/react/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react/src/components/Accordion/Accordion.stories.tsx
@@ -15,33 +15,23 @@ export default {
   },
 } as Meta;
 
-const Content = () => (
-  <Accordion.Content>
-    Magna aliquip aliquip fugiat nostrud nostrud velit pariatur veniam officia
-    laboris voluptate officia pariatur. <a href='#Lorem'>Lorem est</a> ex anim
-    velit occaecat nisi qui nostrud sit consectetur consectetur officia nostrud
-    ullamco.
-  </Accordion.Content>
-);
-
 export const Preview: StoryFn<typeof Accordion> = (args) => (
   <Accordion {...args}>
     <Accordion.Item>
-      <Accordion.Header>Accordion header text</Accordion.Header>
+      <Accordion.Header level={3}>Hva er Lorem Ipsum?</Accordion.Header>
       <Accordion.Content>
-        Magna aliquip aliquip fugiat nostrud nostrud velit pariatur veniam
-        officia laboris voluptate officia pariatur.
-        <a href='#Lorem'>Lorem est</a> ex anim velit occaecat nisi qui nostrud
-        sit consectetur consectetur officia nostrud ullamco.
+        Lorem Ipsum er rett og slett dummytekst fra og for trykkeindustrien.
+        Lorem Ipsum har vært bransjens standard for dummytekst helt siden
+        1500-tallet, da en ukjent boktrykker stokket en mengde bokstaver for å
+        lage et prøveeksemplar av en bok.
       </Accordion.Content>
     </Accordion.Item>
     <Accordion.Item>
-      <Accordion.Header>Accordion header text</Accordion.Header>
+      <Accordion.Header level={3}>Hvor kommer det fra?</Accordion.Header>
       <Accordion.Content>
-        Magna aliquip aliquip fugiat nostrud nostrud velit pariatur veniam
-        officia laboris voluptate officia pariatur.{' '}
-        <a href='#Lorem'>Lorem est</a> ex anim velit occaecat nisi qui nostrud
-        sit consectetur consectetur officia nostrud ullamco.
+        I motsetning til hva mange tror, er ikke Lorem Ipsum bare tilfeldig
+        tekst. Dets røtter springer helt tilbake til et stykke klassisk latinsk
+        litteratur fra 45 år f.kr., hvilket gjør det over 2000 år gammelt.
       </Accordion.Content>
     </Accordion.Item>
   </Accordion>
@@ -61,22 +51,16 @@ export const Controlled: StoryFn<typeof Accordion> = () => {
     <div>
       <Accordion>
         <Accordion.Item open={open}>
-          <Accordion.Header
-            onHeaderClick={() => setOpen(!open)}
-            level={3}
-          >
+          <Accordion.Header onHeaderClick={() => setOpen(!open)}>
             Accordion header text
           </Accordion.Header>
-          <Content />
+          <Accordion.Content>Accordion content</Accordion.Content>
         </Accordion.Item>
         <Accordion.Item open={open2}>
-          <Accordion.Header
-            onHeaderClick={() => setOpen2(!open2)}
-            level={3}
-          >
+          <Accordion.Header onHeaderClick={() => setOpen2(!open2)}>
             Accordion header text
           </Accordion.Header>
-          <Content />
+          <Accordion.Content>Accordion content</Accordion.Content>
         </Accordion.Item>
       </Accordion>
     </div>
@@ -86,12 +70,12 @@ export const Controlled: StoryFn<typeof Accordion> = () => {
 export const Uncontrolled: StoryFn<typeof Accordion> = (args) => (
   <Accordion {...args}>
     <Accordion.Item>
-      <Accordion.Header>Accordion header text</Accordion.Header>
-      <Content />
+      <Accordion.Header>Accordion header tex</Accordion.Header>
+      <Accordion.Content>Accordion content</Accordion.Content>
     </Accordion.Item>
     <Accordion.Item>
-      <Accordion.Header>Accordion header text</Accordion.Header>
-      <Content />
+      <Accordion.Header>Accordion header </Accordion.Header>
+      <Accordion.Content>Accordion content</Accordion.Content>
     </Accordion.Item>
   </Accordion>
 );

--- a/packages/react/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react/src/components/Accordion/Accordion.stories.tsx
@@ -1,27 +1,17 @@
 import React, { useState } from 'react';
-import type { Meta, StoryFn, StoryObj } from '@storybook/react';
-
-import AccordionContent from './AccordionContent';
-import AccordionHeader from './AccordionHeader';
-import AccordionItem from './AccordionItem';
+import type { Meta, StoryFn } from '@storybook/react';
 
 import { Accordion } from '.';
-
-type Story = StoryObj<typeof Accordion>;
 
 export default {
   title: 'Kjernekomponenter/Accordion',
   component: Accordion,
-  subcomponents: {
-    AccordionItem,
-    AccordionContent,
-    AccordionHeader,
-  },
   parameters: {
     status: {
       type: 'beta',
       url: 'http://www.url.com/status',
     },
+    layout: 'padded',
   },
 } as Meta;
 
@@ -34,40 +24,37 @@ const Content = () => (
   </Accordion.Content>
 );
 
-export const props: Story = {
-  args: {
-    children: (
-      <>
-        <Accordion.Item>
-          <Accordion.Header>Accordion header text</Accordion.Header>
-          <Accordion.Content>
-            Magna aliquip aliquip fugiat nostrud nostrud velit pariatur veniam
-            officia laboris voluptate officia pariatur.
-            <a href='#Lorem'>Lorem est</a> ex anim velit occaecat nisi qui
-            nostrud sit consectetur consectetur officia nostrud ullamco.
-          </Accordion.Content>
-        </Accordion.Item>
-        <Accordion.Item>
-          <Accordion.Header>Accordion header text</Accordion.Header>
-          <Accordion.Content>
-            Magna aliquip aliquip fugiat nostrud nostrud velit pariatur veniam
-            officia laboris voluptate officia pariatur.{' '}
-            <a href='#Lorem'>Lorem est</a> ex anim velit occaecat nisi qui
-            nostrud sit consectetur consectetur officia nostrud ullamco.
-          </Accordion.Content>
-        </Accordion.Item>
-      </>
-    ),
-    style: { width: '300px' },
-  },
-};
+export const Preview: StoryFn<typeof Accordion> = (args) => (
+  <Accordion {...args}>
+    <Accordion.Item>
+      <Accordion.Header>Accordion header text</Accordion.Header>
+      <Accordion.Content>
+        Magna aliquip aliquip fugiat nostrud nostrud velit pariatur veniam
+        officia laboris voluptate officia pariatur.
+        <a href='#Lorem'>Lorem est</a> ex anim velit occaecat nisi qui nostrud
+        sit consectetur consectetur officia nostrud ullamco.
+      </Accordion.Content>
+    </Accordion.Item>
+    <Accordion.Item>
+      <Accordion.Header>Accordion header text</Accordion.Header>
+      <Accordion.Content>
+        Magna aliquip aliquip fugiat nostrud nostrud velit pariatur veniam
+        officia laboris voluptate officia pariatur.{' '}
+        <a href='#Lorem'>Lorem est</a> ex anim velit occaecat nisi qui nostrud
+        sit consectetur consectetur officia nostrud ullamco.
+      </Accordion.Content>
+    </Accordion.Item>
+  </Accordion>
+);
 
-export const Controlled: StoryFn = () => {
+Preview.args = { border: false };
+
+export const Controlled: StoryFn<typeof Accordion> = () => {
   const [open, setOpen] = useState(false);
   const [open2, setOpen2] = useState(false);
 
   return (
-    <div style={{ width: 300 }}>
+    <div>
       <Accordion>
         <Accordion.Item open={open}>
           <Accordion.Header
@@ -92,17 +79,15 @@ export const Controlled: StoryFn = () => {
   );
 };
 
-export const Uncontrolled: StoryFn = () => (
-  <div style={{ width: 300 }}>
-    <Accordion>
-      <Accordion.Item>
-        <Accordion.Header>Accordion header text</Accordion.Header>
-        <Content />
-      </Accordion.Item>
-      <Accordion.Item>
-        <Accordion.Header>Accordion header text</Accordion.Header>
-        <Content />
-      </Accordion.Item>
-    </Accordion>
-  </div>
+export const Uncontrolled: StoryFn<typeof Accordion> = (args) => (
+  <Accordion {...args}>
+    <Accordion.Item>
+      <Accordion.Header>Accordion header text</Accordion.Header>
+      <Content />
+    </Accordion.Item>
+    <Accordion.Item>
+      <Accordion.Header>Accordion header text</Accordion.Header>
+      <Content />
+    </Accordion.Item>
+  </Accordion>
 );

--- a/packages/react/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react/src/components/Accordion/Accordion.stories.tsx
@@ -48,34 +48,19 @@ export const Controlled: StoryFn<typeof Accordion> = () => {
   const [open2, setOpen2] = useState(false);
 
   return (
-    <div>
-      <Accordion>
-        <Accordion.Item open={open}>
-          <Accordion.Header onHeaderClick={() => setOpen(!open)}>
-            Accordion header text
-          </Accordion.Header>
-          <Accordion.Content>Accordion content</Accordion.Content>
-        </Accordion.Item>
-        <Accordion.Item open={open2}>
-          <Accordion.Header onHeaderClick={() => setOpen2(!open2)}>
-            Accordion header text
-          </Accordion.Header>
-          <Accordion.Content>Accordion content</Accordion.Content>
-        </Accordion.Item>
-      </Accordion>
-    </div>
+    <Accordion>
+      <Accordion.Item open={open}>
+        <Accordion.Header onHeaderClick={() => setOpen(!open)}>
+          Accordion header text
+        </Accordion.Header>
+        <Accordion.Content>Accordion content</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item open={open2}>
+        <Accordion.Header onHeaderClick={() => setOpen2(!open2)}>
+          Accordion header text
+        </Accordion.Header>
+        <Accordion.Content>Accordion content</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
   );
 };
-
-export const Uncontrolled: StoryFn<typeof Accordion> = (args) => (
-  <Accordion {...args}>
-    <Accordion.Item>
-      <Accordion.Header>Accordion header tex</Accordion.Header>
-      <Accordion.Content>Accordion content</Accordion.Content>
-    </Accordion.Item>
-    <Accordion.Item>
-      <Accordion.Header>Accordion header </Accordion.Header>
-      <Accordion.Content>Accordion content</Accordion.Content>
-    </Accordion.Item>
-  </Accordion>
-);

--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -9,7 +9,7 @@ export type AccordionProps = {
   color?: 'neutral' | 'subtle' | 'primary' | 'secondary' | 'tertiary';
   /** Show border */
   border?: boolean;
-  /** Instances of Accordion.Item */
+  /** Instances of `Accordion.Item` */
   children: React.ReactNode;
 } & HTMLAttributes<HTMLDivElement>;
 

--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -1,46 +1,17 @@
-import cn from 'classnames';
+import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
+import cn from 'classnames';
 
 import classes from './Accordion.module.css';
-import type { AccordionItemType } from './AccordionItem';
-import AccordionItem from './AccordionItem';
-import type { AccordionContentType } from './AccordionContent';
-import AccordionContent from './AccordionContent';
-import type { AccordionHeaderType } from './AccordionHeader';
-import AccordionHeader from './AccordionHeader';
 
-interface AccordionComponent
-  extends React.ForwardRefExoticComponent<
-    AccordionProps & React.RefAttributes<HTMLDivElement>
-  > {
-  Item: AccordionItemType;
-  Header: AccordionHeaderType;
-  Content: AccordionContentType;
-}
-
-export const accordionColor = [
-  'neutral',
-  'subtle',
-  'primary',
-  'secondary',
-  'tertiary',
-] as const;
-type AccordionColor = typeof accordionColor[number];
-
-export interface AccordionProps extends React.HTMLAttributes<HTMLDivElement> {
-  /**
-   * Accordion color
-   */
-  color?: AccordionColor;
-  /**
-   * Show border
-   */
+export type AccordionProps = {
+  /** Accordion background color */
+  color?: 'neutral' | 'subtle' | 'primary' | 'secondary' | 'tertiary';
+  /** Show border */
   border?: boolean;
-  /**
-   * Instances of Accordion.Item
-   */
+  /** Instances of Accordion.Item */
   children: React.ReactNode;
-}
+} & HTMLAttributes<HTMLDivElement>;
 
 export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
   ({ border = false, color = 'neutral', className, ...rest }, ref) => (
@@ -57,10 +28,4 @@ export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
       ref={ref}
     />
   ),
-) as AccordionComponent;
-
-Accordion.Header = AccordionHeader;
-Accordion.Content = AccordionContent;
-Accordion.Item = AccordionItem;
-
-export default Accordion;
+);

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -1,4 +1,5 @@
 import cl from 'classnames';
+import type { HTMLAttributes } from 'react';
 import React, { forwardRef, useContext } from 'react';
 
 import AnimateHeight from '../../utils/AnimateHeight';
@@ -7,47 +8,36 @@ import { Paragraph } from '../';
 import classes from './Accordion.module.css';
 import { AccordionItemContext } from './AccordionItem';
 
-export interface AccordionContentProps
-  extends React.HTMLAttributes<HTMLDivElement> {
-  /**
-   * Content inside Accordion.Content
-   */
-  children: React.ReactNode;
-}
+export type AccordionContentProps = HTMLAttributes<HTMLDivElement>;
 
-export type AccordionContentType = React.ForwardRefExoticComponent<
-  AccordionContentProps & React.RefAttributes<HTMLDivElement>
->;
+export const AccordionContent = forwardRef<
+  HTMLDivElement,
+  AccordionContentProps
+>(({ children, className, ...rest }, ref) => {
+  const context = useContext(AccordionItemContext);
 
-const AccordionContent: AccordionContentType = forwardRef(
-  ({ children, className, ...rest }, ref) => {
-    const context = useContext(AccordionItemContext);
-
-    if (context === null) {
-      console.error(
-        '<Accordion.Content> has to be used within an <Accordion.Item>',
-      );
-      return null;
-    }
-
-    return (
-      <AnimateHeight
-        id={context.contentId}
-        height={context.open ? 'auto' : 0}
-        duration={250}
-      >
-        <Paragraph
-          {...rest}
-          as='div'
-          size='small'
-          ref={ref}
-          className={cl(classes.content, className)}
-        >
-          {children}
-        </Paragraph>
-      </AnimateHeight>
+  if (context === null) {
+    console.error(
+      '<Accordion.Content> has to be used within an <Accordion.Item>',
     );
-  },
-);
+    return null;
+  }
 
-export default AccordionContent;
+  return (
+    <AnimateHeight
+      id={context.contentId}
+      height={context.open ? 'auto' : 0}
+      duration={250}
+    >
+      <Paragraph
+        {...rest}
+        as='div'
+        size='small'
+        ref={ref}
+        className={cl(classes.content, className)}
+      >
+        {children}
+      </Paragraph>
+    </AnimateHeight>
+  );
+});

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -1,4 +1,4 @@
-import cl from 'classnames';
+import cn from 'classnames';
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef, useContext } from 'react';
 
@@ -34,7 +34,7 @@ export const AccordionContent = forwardRef<
         as='div'
         size='small'
         ref={ref}
-        className={cl(classes.content, className)}
+        className={cn(classes.content, className)}
       >
         {children}
       </Paragraph>

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -8,7 +8,10 @@ import { Paragraph } from '../';
 import classes from './Accordion.module.css';
 import { AccordionItemContext } from './AccordionItem';
 
-export type AccordionContentProps = HTMLAttributes<HTMLDivElement>;
+export type AccordionContentProps = {
+  /** Content inside `Accordion.Content`*/
+  children: React.ReactNode;
+} & HTMLAttributes<HTMLDivElement>;
 
 export const AccordionContent = forwardRef<
   HTMLDivElement,

--- a/packages/react/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/react/src/components/Accordion/AccordionHeader.tsx
@@ -1,6 +1,6 @@
 import { Expand } from '@navikt/ds-icons';
 import cn from 'classnames';
-import type { MouseEventHandler } from 'react';
+import type { MouseEventHandler, HTMLAttributes } from 'react';
 import React, { forwardRef, useContext } from 'react';
 
 import { Paragraph, Heading } from '../';
@@ -8,72 +8,56 @@ import { Paragraph, Heading } from '../';
 import classes from './Accordion.module.css';
 import { AccordionItemContext } from './AccordionItem';
 
-export interface AccordionHeaderProps
-  extends React.HTMLAttributes<HTMLHeadingElement> {
-  /**
-   * Heading level
-   */
+export type AccordionHeaderProps = {
+  /** Heading level */
   level?: 1 | 2 | 3 | 4 | 5 | 6;
-  /**
-   * Text inside Accordion.Header
-   */
-  children: React.ReactNode;
-  /**
-   * Handle when clicked on header
-   */
+  /** Handle when clicked on header */
   onHeaderClick?: MouseEventHandler<HTMLButtonElement> | undefined;
-}
+} & HTMLAttributes<HTMLHeadingElement>;
 
-export type AccordionHeaderType = React.ForwardRefExoticComponent<
-  AccordionHeaderProps & React.RefAttributes<HTMLHeadingElement>
->;
+export const AccordionHeader = forwardRef<
+  HTMLHeadingElement,
+  AccordionHeaderProps
+>(({ level = 1, children, className, onHeaderClick, ...rest }, ref) => {
+  const context = useContext(AccordionItemContext);
 
-const AccordionHeader: AccordionHeaderType = forwardRef(
-  ({ level = 1, children, className, onHeaderClick, ...rest }, ref) => {
-    const context = useContext(AccordionItemContext);
-
-    if (context === null) {
-      console.error(
-        '<Accordion.Header> has to be used within an <Accordion.Item>',
-      );
-      return null;
-    }
-
-    const handleClick = (
-      e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-    ) => {
-      context.toggleOpen();
-      onHeaderClick && onHeaderClick(e);
-    };
-
-    return (
-      <Heading
-        {...rest}
-        ref={ref}
-        size='xsmall'
-        level={level}
-        className={cn(classes.header, className)}
-      >
-        <button
-          type='button'
-          onClick={handleClick}
-          aria-expanded={context.open}
-          aria-controls={context.contentId}
-        >
-          <Expand
-            aria-hidden
-            className={classes.expandIcon}
-          />
-          <Paragraph
-            as='span'
-            size='small'
-          >
-            {children}
-          </Paragraph>
-        </button>
-      </Heading>
+  if (context === null) {
+    console.error(
+      '<Accordion.Header> has to be used within an <Accordion.Item>',
     );
-  },
-);
+    return null;
+  }
 
-export default AccordionHeader;
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    context.toggleOpen();
+    onHeaderClick && onHeaderClick(e);
+  };
+
+  return (
+    <Heading
+      {...rest}
+      ref={ref}
+      size='xsmall'
+      level={level}
+      className={cn(classes.header, className)}
+    >
+      <button
+        type='button'
+        onClick={handleClick}
+        aria-expanded={context.open}
+        aria-controls={context.contentId}
+      >
+        <Expand
+          aria-hidden
+          className={classes.expandIcon}
+        />
+        <Paragraph
+          as='span'
+          size='small'
+        >
+          {children}
+        </Paragraph>
+      </button>
+    </Heading>
+  );
+});

--- a/packages/react/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/react/src/components/Accordion/AccordionHeader.tsx
@@ -13,6 +13,8 @@ export type AccordionHeaderProps = {
   level?: 1 | 2 | 3 | 4 | 5 | 6;
   /** Handle when clicked on header */
   onHeaderClick?: MouseEventHandler<HTMLButtonElement> | undefined;
+  /** Heading text */
+  children: React.ReactNode;
 } & HTMLAttributes<HTMLHeadingElement>;
 
 export const AccordionHeader = forwardRef<

--- a/packages/react/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/react/src/components/Accordion/AccordionHeader.tsx
@@ -9,7 +9,7 @@ import classes from './Accordion.module.css';
 import { AccordionItemContext } from './AccordionItem';
 
 export type AccordionHeaderProps = {
-  /** Heading level */
+  /** Heading level. Use this to make sure the heading is correct according to you page heading levels */
   level?: 1 | 2 | 3 | 4 | 5 | 6;
   /** Handle when clicked on header */
   onHeaderClick?: MouseEventHandler<HTMLButtonElement> | undefined;

--- a/packages/react/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem.tsx
@@ -1,41 +1,32 @@
 import cl from 'classnames';
+import type { HTMLAttributes } from 'react';
 import React, { createContext, forwardRef, useState, useId } from 'react';
 
 import styles from './Accordion.module.css';
 
-export interface AccordionItemProps
-  extends React.HTMLAttributes<HTMLDivElement> {
-  /**
-   * Content in Accordion.Item
-   * Should include one Accordion.Header and one Accordion.Content
-   */
+export type AccordionItemProps = {
+  /** Content should be one `<Accordion.Header>` and `<Accordion.Content>` */
   children: React.ReactNode;
   /**
-   * Controlled open-state
+   * Controls open-state.
+   *
    * Using this removes automatic control of open-state
    */
   open?: boolean;
-  /**
-   * Defaults the accordion to open if not controlled
-   * @default false
-   */
+  /**  Defaults the accordion to open if not controlled */
   defaultOpen?: boolean;
-}
+} & HTMLAttributes<HTMLDivElement>;
 
-export type AccordionItemType = React.ForwardRefExoticComponent<
-  AccordionItemProps & React.RefAttributes<HTMLDivElement>
->;
-
-export interface AccordionItemContextProps {
+export type AccordionItemContextProps = {
   open: boolean;
   toggleOpen: () => void;
   contentId: string;
-}
+};
 
 export const AccordionItemContext =
   createContext<AccordionItemContextProps | null>(null);
 
-const AccordionItem: AccordionItemType = forwardRef(
+export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
   ({ children, className, open, defaultOpen = false, ...rest }, ref) => {
     const [internalOpen, setInternalOpen] = useState<boolean>(defaultOpen);
     const contentId = useId();
@@ -65,5 +56,3 @@ const AccordionItem: AccordionItemType = forwardRef(
     );
   },
 );
-
-export default AccordionItem;

--- a/packages/react/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem.tsx
@@ -5,8 +5,6 @@ import React, { createContext, forwardRef, useState, useId } from 'react';
 import styles from './Accordion.module.css';
 
 export type AccordionItemProps = {
-  /** Content should be one `<Accordion.Header>` and `<Accordion.Content>` */
-  children: React.ReactNode;
   /**
    * Controls open-state.
    *
@@ -15,6 +13,8 @@ export type AccordionItemProps = {
   open?: boolean;
   /**  Defaults the accordion to open if not controlled */
   defaultOpen?: boolean;
+  /** Content should be one `<Accordion.Header>` and `<Accordion.Content>` */
+  children: React.ReactNode;
 } & HTMLAttributes<HTMLDivElement>;
 
 export type AccordionItemContextProps = {

--- a/packages/react/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem.tsx
@@ -1,4 +1,4 @@
-import cl from 'classnames';
+import cn from 'classnames';
 import type { HTMLAttributes } from 'react';
 import React, { createContext, forwardRef, useState, useId } from 'react';
 
@@ -33,7 +33,7 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
 
     return (
       <div
-        className={cl(styles.item, className, {
+        className={cn(styles.item, className, {
           [styles.open]: open ?? internalOpen,
         })}
         ref={ref}

--- a/packages/react/src/components/Accordion/index.ts
+++ b/packages/react/src/components/Accordion/index.ts
@@ -1,7 +1,8 @@
 import type { AccordionProps } from './Accordion';
 import { Accordion as AccordionParent } from './Accordion';
 import AccordionItem from './AccordionItem';
-import AccordionContent from './AccordionContent';
+import type { AccordionContentProps } from './AccordionContent';
+import { AccordionContent } from './AccordionContent';
 import AccordionHeader from './AccordionHeader';
 
 type AccordionComponent = typeof AccordionParent & {
@@ -16,5 +17,5 @@ Accordion.Header = AccordionHeader;
 Accordion.Content = AccordionContent;
 Accordion.Item = AccordionItem;
 
-export type { AccordionProps };
+export type { AccordionProps, AccordionContentProps };
 export { Accordion };

--- a/packages/react/src/components/Accordion/index.ts
+++ b/packages/react/src/components/Accordion/index.ts
@@ -1,1 +1,20 @@
-export { type AccordionProps, default as Accordion } from './Accordion';
+import type { AccordionProps } from './Accordion';
+import { Accordion as AccordionParent } from './Accordion';
+import AccordionItem from './AccordionItem';
+import AccordionContent from './AccordionContent';
+import AccordionHeader from './AccordionHeader';
+
+type AccordionComponent = typeof AccordionParent & {
+  Item: typeof AccordionItem;
+  Header: typeof AccordionHeader;
+  Content: typeof AccordionContent;
+};
+
+const Accordion = AccordionParent as AccordionComponent;
+
+Accordion.Header = AccordionHeader;
+Accordion.Content = AccordionContent;
+Accordion.Item = AccordionItem;
+
+export type { AccordionProps };
+export { Accordion };

--- a/packages/react/src/components/Accordion/index.ts
+++ b/packages/react/src/components/Accordion/index.ts
@@ -1,9 +1,10 @@
 import type { AccordionProps } from './Accordion';
-import { Accordion as AccordionParent } from './Accordion';
-import AccordionItem from './AccordionItem';
+import type { AccordionItemProps } from './AccordionItem';
 import type { AccordionContentProps } from './AccordionContent';
-import { AccordionContent } from './AccordionContent';
 import type { AccordionHeaderProps } from './AccordionHeader';
+import { Accordion as AccordionParent } from './Accordion';
+import { AccordionItem } from './AccordionItem';
+import { AccordionContent } from './AccordionContent';
 import { AccordionHeader } from './AccordionHeader';
 
 type AccordionComponent = typeof AccordionParent & {
@@ -18,5 +19,10 @@ Accordion.Header = AccordionHeader;
 Accordion.Content = AccordionContent;
 Accordion.Item = AccordionItem;
 
-export type { AccordionProps, AccordionContentProps, AccordionHeaderProps };
+export type {
+  AccordionProps,
+  AccordionContentProps,
+  AccordionHeaderProps,
+  AccordionItemProps,
+};
 export { Accordion };

--- a/packages/react/src/components/Accordion/index.ts
+++ b/packages/react/src/components/Accordion/index.ts
@@ -3,7 +3,8 @@ import { Accordion as AccordionParent } from './Accordion';
 import AccordionItem from './AccordionItem';
 import type { AccordionContentProps } from './AccordionContent';
 import { AccordionContent } from './AccordionContent';
-import AccordionHeader from './AccordionHeader';
+import type { AccordionHeaderProps } from './AccordionHeader';
+import { AccordionHeader } from './AccordionHeader';
 
 type AccordionComponent = typeof AccordionParent & {
   Item: typeof AccordionItem;
@@ -17,5 +18,5 @@ Accordion.Header = AccordionHeader;
 Accordion.Content = AccordionContent;
 Accordion.Item = AccordionItem;
 
-export type { AccordionProps, AccordionContentProps };
+export type { AccordionProps, AccordionContentProps, AccordionHeaderProps };
 export { Accordion };

--- a/packages/react/src/components/Typography/Typography.mdx
+++ b/packages/react/src/components/Typography/Typography.mdx
@@ -6,7 +6,7 @@ import {
   Primary,
   ArgsTable,
 } from '@storybook/blocks';
-import { BetaBlock } from '../../../../../docs-components';
+import { BetaBlock, TokenBlock } from '../../../../../docs-components';
 import * as typographyStories from './Typography.stories';
 import * as HeadingStories from './Heading/Heading.stories';
 import * as ParagraphStories from './Paragraph/Paragraph.stories';
@@ -36,6 +36,9 @@ H1 trenger ikke vere samme størrelse på alle nettsider. I en intern admin appl
 <Canvas of={HeadingStories.Preview} />
 <Controls of={HeadingStories.Preview} />
 
+## Bruk
+
+<TokenBlock />
 ## Paragraph
 
 Brukes når det trengs tekst over flere linjer. Mesteparten av teksten på et nettsted vil bruke `Paragraph`.


### PR DESCRIPTION
resolves #400 

- Some overrides for storybook styling to give more air in the bottom
- Added `TokenBlock` for reminder to use new token package
- Tweaked `BetaBlock` to match `TokenBlock` and be more in style with our upcoming alert
- Changed how compound props for `Accordion` as old way didn't work with props table and default values
- Cleaned up story and updated docs on all props