### PR TITLE
fix(Checkbox, Input): display charLimit on the right instead of left

### DIFF
--- a/packages/react/src/components/_InputWrapper/InputWrapper.module.css
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.module.css
@@ -98,6 +98,11 @@
   padding: 0;
 }
 
+.characterLimitContainer {
+  display: flex;
+  justify-content: flex-end;
+}
+
 .characterLimitLabel {
   margin-top: 4px;
 }

--- a/packages/react/src/components/_InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.tsx
@@ -109,11 +109,13 @@ export const InputWrapper = ({
         </span>
       </span>
       {characterLimit && (
-        <CharacterCounter
-          {...characterLimit}
-          value={currentInputValue}
-          ariaDescribedById={characterLimitDescriptionId}
-        />
+        <div className={classes.characterLimitContainer}>
+          <CharacterCounter
+            {...characterLimit}
+            value={currentInputValue}
+            ariaDescribedById={characterLimitDescriptionId}
+          />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
To enhance the layout, relocate the text for CharLimit from the left side to the right side of the input/textarea.