### PR TITLE
feat(TextField): Type attribute

### DIFF
--- a/packages/react/src/components/TextField/TextField.test.tsx
+++ b/packages/react/src/components/TextField/TextField.test.tsx
@@ -94,6 +94,17 @@ describe('TextField', () => {
       await user.click(screen.getByText(label));
       expect(screen.getByRole('textbox')).toHaveFocus();
     });
+
+    it('Has type attribute set to "text" by default', () => {
+      render();
+      expect(screen.getByRole('textbox')).toHaveAttribute('type', 'text');
+    });
+
+    it('Has given type attribute if set', () => {
+      const type = 'tel';
+      render({ type });
+      expect(screen.getByRole('textbox')).toHaveAttribute('type', type);
+    });
   });
 
   describe('Number format', () => {

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -63,7 +63,7 @@ export type TextFieldProps = {
 } & Omit<
   NumericFormatProps | PatternFormatProps,
   'readOnly' | 'value' | 'defaultValue' | 'type'
->;
+>; // Todo: We should extend the props of <input> here, but it's complex because of the number format implementation. We should move that out to a separate component first.
 
 export type TextFieldFormatting = {
   align?: 'right' | 'center' | 'left';

--- a/packages/react/src/components/TextField/TextField.tsx
+++ b/packages/react/src/components/TextField/TextField.tsx
@@ -20,25 +20,49 @@ export type TextFieldProps = {
    *  Use `srLabel` to describe `maxCount` for screen readers.
    */
   characterLimit?: CharacterLimit;
+
   /** The default value for the text field. */
   defaultValue?: string | number;
+
   /** The formatting options for the text field. */
   formatting?: TextFieldFormatting;
+
   /** Specifies whether the value of the text field is valid. */
   isValid?: boolean;
+
   /** The label for the text field. */
   label?: string;
+
   /** Whether the text field is read-only. */
   readOnly?: boolean | ReadOnlyVariant_;
+
   /** The value of the text field. */
   value?: string;
+
   /** Specifies whether the text field is disabled. */
   disabled?: boolean;
+
   /** Specifies whether the text field is required. */
   required?: boolean;
+
+  /** Specifies the type of the text field. */
+  type?:
+    | 'text'
+    | 'password'
+    | 'color'
+    | 'date'
+    | 'datetime-local'
+    | 'email'
+    | 'month'
+    | 'number'
+    | 'search'
+    | 'tel'
+    | 'time'
+    | 'url'
+    | 'week';
 } & Omit<
   NumericFormatProps | PatternFormatProps,
-  'readOnly' | 'value' | 'defaultValue'
+  'readOnly' | 'value' | 'defaultValue' | 'type'
 >;
 
 export type TextFieldFormatting = {
@@ -76,6 +100,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       disabled = false,
       readOnly = false,
       required = false,
+      type = 'text',
       formatting,
       label,
       value,
@@ -181,6 +206,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
                 onChange={handleNativeInputChange}
                 aria-describedby={describedBy}
                 ref={ref}
+                type={type}
               />
             );
           }


### PR DESCRIPTION
As a step towards increasing the flexibility of the `TextField` component, I have added the `type` attribute and restricted its possible values to types that are appropriate with its styling. This makes it possible to use native features like date picker, integer selector etc.

Ideally, the component should extend `input` props, but this is not straightforward because of restrictions on the number format implementation. This should probably be extracted into a separate component in the future.