### PR TITLE
style(Tokens)!: added themeable action color tokens

### DIFF
--- a/design-tokens/$themes.json
+++ b/design-tokens/$themes.json
@@ -229,7 +229,6 @@
       "brand.secondary.500": "S:c9127aee996cd9b6a5e13cb12b5f3713e27dfaa6,",
       "brand.secondary.600": "S:e239daacd4ddab975276a269eba062c30fd4dda6,",
       "brand.secondary.700": "S:bcdac34d5aa4b4815527843cd4b153cb953a40c4,",
-      "brand.secondary.800": "S:23925b130515fb61d12fb3414165f61e094a6262,",
       "brand.tertiary.100": "S:7c730a24ad0dad54ef6144e3ecdefe8652f0a50f,",
       "brand.tertiary.200": "S:539f73d39ad53968a77d0d2c276c67ebf5541c22,",
       "brand.tertiary.300": "S:c826592de90b0d29de382534b9b7a923f0465a24,",
@@ -264,7 +263,8 @@
       "semantic.surface.neutral.selected": "S:6163d38fd3182f85880fd831fe83f5e3dc826d6a,",
       "semantic.surface.neutral.subtle": "S:135a09c13885b731f952bdf86076216d6dfcdad0,",
       "semantic.surface.neutral.subtle-hover": "S:ecb9014f477602ba313b83b489c86b56d3cdb0ba,",
-      "semantic.surface.primary.light": "S:5d186a6b3411853833badfc76abd94a6fdfbc63a,"
+      "semantic.surface.primary.light": "S:5d186a6b3411853833badfc76abd94a6fdfbc63a,",
+      "brand.secondary.900": "S:23925b130515fb61d12fb3414165f61e094a6262,"
     }
   },
   {

--- a/design-tokens/Base/Component.json
+++ b/design-tokens/Base/Component.json
@@ -74,11 +74,11 @@
             "type": "color"
           },
           "hover": {
-            "value": "{semantic.border.action.default}",
+            "value": "{semantic.border.action.primary.default}",
             "type": "color"
           },
           "checked": {
-            "value": "{semantic.border.action.default}",
+            "value": "{semantic.border.action.primary.default}",
             "type": "color"
           },
           "error": {
@@ -92,11 +92,11 @@
             "type": "color"
           },
           "hover": {
-            "value": "{semantic.surface.action.subtle}",
+            "value": "{semantic.surface.action.primary.subtle}",
             "type": "color"
           },
           "checked": {
-            "value": "{semantic.surface.action.default}",
+            "value": "{semantic.surface.action.primary.default}",
             "type": "color"
           },
           "error": {
@@ -110,7 +110,7 @@
             "type": "color"
           },
           "hover": {
-            "value": "{semantic.text.action.default}",
+            "value": "{semantic.text.action.primary.default}",
             "type": "color"
           },
           "checked": {
@@ -170,7 +170,7 @@
             "type": "color"
           },
           "hover": {
-            "value": "{semantic.border.action.default}",
+            "value": "{semantic.border.action.primary.default}",
             "type": "color"
           },
           "error": {
@@ -266,7 +266,7 @@
       "color": {
         "background": {
           "active": {
-            "value": "{semantic.surface.action.default}",
+            "value": "{semantic.surface.action.primary.default}",
             "type": "color"
           },
           "inactive": {
@@ -276,7 +276,7 @@
         },
         "text": {
           "active": {
-            "value": "{semantic.text.action.on_action}",
+            "value": "{semantic.text.action.primary.on_action}",
             "type": "color"
           },
           "inactive": {
@@ -286,7 +286,7 @@
         },
         "border": {
           "inactive": {
-            "value": "{semantic.border.action.default}",
+            "value": "{semantic.border.action.primary.default}",
             "type": "color"
           }
         }
@@ -384,7 +384,7 @@
             "type": "color"
           },
           "hover": {
-            "value": "{semantic.border.action.default}",
+            "value": "{semantic.border.action.primary.default}",
             "type": "color"
           }
         },

--- a/design-tokens/Base/Semantic.json
+++ b/design-tokens/Base/Semantic.json
@@ -233,7 +233,7 @@
           "type": "color"
         },
         "dark": {
-          "value": "{brand.secondary.800}",
+          "value": "{brand.secondary.900}",
           "type": "color"
         }
       },
@@ -292,7 +292,11 @@
       "action": {
         "primary": {
           "subtle": {
-            "value": "{colors.blue.100}",
+            "value": "{colors.blue.200}",
+            "type": "color"
+          },
+          "subtle-hover": {
+            "value": "{colors.blue.400}",
             "type": "color"
           },
           "default": {
@@ -311,6 +315,10 @@
         "secondary": {
           "subtle": {
             "value": "{colors.grey.200}",
+            "type": "color"
+          },
+          "subtle-hover": {
+            "value": "{colors.grey.300}",
             "type": "color"
           },
           "default": {

--- a/design-tokens/Base/Semantic.json
+++ b/design-tokens/Base/Semantic.json
@@ -526,11 +526,11 @@
             "type": "color"
           },
           "hover": {
-            "value": "#004e95",
+            "value": "{colors.blue.900}",
             "type": "color"
           },
           "active": {
-            "value": "#00315d",
+            "value": "{colors.blue.900}",
             "type": "color"
           },
           "on_action": {

--- a/design-tokens/Base/Semantic.json
+++ b/design-tokens/Base/Semantic.json
@@ -38,38 +38,75 @@
         }
       },
       "action": {
-        "subtle": {
-          "value": "{colors.blue.100}",
-          "type": "color"
+        "primary": {
+          "subtle": {
+            "value": "{colors.blue.100}",
+            "type": "color"
+          },
+          "subtle-hover": {
+            "value": "{colors.blue.200}",
+            "type": "color"
+          },
+          "default": {
+            "value": "{colors.blue.700}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{colors.blue.800}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{colors.blue.900}",
+            "type": "color",
+            "description": "Standard farge for handlinger"
+          },
+          "no_fill": {
+            "value": "{colors.white}",
+            "type": "color"
+          },
+          "no_fill-hover": {
+            "value": "{colors.blue.100}",
+            "type": "color"
+          },
+          "no_fill-active": {
+            "value": "{colors.blue.200}",
+            "type": "color"
+          }
         },
-        "subtle-hover": {
-          "value": "{colors.blue.200}",
-          "type": "color"
-        },
-        "default": {
-          "value": "{colors.blue.700}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{colors.blue.800}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{colors.blue.900}",
-          "type": "color",
-          "description": "Standard farge for handlinger"
-        },
-        "no_fill": {
-          "value": "{colors.white}",
-          "type": "color"
-        },
-        "no_fill-hover": {
-          "value": "{colors.blue.100}",
-          "type": "color"
-        },
-        "no_fill-active": {
-          "value": "{colors.blue.200}",
-          "type": "color"
+        "secondary": {
+          "subtle": {
+            "value": "{colors.grey.100}",
+            "type": "color"
+          },
+          "subtle-hover": {
+            "value": "{colors.grey.200}",
+            "type": "color"
+          },
+          "default": {
+            "value": "{colors.blue.900}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "rgba($colors.blue.900, 0.9)",
+            "type": "color"
+          },
+          "active": {
+            "value": "rgba($colors.blue.900, 0.8)",
+            "type": "color",
+            "description": "Standard farge for handlinger"
+          },
+          "no_fill": {
+            "value": "{colors.white}",
+            "type": "color"
+          },
+          "no_fill-hover": {
+            "value": "rgba($colors.blue.900, 0.1)",
+            "type": "color"
+          },
+          "no_fill-active": {
+            "value": "rgba($colors.blue.900, 0.2)",
+            "type": "color"
+          }
         }
       },
       "success": {
@@ -253,21 +290,41 @@
         }
       },
       "action": {
-        "subtle": {
-          "value": "{colors.blue.100}",
-          "type": "color"
+        "primary": {
+          "subtle": {
+            "value": "{colors.blue.100}",
+            "type": "color"
+          },
+          "default": {
+            "value": "{colors.blue.700}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{colors.blue.800}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{colors.blue.900}",
+            "type": "color"
+          }
         },
-        "default": {
-          "value": "{colors.blue.700}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{colors.blue.800}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{colors.blue.900}",
-          "type": "color"
+        "secondary": {
+          "subtle": {
+            "value": "{colors.grey.200}",
+            "type": "color"
+          },
+          "default": {
+            "value": "{colors.blue.900}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{colors.blue.900}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{colors.blue.900}",
+            "type": "color"
+          }
         }
       },
       "neutral": {
@@ -437,21 +494,41 @@
         }
       },
       "action": {
-        "default": {
-          "value": "{colors.blue.700}",
-          "type": "color"
+        "primary": {
+          "default": {
+            "value": "{colors.blue.700}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "#004e95",
+            "type": "color"
+          },
+          "active": {
+            "value": "#00315d",
+            "type": "color"
+          },
+          "on_action": {
+            "value": "{colors.white}",
+            "type": "color"
+          }
         },
-        "hover": {
-          "value": "#004e95",
-          "type": "color"
-        },
-        "active": {
-          "value": "#00315d",
-          "type": "color"
-        },
-        "on_action": {
-          "value": "{colors.white}",
-          "type": "color"
+        "secondary": {
+          "default": {
+            "value": "{colors.blue.900}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "#004e95",
+            "type": "color"
+          },
+          "active": {
+            "value": "#00315d",
+            "type": "color"
+          },
+          "on_action": {
+            "value": "{colors.white}",
+            "type": "color"
+          }
         }
       },
       "warning": {
@@ -493,12 +570,6 @@
       "visited": {
         "default": {
           "value": "{colors.purple.700}",
-          "type": "color"
-        }
-      },
-      "action_dark": {
-        "default": {
-          "value": "#00315d",
           "type": "color"
         }
       }

--- a/design-tokens/Brand/Digdir.json
+++ b/design-tokens/Brand/Digdir.json
@@ -40,6 +40,10 @@
         "value": "#c34c4f",
         "type": "color",
         "description": "AA 4.7 on white"
+      },
+      "900": {
+        "value": "#B83D41",
+        "type": "color"
       }
     },
     "secondary": {
@@ -82,6 +86,10 @@
         "value": "#b7881a",
         "type": "color",
         "description": "AA18 4.4 on grey 800\nAA18 3.2 on white"
+      },
+      "900": {
+        "value": "#A17717",
+        "type": "color"
       }
     },
     "tertiary": {
@@ -124,22 +132,10 @@
         "value": "#156aac",
         "type": "color",
         "description": "AA 5.6 on white"
-      }
-    },
-    "action": {
-      "primary": {
-        "default": {
-          "value": "{brand.tertiary.700}",
-          "type": "color"
-        },
-        "hover": {
-          "value": "{brand.tertiary.800}",
-          "type": "color"
-        },
-        "active": {
-          "value": "{brand.tertiary.800}",
-          "type": "color"
-        }
+      },
+      "900": {
+        "value": "#125A91",
+        "type": "color"
       }
     }
   }

--- a/design-tokens/Brand/Digdir.json
+++ b/design-tokens/Brand/Digdir.json
@@ -125,6 +125,22 @@
         "type": "color",
         "description": "AA 5.6 on white"
       }
+    },
+    "action": {
+      "primary": {
+        "default": {
+          "value": "{brand.tertiary.700}",
+          "type": "color"
+        },
+        "hover": {
+          "value": "{brand.tertiary.800}",
+          "type": "color"
+        },
+        "active": {
+          "value": "{brand.tertiary.800}",
+          "type": "color"
+        }
+      }
     }
   }
 }

--- a/design-tokens/Brand/Tilsynet.json
+++ b/design-tokens/Brand/Tilsynet.json
@@ -32,6 +32,10 @@
       "800": {
         "value": "#0008b8",
         "type": "color"
+      },
+      "900": {
+        "value": "#00078F",
+        "type": "color"
       }
     },
     "secondary": {
@@ -65,6 +69,10 @@
       },
       "800": {
         "value": "#b3764a",
+        "type": "color"
+      },
+      "900": {
+        "value": "#9F6841",
         "type": "color"
       }
     },
@@ -100,6 +108,67 @@
       "800": {
         "value": "#407d6d",
         "type": "color"
+      },
+      "900": {
+        "value": "#376C5E",
+        "type": "color"
+      }
+    }
+  },
+  "semantic": {
+    "surface": {
+      "action": {
+        "primary": {
+          "default": {
+            "value": "{brand.tertiary.900}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "rgba($brand.tertiary.900, 0.9)",
+            "type": "color"
+          },
+          "active": {
+            "value": "rgba($brand.tertiary.900, 0.8)",
+            "type": "color",
+            "description": "Standard farge for handlinger"
+          }
+        }
+      }
+    },
+    "border": {
+      "action": {
+        "primary": {
+          "default": {
+            "value": "{brand.tertiary.900}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{brand.tertiary.900}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{brand.tertiary.900}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "text": {
+      "action": {
+        "primary": {
+          "default": {
+            "value": "{brand.tertiary.900}",
+            "type": "color"
+          },
+          "hover": {
+            "value": "{brand.tertiary.900}",
+            "type": "color"
+          },
+          "active": {
+            "value": "{brand.tertiary.900}",
+            "type": "color"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
BREAKING-CHANGE: The action-color for `surface`, `border` and `text` is diveded into primary and secondary action colors. 

Resolves #440 

The action-color for `surface`, `border` and `text` is diveded into primary and secondary action colors. 

Old structure was: 
```
surface {
  neutral 
  action
  success
  danger
}
```

New structure is: 
```
surface {
  neutral 
  action {
    primary { }
    secondary { }
  success
  danger
}
```


The brand-set can override primary and secondary action colors:

![image](https://github.com/digdir/designsystem/assets/1464915/e40b036b-4a0d-432e-abdc-d141fb379ab2)
