### PR TITLE
chore: storefront ol styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Design tokens contain UI data like colors, fonts and spacing for styling and bui
 
 ### Storybook
 
-See [Storybook](https://digdir.github.io/designsystem/) for overview of available components
+We use Storybook to develop and test our React components. Check it out [here](https://digdir.github.io/designsystem/).
 
-### Storefront (Coming soon!)
+### Storefront
 
-Here you will find everything you need to start using the designsystem.
+Learn everything you need to get started with the design system at [designsystemet.no](https://designsystemet.no).
 
 ---
 
@@ -279,18 +279,6 @@ Please ensure that the appearance closely matches the image below. Consistency p
 The storefront is configured to deploy automatically upon merging changes into the main branch.
 
 If any changes are detected in the `/storefront` folder, links to the preview deployments will be automatically added as comments in the pull requests. This convenient feature enables easy access to preview deployments for review and testing purposes directly within the pull request context.
-
-### Testing the storefront in the preview deployment
-
-Open the 5 layout files to make sure they all work:
-
-- Navigate to `/`.
-- Navigate to `/grunnleggende`.
-- Navigate to `/grunnleggende/introduksjon/om-designsystemet`.
-- Navigate to `/god-praksis`.
-- Navigate to `/god-praksis/brukerinnsikt/felles-innsiktsbase`.
-
-Also test the new content or functionalty that you introduced in your changes.
 
 ---
 

--- a/storefront/components/MdxContent/MdxContent.module.css
+++ b/storefront/components/MdxContent/MdxContent.module.css
@@ -93,9 +93,15 @@
   font-weight: 500;
 }
 
-.content > ul > li {
+.content > ul > li,
+.content > ol > li {
   font-size: 18px;
-  line-height: 1.7em;
+  line-height: 1.9em;
+}
+
+.content > ul > li > ol,
+.content > ol > li > ul {
+  margin-top: 8px;
 }
 
 .content > p > a:hover,

--- a/storefront/components/MdxContent/MdxContent.module.css
+++ b/storefront/components/MdxContent/MdxContent.module.css
@@ -68,7 +68,8 @@
 }
 
 .content > p > a,
-.content > ul > li > a {
+.content > ul > li a,
+.content > ol > li a {
   color: #0062ba;
   text-underline-offset: 4px;
 }

--- a/storefront/components/MdxContent/MdxContent.module.css
+++ b/storefront/components/MdxContent/MdxContent.module.css
@@ -106,7 +106,8 @@
 }
 
 .content > p > a:hover,
-.content > ul > li > a:hover {
+.content > ul > li a:hover,
+.content > ol > li a:hover {
   text-decoration-thickness: 2px;
 }
 

--- a/storefront/components/Meta/Meta.tsx
+++ b/storefront/components/Meta/Meta.tsx
@@ -20,6 +20,10 @@ const Meta = ({ title, description }: MetaProps) => {
         name='viewport'
         content='width=device-width, initial-scale=1'
       />
+      <link
+        rel='shortcut icon'
+        href='/favicon.ico'
+      />
     </Head>
   );
 };


### PR DESCRIPTION
Resolved #632 

* Changed font-size of numbered lists to 18px, which is the same as ul.
* Added a small space if a ul/ol is inside another ul/ol
* Changed line-height of items inside ul/ol from 1.7em to 1.9em.

Other fixes:
* Added favicon link to Head.
* Updated readme with storefront link.
* Added link styling to links inside ol.