### PR TITLE
fix(Table): Remove padding in header cells

### DIFF
--- a/packages/react/src/components/Table/TableCell.module.css
+++ b/packages/react/src/components/Table/TableCell.module.css
@@ -1,7 +1,6 @@
 .headerTableCell {
   background: #f5f5f5;
   margin: 20px 0;
-  padding: 8px;
   text-align: left;
   user-select: none;
 }

--- a/packages/react/src/components/Table/TableCell.tsx
+++ b/packages/react/src/components/Table/TableCell.tsx
@@ -69,11 +69,9 @@ export function TableCell({
           }
         >
           <div
-            className={
-              sortDirection != 'notSortable'
-                ? classes.containerSortable
-                : classes.container
-            }
+            className={cn(
+              sortDirection != 'notSortable' && classes.containerSortable,
+            )}
             onClick={() => handleChange()}
             onKeyUp={(event) => {
               if (event.key === 'Enter' || event.key === ' ') {

--- a/packages/react/src/components/Table/TableHeader.module.css
+++ b/packages/react/src/components/Table/TableHeader.module.css
@@ -1,4 +1,4 @@
-.table-header {
+.tableHeader {
   align-self: stretch;
   background: #f5f5f5;
   flex-grow: 0;


### PR DESCRIPTION
Removed padding in header cells to make the content aligned with the content of normal cells. Fixes #388.

Did also remove a reference to an nonexistent CSS class.