### PR TITLE
style: replaced dollar sign with curly brackets

### DIFF
--- a/design-tokens/Base/Semantic.json
+++ b/design-tokens/Base/Semantic.json
@@ -87,11 +87,11 @@
             "type": "color"
           },
           "hover": {
-            "value": "rgba($colors.blue.900, 0.9)",
+            "value": "rgba({colors.blue.900}, 0.9)",
             "type": "color"
           },
           "active": {
-            "value": "rgba($colors.blue.900, 0.8)",
+            "value": "rgba({colors.blue.900}, 0.8)",
             "type": "color",
             "description": "Standard farge for handlinger"
           },
@@ -100,11 +100,11 @@
             "type": "color"
           },
           "no_fill-hover": {
-            "value": "rgba($colors.blue.900, 0.1)",
+            "value": "rgba({colors.blue.900}, 0.1)",
             "type": "color"
           },
           "no_fill-active": {
-            "value": "rgba($colors.blue.900, 0.2)",
+            "value": "rgba({colors.blue.900}, 0.2)",
             "type": "color"
           }
         }


### PR DESCRIPTION
Needed to change from dollar sign to curly brackets to ensure that style-dictionary successfully created RGBA tokens. With dollar signs, style-dictionary could not resolve the colour reference. 