### PR TITLE
style: added label with correct weight for radio

### DIFF
--- a/design-tokens/Base/Semantic.json
+++ b/design-tokens/Base/Semantic.json
@@ -785,6 +785,64 @@
           "textDecoration": "{textDecoration.none}"
         },
         "type": "typography"
+      },
+      "radio_and_checkbox": {
+        "large": {
+          "value": {
+            "fontFamily": "{fontFamilies.inter}",
+            "fontWeight": "{fontWeights.medium}",
+            "lineHeight": "{lineHeights.300}",
+            "fontSize": "{font-size.f1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography"
+        },
+        "medium": {
+          "value": {
+            "fontFamily": "{fontFamilies.inter}",
+            "fontWeight": "{fontWeights.medium}",
+            "lineHeight": "{lineHeights.300}",
+            "fontSize": "{font-size.f0}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography"
+        },
+        "small": {
+          "value": {
+            "fontFamily": "{fontFamilies.inter}",
+            "fontWeight": "{fontWeights.medium}",
+            "lineHeight": "{lineHeights.300}",
+            "fontSize": "{font-size.f-1}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography"
+        },
+        "xsmall": {
+          "value": {
+            "fontFamily": "{fontFamilies.inter}",
+            "fontWeight": "{fontWeights.medium}",
+            "lineHeight": "{lineHeights.300}",
+            "fontSize": "{font-size.f-2}",
+            "letterSpacing": "{letterSpacing.0}",
+            "paragraphSpacing": "{paragraphSpacing.0}",
+            "paragraphIndent": "{paragraphIndent.0}",
+            "textCase": "{textCase.none}",
+            "textDecoration": "{textDecoration.none}"
+          },
+          "type": "typography"
+        }
       }
     },
     "error_message": {


### PR DESCRIPTION
Talked to @Febakke today about labels used next to radio and checkboxes. It looks a bit weird when they are the same weight and size as their legend. They should use medium weight while the rest of the labels and legends use font-weight semibold. 