### PR TITLE
fix(Alert): avoid the border-left to disappear when elevated is true

### DIFF
--- a/packages/react/src/components/Alert/Alert.module.css
+++ b/packages/react/src/components/Alert/Alert.module.css
@@ -4,7 +4,8 @@
   --fdsc-alert-background: var(--fds-semantic-surface-info-subtle);
   --fdsc-alert-color: var(--fds-semantic-text-neutral-default);
 
-  box-shadow: 8px 0 0 0 var(--fdsc-alert-border) inset;
+  /* Negative drop-shadow to place it on the left side of the element */
+  filter: drop-shadow(-8px 0 0 var(--fdsc-alert-border));
   background: var(--fdsc-alert-background);
   color: var(--fdsc-alert-color);
   padding: var(--fds-spacing-4);


### PR DESCRIPTION
Resolved: #549 

When elevated is set to true, the box-shadow property is used for the displayed shadow, hence we cannot use the same property to make the left border. Therefore I changed it to filter(drop-shadow). 


**Note**
We cannot use border-left because it conflicts with the Figma implementation. [More details can be found here.](https://github.com/digdir/designsystem/pull/532)