### PR TITLE
refactor(InputWrapper): use the ErrorMessage and Paragraph

### DIFF
--- a/packages/react/src/components/_InputWrapper/InputWrapper.module.css
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.module.css
@@ -89,7 +89,3 @@
   display: inline-block;
   margin-top: 4px;
 }
-
-.characterLimitExceeded {
-  color: var(--fds-semantic-text-danger-default);
-}

--- a/packages/react/src/components/_InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.tsx
@@ -202,18 +202,13 @@ const CharacterCounter = ({
       >
         {srLabel}
       </span>
-      {hasExceededLimit ? (
-        <ErrorMessage
-          className={classes.characterLimitLabel}
-          aria-live='polite'
-        >
-          {label(currentCount)}
-        </ErrorMessage>
-      ) : (
-        <Paragraph className={classes.characterLimitLabel}>
-          {label(currentCount)}
-        </Paragraph>
-      )}
+      <div className={classes.characterLimitLabel}>
+        {hasExceededLimit ? (
+          <ErrorMessage aria-live='polite'>{label(currentCount)}</ErrorMessage>
+        ) : (
+          <Paragraph>{label(currentCount)}</Paragraph>
+        )}
+      </div>
     </>
   );
 };

--- a/packages/react/src/components/_InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.tsx
@@ -202,7 +202,7 @@ const CharacterCounter = ({
       >
         {srLabel}
       </span>
-      <div className={classes.characterLimitLabel}>
+      <span className={classes.characterLimitLabel}>
         {hasExceededLimit ? (
           <ErrorMessage
             as='span'
@@ -213,7 +213,7 @@ const CharacterCounter = ({
         ) : (
           <Paragraph as='span'>{label(currentCount)}</Paragraph>
         )}
-      </div>
+      </span>
     </>
   );
 };

--- a/packages/react/src/components/_InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.tsx
@@ -204,9 +204,14 @@ const CharacterCounter = ({
       </span>
       <div className={classes.characterLimitLabel}>
         {hasExceededLimit ? (
-          <ErrorMessage aria-live='polite'>{label(currentCount)}</ErrorMessage>
+          <ErrorMessage
+            as='span'
+            aria-live='polite'
+          >
+            {label(currentCount)}
+          </ErrorMessage>
         ) : (
-          <Paragraph>{label(currentCount)}</Paragraph>
+          <Paragraph as='span'>{label(currentCount)}</Paragraph>
         )}
       </div>
     </>

--- a/packages/react/src/components/_InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.tsx
@@ -207,11 +207,17 @@ const CharacterCounter = ({
           <ErrorMessage
             as='span'
             aria-live='polite'
+            size='small'
           >
             {label(currentCount)}
           </ErrorMessage>
         ) : (
-          <Paragraph as='span'>{label(currentCount)}</Paragraph>
+          <Paragraph
+            as='span'
+            size='small'
+          >
+            {label(currentCount)}
+          </Paragraph>
         )}
       </span>
     </>

--- a/packages/react/src/components/_InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import cn from 'classnames';
 
 import utilityClasses from '../../utils/utility.module.css';
+import { ErrorMessage, Paragraph } from '../Typography';
 
 import type { ReadOnlyVariant_, InputVariant_ } from './utils';
 import { getVariant } from './utils';
@@ -201,15 +202,18 @@ const CharacterCounter = ({
       >
         {srLabel}
       </span>
-      <span
-        className={[
-          classes.characterLimitLabel,
-          hasExceededLimit ? classes.characterLimitExceeded : '',
-        ].join(' ')}
-        aria-live={hasExceededLimit ? 'polite' : 'off'}
-      >
-        {label(currentCount)}
-      </span>
+      {hasExceededLimit ? (
+        <ErrorMessage
+          className={classes.characterLimitLabel}
+          aria-live='polite'
+        >
+          {label(currentCount)}
+        </ErrorMessage>
+      ) : (
+        <Paragraph className={classes.characterLimitLabel}>
+          {label(currentCount)}
+        </Paragraph>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Earlier we used the native `<span/>` element to render content about how many characters remain. This is now replaced with `ErrorMessage` and `Paragraph` to ensure the fonts to behaves according to other components within digdir-designsystem. Since we are using the `ErrorMessage` component, we do not need to set the error colour within the `InputWrapper.module.css.`.