### PR TITLE
refactor(Chip): :recycle: Improve `Chip.Group` application of childrens sizes

### DIFF
--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -24,9 +24,3 @@ export const Preview: Story = {
     checkmark: false,
   },
 };
-
-export const Test = () => (
-  <Chip.Group>
-    <Chip.Toggle>Test</Chip.Toggle>
-  </Chip.Group>
-);

--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Chip } from './index';

--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Chip } from './index';
 
-type Story = StoryObj<typeof Chip>;
+type Story = StoryObj<typeof Chip.Toggle>;
 
 export default {
   title: 'Kjernekomponenter/Chip',
@@ -23,3 +24,9 @@ export const Preview: Story = {
     checkmark: false,
   },
 };
+
+export const Test = () => (
+  <Chip.Group>
+    <Chip.Toggle>Test</Chip.Toggle>
+  </Chip.Group>
+);

--- a/packages/react/src/components/Chip/Group/Group.tsx
+++ b/packages/react/src/components/Chip/Group/Group.tsx
@@ -19,14 +19,6 @@ export type ChipGroupProps = {
   size?: 'xsmall' | 'small';
 } & HTMLAttributes<HTMLUListElement>;
 
-/**
- * Grouping multiple `Chip` together. Avoid mixing different kind of chips.
- * @example
- * <Chip.Group>
- *    <Chip.Removable>Tekst</Chip.Removable>
- *    <Chip.Removable>Tekst</Chip.Removable>
- * </Chip.Group>
- */
 export const Group = forwardRef<HTMLUListElement, ChipGroupProps>(
   ({ children, size = 'xsmall', ...rest }: ChipGroupProps, ref) => (
     <ul

--- a/packages/react/src/components/Chip/Group/Group.tsx
+++ b/packages/react/src/components/Chip/Group/Group.tsx
@@ -1,14 +1,20 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import React, { forwardRef, createContext } from 'react';
 import cn from 'classnames';
 
 import type { ChipBaseProps } from '../_ChipBase';
 
 import classes from './Group.module.css';
 
+export type ChipGroupContext = {
+  size?: ChipBaseProps['size'];
+};
+
+export const ChipGroupContext = createContext<ChipGroupContext | null>(null);
+
 export type ChipGroupProps = {
   /**
-   * Changes padding, font-sizes and gap between chips.
+   * Changes Chip size and gap between chips.
    */
   size?: 'xsmall' | 'small';
 } & HTMLAttributes<HTMLUListElement>;
@@ -20,15 +26,13 @@ export const Group = forwardRef<HTMLUListElement, ChipGroupProps>(
       ref={ref}
       className={cn(classes.groupContainer, classes[size], rest.className)}
     >
-      {React.Children.toArray(children).map((child, index) =>
-        React.isValidElement(child) ? (
-          <li key={`${child.toString()}-${index}`}>
-            {React.cloneElement(child as React.ReactElement<ChipBaseProps>, {
-              size,
-            })}
-          </li>
-        ) : null,
-      )}
+      <ChipGroupContext.Provider value={{ size }}>
+        {React.Children.toArray(children).map((child, index) =>
+          React.isValidElement(child) ? (
+            <li key={`${child.toString()}-${index}`}>{child}</li>
+          ) : null,
+        )}
+      </ChipGroupContext.Provider>
     </ul>
   ),
 );

--- a/packages/react/src/components/Chip/Group/Group.tsx
+++ b/packages/react/src/components/Chip/Group/Group.tsx
@@ -19,6 +19,14 @@ export type ChipGroupProps = {
   size?: 'xsmall' | 'small';
 } & HTMLAttributes<HTMLUListElement>;
 
+/**
+ * Grouping multiple `Chip` together. Avoid mixing different kind of chips.
+ * @example
+ * <Chip.Group>
+ *    <Chip.Removable>Tekst</Chip.Removable>
+ *    <Chip.Removable>Tekst</Chip.Removable>
+ * </Chip.Group>
+ */
 export const Group = forwardRef<HTMLUListElement, ChipGroupProps>(
   ({ children, size = 'xsmall', ...rest }: ChipGroupProps, ref) => (
     <ul

--- a/packages/react/src/components/Chip/Toggle/Toggle.tsx
+++ b/packages/react/src/components/Chip/Toggle/Toggle.tsx
@@ -12,6 +12,7 @@ export type ToggleChipProps = {
    */
   checkmark?: boolean;
 } & ChipBaseProps;
+
 export const ToggleChip = forwardRef<HTMLButtonElement, ToggleChipProps>(
   (
     {

--- a/packages/react/src/components/Chip/_ChipBase/ChipBase.tsx
+++ b/packages/react/src/components/Chip/_ChipBase/ChipBase.tsx
@@ -1,9 +1,10 @@
 import type { ButtonHTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import React, { useContext, forwardRef } from 'react';
 import cn from 'classnames';
 
 import { Paragraph } from '../../Typography';
 import type { OverridableComponent } from '../../../types/OverridableComponent';
+import { ChipGroupContext } from '../Group';
 
 import classes from './ChipBase.module.css';
 
@@ -31,12 +32,17 @@ export const ChipBase: OverridableComponent<ChipBaseProps, HTMLLabelElement> =
       },
       ref,
     ): JSX.Element => {
+      const group = useContext(ChipGroupContext);
       return (
         <Component
           {...rest}
           ref={ref}
           aria-pressed={selected}
-          className={cn(classes.chipButton, classes[size], className)}
+          className={cn(
+            classes.chipButton,
+            classes[group?.size || size],
+            className,
+          )}
         >
           <Paragraph
             as='span'

--- a/packages/react/src/components/Chip/index.ts
+++ b/packages/react/src/components/Chip/index.ts
@@ -6,6 +6,14 @@ import { ToggleChip } from './Toggle';
 import type { ToggleChipProps } from './Toggle/';
 
 type ChipComponent = {
+  /**
+   * Grouping  multiple `Chip` together. Avoid mixing different kind of chips.
+   * @example
+   * <Chip.Group>
+   *    <Chip.Removable>Tekst</Chip.Removable>
+   *    <Chip.Removable>Tekst</Chip.Removable>
+   * </Chip.Group>
+   */
   Group: typeof Group;
   Removable: typeof RemovableChip;
   Toggle: typeof ToggleChip;


### PR DESCRIPTION
Use context instead of clonelement for applying sizes to children