### PR TITLE
build: :heavy_plus_sign: Added `@navikt/aksel-icons` dependency to react package

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,7 @@
     "@altinn/figma-design-tokens": "^6.0.1",
     "@digdir/design-system-tokens": "^0.1.1",
     "@floating-ui/react": "0.24.1",
+    "@navikt/aksel-icons": "^3.2.4",
     "@navikt/ds-icons": "^2.3.0",
     "react-number-format": "5.2.2"
   }

--- a/packages/react/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/react/src/components/Accordion/AccordionHeader.tsx
@@ -1,4 +1,4 @@
-import { Expand } from '@navikt/ds-icons';
+import { ExpandIcon } from '@navikt/aksel-icons';
 import cn from 'classnames';
 import type { MouseEventHandler, HTMLAttributes } from 'react';
 import React, { forwardRef, useContext } from 'react';
@@ -49,7 +49,7 @@ export const AccordionHeader = forwardRef<
         aria-expanded={context.open}
         aria-controls={context.contentId}
       >
-        <Expand
+        <ExpandIcon
           aria-hidden
           className={classes.expandIcon}
         />

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Success as SuccessIcon } from '@navikt/ds-icons';
+import { CheckmarkIcon } from '@navikt/aksel-icons';
 
 import type { ButtonProps } from './Button';
 import { Button, buttonSize, buttonVariant, buttonColor } from './Button';
@@ -59,7 +59,7 @@ describe('Button', () => {
   );
 
   it('should render an icon on the left side of text when given an existing iconName and no iconPlacement', () => {
-    render({ icon: <SuccessIcon />, children: 'Button text' });
+    render({ icon: <CheckmarkIcon />, children: 'Button text' });
     const icon = screen.getByRole('img');
     expect(
       screen.getByRole('button', {
@@ -70,7 +70,7 @@ describe('Button', () => {
 
   it('should render an icon on the right side of text when given an existing iconName and iconPlacement is right', () => {
     render({
-      icon: <SuccessIcon />,
+      icon: <CheckmarkIcon />,
       iconPlacement: 'right',
       children: 'Button text',
     });

--- a/packages/react/src/components/SvgIcon/SvgIcon.test.tsx
+++ b/packages/react/src/components/SvgIcon/SvgIcon.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Success as SuccessIcon } from '@navikt/ds-icons';
+import { CheckmarkIcon } from '@navikt/aksel-icons';
 
 import { ReactComponent as MockIcon } from './success.svg';
 import { SvgIcon } from './SvgIcon';
 
 describe('SvgIcon', () => {
   it('should render an icon when given an icon in NAVs icon library', () => {
-    render(<SvgIcon svgIconComponent={<SuccessIcon />} />);
+    render(<SvgIcon svgIconComponent={<CheckmarkIcon />} />);
     expect(screen.getByRole('img')).toBeInTheDocument();
   });
   it('should render an icon when given a svg imported as a react component', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2688,6 +2688,7 @@ __metadata:
     "@altinn/figma-design-tokens": ^6.0.1
     "@digdir/design-system-tokens": ^0.1.1
     "@floating-ui/react": 0.24.1
+    "@navikt/aksel-icons": ^3.2.4
     "@navikt/ds-icons": ^2.3.0
     react-number-format: 5.2.2
   peerDependencies:
@@ -4292,6 +4293,13 @@ __metadata:
   version: 2.8.4
   resolution: "@navikt/aksel-icons@npm:2.8.4"
   checksum: f6cca11a234f5ab75e7dec3fe1c3fd477fc797c4e119f6b9459815752706bc7c9829dea8b8e9b5c52e13f1998516b584901e2e14d68493501c913cd422b47f68
+  languageName: node
+  linkType: hard
+
+"@navikt/aksel-icons@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "@navikt/aksel-icons@npm:3.2.4"
+  checksum: 7860cc2a1128cb75a93776f1b8e29b77a709d1a7af07d164c9c8f742801100250f41196e3e8a1e88d88538d18c72335093ab83df41238857528cb75709a2469f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The new aksel icon package was introduced in #393 so I updated our dependency in react package and changed usage from old to new package where they were used. 

Did not update icon for `HelpText` as there is a separate issue for that #444. Will not be able to remove the dependency for old package until this issue is resolved.