### PR TITLE
fix(Accordion): :bug: Fix `displayName` for Accordion sub-components

### DIFF
--- a/packages/react/src/components/Accordion/index.ts
+++ b/packages/react/src/components/Accordion/index.ts
@@ -19,6 +19,10 @@ Accordion.Header = AccordionHeader;
 Accordion.Content = AccordionContent;
 Accordion.Item = AccordionItem;
 
+Accordion.Header.displayName = 'Accordion.Header';
+Accordion.Content.displayName = 'Accordion.Content';
+Accordion.Item.displayName = 'Accordion.Item';
+
 export type {
   AccordionProps,
   AccordionContentProps,


### PR DESCRIPTION
This fix is so that the correct component name for sub-components are displayed when using react dev tools and "show code" in Storybook.

Normally `displayName` is derived from the const name of declared component, but since we are exposing them are sub-components (of compound component) we need to overwrite the `displayName` with the correct sub-component name. 