### PR TITLE
refactor(Alert): use box-shadow as border-left

### DIFF
--- a/packages/react/src/components/Alert/Alert.module.css
+++ b/packages/react/src/components/Alert/Alert.module.css
@@ -7,10 +7,7 @@
   box-shadow: 8px 0 0 0 var(--fdsc-alert-border) inset;
   background: var(--fdsc-alert-background);
   color: var(--fdsc-alert-color);
-  padding-left: var(--fds-spacing-4);
-  padding-right: var(--fds-spacing-4);
-  padding-top: var(--fds-spacing-4);
-  padding-bottom: var(--fds-spacing-4);
+  padding: var(--fds-spacing-4);
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: min-content auto;

--- a/packages/react/src/components/Alert/Alert.module.css
+++ b/packages/react/src/components/Alert/Alert.module.css
@@ -4,10 +4,11 @@
   --fdsc-alert-background: var(--fds-semantic-surface-info-subtle);
   --fdsc-alert-color: var(--fds-semantic-text-neutral-default);
 
-  border-left: 8px solid var(--fdsc-alert-border);
+  box-shadow: 8px 0 0 0 var(--fdsc-alert-border) inset;
+  box-sizing: border-box;
   background: var(--fdsc-alert-background);
   color: var(--fdsc-alert-color);
-  padding-left: var(--fds-spacing-3);
+  padding-left: var(--fds-spacing-4);
   padding-right: var(--fds-spacing-4);
   padding-top: var(--fds-spacing-4);
   padding-bottom: var(--fds-spacing-4);

--- a/packages/react/src/components/Alert/Alert.module.css
+++ b/packages/react/src/components/Alert/Alert.module.css
@@ -5,7 +5,6 @@
   --fdsc-alert-color: var(--fds-semantic-text-neutral-default);
 
   box-shadow: 8px 0 0 0 var(--fdsc-alert-border) inset;
-  box-sizing: border-box;
   background: var(--fdsc-alert-background);
   color: var(--fdsc-alert-color);
   padding-left: var(--fds-spacing-4);


### PR DESCRIPTION
resolves: #505 

Should use box-shadow as border-left instead of the border-left property. This is done to have the border on the inside of the box just like it is in Figma.