### PR TITLE
fix(CheckboxRadioTemplate): ensure to remove spacing/gap when label is hidden

### DIFF
--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
@@ -18,19 +18,17 @@
 .template.xsmall {
   --description-margin_top: var(--component-field_description-space-top-xsmall);
   --font_size: var(--component-checkbox-font_size-xs);
+  --gap: var(--component-checkbox-space-gap-xsmall);
 }
 
 .template.small {
   --description-margin_top: var(--component-field_description-space-top-small);
   --font_size: var(--component-checkbox-font_size-sm);
-}
-
-.template.xsmallSpacing {
-  --gap: var(--component-checkbox-space-gap-xsmall);
-}
-
-.template.smallSpacing {
   --gap: var(--component-checkbox-space-gap-small);
+}
+
+.template.hiddenLabel {
+  --gap: 0;
 }
 
 .template:not(.disabled):hover {

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.module.css
@@ -18,12 +18,18 @@
 .template.xsmall {
   --description-margin_top: var(--component-field_description-space-top-xsmall);
   --font_size: var(--component-checkbox-font_size-xs);
-  --gap: var(--component-checkbox-space-gap-xsmall);
 }
 
 .template.small {
   --description-margin_top: var(--component-field_description-space-top-small);
   --font_size: var(--component-checkbox-font_size-sm);
+}
+
+.template.xsmallSpacing {
+  --gap: var(--component-checkbox-space-gap-xsmall);
+}
+
+.template.smallSpacing {
   --gap: var(--component-checkbox-space-gap-small);
 }
 

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -59,7 +59,7 @@ export const CheckboxRadioTemplate = ({
     !presentation ||
     (typeof label !== 'object' && typeof description !== 'object');
 
-  const spacingCssMap: Record<typeof size, string> = {
+  const labelSpacingMap: Record<typeof size, string> = {
     small: classes.smallSpacing,
     xsmall: classes.xsmallSpacing,
   };
@@ -69,7 +69,7 @@ export const CheckboxRadioTemplate = ({
       className={cn(
         classes.template,
         classes[size],
-        showLabel ? spacingCssMap[size] : '',
+        showLabel ? labelSpacingMap[size] : '',
         disabled ? classes.disabled : utilityClasses.focusable,
         className,
       )}

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -59,11 +59,17 @@ export const CheckboxRadioTemplate = ({
     !presentation ||
     (typeof label !== 'object' && typeof description !== 'object');
 
+  const spacingCssMap: Record<typeof size, string> = {
+    small: classes.smallSpacing,
+    xsmall: classes.xsmallSpacing,
+  };
+
   return (
     <Wrapper
       className={cn(
         classes.template,
         classes[size],
+        showLabel ? spacingCssMap[size] : '',
         disabled ? classes.disabled : utilityClasses.focusable,
         className,
       )}

--- a/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -59,17 +59,12 @@ export const CheckboxRadioTemplate = ({
     !presentation ||
     (typeof label !== 'object' && typeof description !== 'object');
 
-  const labelSpacingMap: Record<typeof size, string> = {
-    small: classes.smallSpacing,
-    xsmall: classes.xsmallSpacing,
-  };
-
   return (
     <Wrapper
       className={cn(
         classes.template,
         classes[size],
-        showLabel ? labelSpacingMap[size] : '',
+        !showLabel && classes.hiddenLabel,
         disabled ? classes.disabled : utilityClasses.focusable,
         className,
       )}


### PR DESCRIPTION
Ensure to remove spacing/gap when the label is hidden on checkboxes and radio.

This PR resolved #384 :)