### PR TITLE
fix(Typography): :bug: Fix Typography components to inherit font-family

### DIFF
--- a/packages/react/src/components/Typography/ErrorMessage/ErrorMessage.module.css
+++ b/packages/react/src/components/Typography/ErrorMessage/ErrorMessage.module.css
@@ -1,4 +1,6 @@
 .errorMessage {
+  --fdsc-typography-font-family: inherit;
+
   margin: 0;
   color: var(--fds-semantic-text-danger-default);
 }
@@ -9,8 +11,10 @@
 
 .errorMessage.medium {
   font: var(--fds-typography-error_message-medium);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .errorMessage.small {
   font: var(--fds-typography-error_message-small);
+  font-family: var(--fdsc-typography-font-family);
 }

--- a/packages/react/src/components/Typography/Heading/Heading.module.css
+++ b/packages/react/src/components/Typography/Heading/Heading.module.css
@@ -1,4 +1,6 @@
 .heading {
+  --fdsc-typography-font-family: inherit;
+
   margin: 0;
 }
 
@@ -8,24 +10,30 @@
 
 .heading.xlarge {
   font: var(--fds-typography-heading-xlarge);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .heading.large {
   font: var(--fds-typography-heading-large);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .heading.medium {
   font: var(--fds-typography-heading-medium);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .heading.small {
   font: var(--fds-typography-heading-small);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .heading.xsmall {
   font: var(--fds-typography-heading-xsmall);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .heading.xxsmall {
   font: var(--fds-typography-heading-xxsmall);
+  font-family: var(--fdsc-typography-font-family);
 }

--- a/packages/react/src/components/Typography/Ingress/Ingress.module.css
+++ b/packages/react/src/components/Typography/Ingress/Ingress.module.css
@@ -1,4 +1,6 @@
 .ingress {
+  --fdsc-typography-font-family: inherit;
+
   margin: 0;
 }
 
@@ -8,8 +10,10 @@
 
 .ingress.medium {
   font: var(--fds-typography-ingress-medium);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .ingress.large {
   font: var(--fds-typography-ingress-large);
+  font-family: var(--fdsc-typography-font-family);
 }

--- a/packages/react/src/components/Typography/Label/Label.module.css
+++ b/packages/react/src/components/Typography/Label/Label.module.css
@@ -1,4 +1,6 @@
 .label {
+  --fdsc-typography-font-family: inherit;
+
   display: inline-block;
   margin: 0;
 }
@@ -9,16 +11,20 @@
 
 .label.large {
   font: var(--fds-typography-label-large);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .label.medium {
   font: var(--fds-typography-label-medium);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .label.small {
   font: var(--fds-typography-label-small);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .label.xsmall {
   font: var(--fds-typography-label-xsmall);
+  font-family: var(--fdsc-typography-font-family);
 }

--- a/packages/react/src/components/Typography/Paragraph/Paragraph.module.css
+++ b/packages/react/src/components/Typography/Paragraph/Paragraph.module.css
@@ -1,4 +1,6 @@
 .paragraph {
+  --fdsc-typography-font-family: inherit;
+
   margin: 0;
 }
 
@@ -8,32 +10,40 @@
 
 .paragraph.large {
   font: var(--fds-typography-paragraph-large);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .paragraph.large.short {
   font: var(--fds-typography-paragraph-short-large);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .paragraph.medium {
   font: var(--fds-typography-paragraph-medium);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .paragraph.medium.short {
   font: var(--fds-typography-paragraph-short-medium);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .paragraph.small {
   font: var(--fds-typography-paragraph-small);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .paragraph.small.short {
   font: var(--fds-typography-paragraph-short-small);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .paragraph.xsmall {
   font: var(--fds-typography-paragraph-xsmall);
+  font-family: var(--fdsc-typography-font-family);
 }
 
 .paragraph.xsmall.short {
   font: var(--fds-typography-paragraph-short-xsmall);
+  font-family: var(--fdsc-typography-font-family);
 }


### PR DESCRIPTION
resolves #431

We decided to not force font-family to `Inter` for our users in #345

This is just a temporary solution to inherit font-family as `font` css shorthand needs to have a font-family defined (and not inherit). 

Will make a better solution for this in tokens transformer at a later point