### PR TITLE
fix(Readme): fixed spelling issue

### DIFF
--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -63,7 +63,7 @@ div {
 
 #### ⚠️ Warning
 
-Typography and spacing tokens are static for javascript tokens. This is due to limitations in CSS with nested `calc()` only being supported using css-variables. Since js tokens can be scoped to only import one, this might lead to unintended bugs are referecend css-variables might not be present/imported.
+Typography and spacing tokens are static for javascript tokens. This is due to limitations in CSS with nested `calc()` only being supported using css-variables. Since js tokens can be scoped to only import one, this might lead to unintended bugs are referenced css-variables might not be present/imported.
 
 #### Usage
 


### PR DESCRIPTION
Fixed spelling issue within Readme. 

This PR was created to pump token-package to a new version, since earlier commits did not follow correct commit-conventions.