### PR TITLE
feat(Checkbox): ✨ New `Checkbox` component (unreleased)

### DIFF
--- a/packages/react/src/components/form/Checkbox/Checkbox.mdx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.mdx
@@ -1,15 +1,15 @@
 import { Meta, Canvas, Story, Controls, Primary } from '@storybook/blocks';
 import { Information } from '../../../../../../docs-components';
-import * as CheckboxStories from './Radio.stories';
+import * as CheckboxStories from './Checkbox.stories';
 import * as CheckboxGroupStories from './Group/Group.stories';
 
 <Meta of={CheckboxStories} />
 
-# Radio
+# Checkbox
 
 <Information text='development' />
 
-`Radio` er en knapp som skal brukes i kombinasjon med andre radioknapper for å velge mellom flere alternativer. Vi anbefaler å bruke `Radio.Group` hvis man har behov for radioknapper.
+`Checkbox` er en knapp som skal brukes i kombinasjon med andre Checkboxknapper for å velge mellom flere alternativer. Vi anbefaler å bruke `Checkbox.Group` hvis man har behov for Checkboxknapper.
 
 <Primary />
 <Controls />
@@ -20,38 +20,38 @@ import * as CheckboxGroupStories from './Group/Group.stories';
 
 ```tsx
 import '@digdir/design-system-tokens/brand/altinn/tokens.css'; // Importeres kun en gang i appen din.
-import { Radio } from '@digdir/design-system-react';
+import { Checkbox } from '@digdir/design-system-react';
 
-<Radio.Group legend='Er du over 18 år?'>
-  <Radio value='Ja'>Ja</Radio>
-  <Radio value='Ne'>Nei</Radio>
-</Radio.Group>;
+<Checkbox.Group legend='Er du over 18 år?'>
+  <Checkbox value='Ja'>Ja</Checkbox>
+  <Checkbox value='Ne'>Nei</Checkbox>
+</Checkbox.Group>;
 ```
 
 ### Enkel
 
-`Radio` skal alltid ha en label i en form eller annen. Bruk din egen `label` eller ledetekten fra en annen plass, husk å bruk da `aria-label` eller `aria-labelledby`
+`Checkbox` skal alltid ha en label i en form eller annen. Bruk din egen `label` eller ledetekten fra en annen plass, husk å bruk da `aria-label` eller `aria-labelledby`
 
 <Canvas of={CheckboxStories.Single} />
 
-## `Radio.Group`
+## `Checkbox.Group`
 
-Bruk `Radio.Group` for gruppering av radioknapper.
+Bruk `Checkbox.Group` for gruppering av Checkboxknapper.
 
 <Canvas of={CheckboxGroupStories.Preview} />
 <Controls of={CheckboxGroupStories.Preview} />
 
 ### Feilmelding
 
-Bruk `error` på `Radio.Group` for å vise feilmelding.
+Bruk `error` på `Checkbox.Group` for å vise feilmelding.
 
-Her må `Radio.Group` brukes da den aktivere korrekt stil og sørger for at innholdet har riktige attributter mtp. tilgjengelighet.
+Her må `Checkbox.Group` brukes da den aktivere korrekt stil og sørger for at innholdet har riktige attributter mtp. tilgjengelighet.
 
 <Canvas of={CheckboxGroupStories.Error} />
 
 ### Kontrollert
 
-Bruk `value` på `Radio.Group` for å kontrollere verdiene selv.
+Bruk `value` på `Checkbox.Group` for å kontrollere verdiene selv.
 
 <Canvas of={CheckboxGroupStories.Controlled} />
 
@@ -62,9 +62,3 @@ Bruk `value` på `Radio.Group` for å kontrollere verdiene selv.
 ### Disabled
 
 <Canvas of={CheckboxGroupStories.Disabled} />
-
-### Inline
-
-Bruk `inline` for å plassere alternativene på samme linje. Anbefales kun bruke dette dersom du har kun to alternativer og kort label, som i f.eks typisk ja/nei spørsmål.
-
-<Canvas of={CheckboxGroupStories.Inline} />

--- a/packages/react/src/components/form/Checkbox/Checkbox.mdx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.mdx
@@ -1,0 +1,70 @@
+import { Meta, Canvas, Story, Controls, Primary } from '@storybook/blocks';
+import { Information } from '../../../../../../docs-components';
+import * as CheckboxStories from './Radio.stories';
+import * as CheckboxGroupStories from './Group/Group.stories';
+
+<Meta of={CheckboxStories} />
+
+# Radio
+
+<Information text='development' />
+
+`Radio` er en knapp som skal brukes i kombinasjon med andre radioknapper for å velge mellom flere alternativer. Vi anbefaler å bruke `Radio.Group` hvis man har behov for radioknapper.
+
+<Primary />
+<Controls />
+
+## Bruk
+
+<Information text='token' />
+
+```tsx
+import '@digdir/design-system-tokens/brand/altinn/tokens.css'; // Importeres kun en gang i appen din.
+import { Radio } from '@digdir/design-system-react';
+
+<Radio.Group legend='Er du over 18 år?'>
+  <Radio value='Ja'>Ja</Radio>
+  <Radio value='Ne'>Nei</Radio>
+</Radio.Group>;
+```
+
+### Enkel
+
+`Radio` skal alltid ha en label i en form eller annen. Bruk din egen `label` eller ledetekten fra en annen plass, husk å bruk da `aria-label` eller `aria-labelledby`
+
+<Canvas of={CheckboxStories.Single} />
+
+## `Radio.Group`
+
+Bruk `Radio.Group` for gruppering av radioknapper.
+
+<Canvas of={CheckboxGroupStories.Preview} />
+<Controls of={CheckboxGroupStories.Preview} />
+
+### Feilmelding
+
+Bruk `error` på `Radio.Group` for å vise feilmelding.
+
+Her må `Radio.Group` brukes da den aktivere korrekt stil og sørger for at innholdet har riktige attributter mtp. tilgjengelighet.
+
+<Canvas of={CheckboxGroupStories.Error} />
+
+### Kontrollert
+
+Bruk `value` på `Radio.Group` for å kontrollere verdiene selv.
+
+<Canvas of={CheckboxGroupStories.Controlled} />
+
+### Readonly
+
+<Canvas of={CheckboxGroupStories.ReadOnly} />
+
+### Disabled
+
+<Canvas of={CheckboxGroupStories.Disabled} />
+
+### Inline
+
+Bruk `inline` for å plassere alternativene på samme linje. Anbefales kun bruke dette dersom du har kun to alternativer og kort label, som i f.eks typisk ja/nei spørsmål.
+
+<Canvas of={CheckboxGroupStories.Inline} />

--- a/packages/react/src/components/form/Checkbox/Checkbox.mdx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.mdx
@@ -22,9 +22,11 @@ import * as CheckboxGroupStories from './Group/Group.stories';
 import '@digdir/design-system-tokens/brand/altinn/tokens.css'; // Importeres kun en gang i appen din.
 import { Checkbox } from '@digdir/design-system-react';
 
-<Checkbox.Group legend='Er du over 18 år?'>
-  <Checkbox value='Ja'>Ja</Checkbox>
-  <Checkbox value='Ne'>Nei</Checkbox>
+<Checkbox.Group legend='What would your D&D party like to eat?'>
+  <Checkbox value='elfsalad'>Wood Elf forest salad</Checkbox>
+  <Checkbox value='firecakes'>Fire breath rice cakes</Checkbox>
+  <Checkbox value='dumplings'>Chicken-something dumplings</Checkbox>
+  <Checkbox value='ribs'>Sembian honey-glazed rothè ribs</Checkbox>
 </Checkbox.Group>;
 ```
 

--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -45,9 +45,9 @@
   grid-auto-flow: column;
 }
 
-.radio,
-.radio .icon {
-  border-radius: var(--fds-border_radius-full);
+.checkbox,
+.checkbox .icon {
+  border-radius: var(--fds-border_radius-interactive);
 }
 
 .input {

--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -31,6 +31,21 @@
   cursor: pointer;
 }
 
+.label.medium {
+  font: var(--fds-typography-label-radio_and_checkbox-medium);
+  font-family: inherit;
+}
+
+.label.small {
+  font: var(--fds-typography-label-radio_and_checkbox-small);
+  font-family: inherit;
+}
+
+.label.xsmall {
+  font: var(--fds-typography-label-radio_and_checkbox-xsmall);
+  font-family: inherit;
+}
+
 .description {
   padding-left: 3px;
   margin-top: calc(var(--fds-spacing-2) * -1);

--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -1,6 +1,6 @@
 .container {
   position: relative;
-  padding-left: calc(var(--fds-spacing-6) + 18px);
+  padding-left: calc(var(--fds-spacing-6) + 17px);
   min-width: 44px;
   min-height: 44px;
 }
@@ -15,7 +15,13 @@
   overflow: visible;
 }
 
+.checkbox,
+.checkbox .icon {
+  border-radius: var(--fds-border_radius-interactive);
+}
+
 .label {
+  padding-left: 3px;
   min-height: 44px;
   min-width: min-content;
   display: inline-flex;
@@ -26,6 +32,8 @@
 }
 
 .description {
+  padding-left: 3px;
+  margin-top: calc(var(--fds-spacing-2) * -1);
   color: var(--fds-semantic-text-neutral-subtle);
 }
 
@@ -45,9 +53,9 @@
   grid-auto-flow: column;
 }
 
-.checkbox,
-.checkbox .icon {
-  border-radius: var(--fds-border_radius-interactive);
+.radio,
+.radio .icon {
+  border-radius: var(--fds-border_radius-full);
 }
 
 .input {
@@ -59,8 +67,6 @@
   cursor: pointer;
 }
 
-.error > .input,
-.error > .label,
 .readonly > .control > .input,
 .readonly > .label {
   cursor: default;
@@ -82,19 +88,20 @@
 
 .input:checked ~ .icon .checked {
   display: inline;
-  fill: var(--fds-semantic-border-input-hover);
 }
 
 .input:not(:checked) ~ .icon .box {
   stroke: var(--fds-semantic-border-input-default);
 }
 
-.input:checked ~ .icon .box {
-  stroke: var(--fds-semantic-border-input-hover);
-}
-
 .input:disabled ~ .icon .box {
   stroke: var(--fds-semantic-border-neutral-subtle);
+  fill: white;
+}
+
+.input:checked:not(:disabled) ~ .icon .box {
+  stroke: var(--fds-semantic-border-input-hover);
+  fill: var(--fds-semantic-border-input-hover);
 }
 
 .input:focus-visible ~ .icon {
@@ -102,7 +109,7 @@
   outline-offset: 0;
 }
 
-.input:focus-visible ~ .icon .box {
+.input:focus-visible:not(:disabled) ~ .icon .box {
   stroke: var(--fds-semantic-border-focus-boxshadow);
   stroke-width: var(--fds-focus-border-width);
 }
@@ -111,16 +118,12 @@
   fill: var(--fds-semantic-border-neutral-subtle);
 }
 
-.error .input:not(:disabled, :focus-visible) ~ .icon .box {
+.error .input:not(:disabled, :focus-visible, :checked) ~ .icon .box {
   stroke: var(--fds-semantic-border-danger-default);
 }
 
-.error .input:not(:disabled, :focus-visible) ~ .icon .checked {
-  fill: var(--fds-semantic-border-danger-default);
-}
-
 .readonly .input:read-only:not(:focus-visible) ~ .icon .box {
-  stroke: var(--fds-semantic-border-neutral-default);
+  stroke: var(--fds-semantic-border-neutral-subtle);
   fill: var(--fds-semantic-background-subtle);
 }
 
@@ -128,15 +131,17 @@
   fill: var(--fds-semantic-border-neutral-default);
 }
 
-.container:not(.disabled, .readonly) > .control:hover {
+.container:not(.disabled, .readonly) > .control:hover,
+.container:not(.disabled, .readonly):has(.label:hover) > .control {
   background: var(--fds-semantic-surface-info-subtle-hover);
 }
 
 .container:not(.disabled, .readonly) > .label:hover,
-.container:not(.disabled, .readonly) > .control:hover ~ .label:hover {
+.container:not(.disabled, .readonly) > .control:hover ~ .label {
   color: var(--fds-semantic-border-input-hover);
 }
 
-.container:not(.disabled, .readonly) > .control:hover .icon .box {
+.container:not(.disabled, .readonly) > .control:hover > .icon > .box,
+.container:not(.disabled, .readonly):has(.label:hover) > .control > .icon > .box {
   stroke: var(--fds-semantic-border-input-hover);
 }

--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -1,0 +1,142 @@
+.container {
+  position: relative;
+  padding-left: calc(var(--fds-spacing-6) + 18px);
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.icon {
+  grid-area: input;
+  pointer-events: none;
+  height: 1.75em;
+  width: 1.75em;
+  z-index: 1;
+  margin: auto;
+  overflow: visible;
+}
+
+.label {
+  min-height: 44px;
+  min-width: min-content;
+  display: inline-flex;
+  flex-direction: row;
+  gap: var(--fds-spacing-1);
+  align-items: center;
+  cursor: pointer;
+}
+
+.description {
+  color: var(--fds-semantic-text-neutral-subtle);
+}
+
+.control {
+  --fds-inner-focus-border-color: var(--fds-semantic-border-focus-boxshadow);
+  --fds-outer-focus-border-color: var(--fds-semantic-border-focus-outline);
+  --fds-focus-border-width: 3px;
+
+  position: absolute;
+  left: 0;
+  top: 0;
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-grid;
+  grid: [input] 1fr / [input] 1fr;
+  gap: var(--fds-spacing-2);
+  grid-auto-flow: column;
+}
+
+.radio,
+.radio .icon {
+  border-radius: var(--fds-border_radius-full);
+}
+
+.input {
+  height: 100%;
+  width: 100%;
+  opacity: 0;
+  margin: 0;
+  grid-area: input;
+  cursor: pointer;
+}
+
+.error > .input,
+.error > .label,
+.readonly > .control > .input,
+.readonly > .label {
+  cursor: default;
+}
+
+.disabled > .control .input,
+.disabled > .label {
+  cursor: not-allowed;
+  color: var(--fds-semantic-border-neutral-subtle);
+}
+
+.disabled > .description {
+  color: var(--fds-semantic-border-neutral-subtle);
+}
+
+.input:not(:checked) ~ .icon .checked {
+  display: none;
+}
+
+.input:checked ~ .icon .checked {
+  display: inline;
+  fill: var(--fds-semantic-border-input-hover);
+}
+
+.input:not(:checked) ~ .icon .box {
+  stroke: var(--fds-semantic-border-input-default);
+}
+
+.input:checked ~ .icon .box {
+  stroke: var(--fds-semantic-border-input-hover);
+}
+
+.input:disabled ~ .icon .box {
+  stroke: var(--fds-semantic-border-neutral-subtle);
+}
+
+.input:focus-visible ~ .icon {
+  outline: var(--fds-focus-border-width) solid var(--fds-outer-focus-border-color);
+  outline-offset: 0;
+}
+
+.input:focus-visible ~ .icon .box {
+  stroke: var(--fds-semantic-border-focus-boxshadow);
+  stroke-width: var(--fds-focus-border-width);
+}
+
+.input:disabled ~ .icon .checked {
+  fill: var(--fds-semantic-border-neutral-subtle);
+}
+
+.error .input:not(:disabled, :focus-visible) ~ .icon .box {
+  stroke: var(--fds-semantic-border-danger-default);
+}
+
+.error .input:not(:disabled, :focus-visible) ~ .icon .checked {
+  fill: var(--fds-semantic-border-danger-default);
+}
+
+.readonly .input:read-only:not(:focus-visible) ~ .icon .box {
+  stroke: var(--fds-semantic-border-neutral-default);
+  fill: var(--fds-semantic-background-subtle);
+}
+
+.readonly .input:read-only:not(:focus-visible):is(:checked) ~ .icon .checked {
+  fill: var(--fds-semantic-border-neutral-default);
+}
+
+.container:not(.disabled, .readonly) > .control:hover {
+  background: var(--fds-semantic-surface-info-subtle-hover);
+}
+
+.container:not(.disabled, .readonly) > .label:hover,
+.container:not(.disabled, .readonly) > .control:hover ~ .label:hover {
+  color: var(--fds-semantic-border-input-hover);
+}
+
+.container:not(.disabled, .readonly) > .control:hover .icon .box {
+  stroke: var(--fds-semantic-border-input-hover);
+}

--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -31,21 +31,6 @@
   cursor: pointer;
 }
 
-.label.medium {
-  font: var(--fds-typography-label-radio_and_checkbox-medium);
-  font-family: inherit;
-}
-
-.label.small {
-  font: var(--fds-typography-label-radio_and_checkbox-small);
-  font-family: inherit;
-}
-
-.label.xsmall {
-  font: var(--fds-typography-label-radio_and_checkbox-xsmall);
-  font-family: inherit;
-}
-
 .description {
   padding-left: 3px;
   margin-top: calc(var(--fds-spacing-2) * -1);

--- a/packages/react/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Checkbox } from '.';
+
+type Story = StoryObj<typeof Checkbox>;
+
+export default {
+  title: 'ikke utgitt/Checkbox',
+  component: Checkbox,
+  parameters: {
+    status: {
+      type: 'beta',
+      url: 'http://www.url.com/status',
+    },
+  },
+} as Meta;
+
+export const Preview: Story = {
+  args: {
+    children: 'Checkbox',
+    description: 'Description',
+    disabled: false,
+    readOnly: false,
+    value: 'value',
+  },
+};
+
+export const Single: Story = {
+  args: {
+    value: 'value',
+    'aria-label': 'Checkbox',
+  },
+};

--- a/packages/react/src/components/form/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.test.tsx
@@ -21,7 +21,7 @@ describe('Radio', () => {
       </Checkbox>,
     );
     expect(
-      screen.getByRole('radio', { description: 'description' }),
+      screen.getByRole('checkbox', { description: 'description' }),
     ).toBeDefined();
   });
   it('calls onChange and onClick when user clicks', async () => {
@@ -41,7 +41,7 @@ describe('Radio', () => {
       </Checkbox>,
     );
 
-    const radio = screen.getByRole<HTMLInputElement>('radio');
+    const radio = screen.getByRole<HTMLInputElement>('checkbox');
 
     expect(radio.checked).toBeFalsy();
 
@@ -68,7 +68,7 @@ describe('Radio', () => {
       </Checkbox>,
     );
 
-    const radio = screen.getByRole('radio');
+    const radio = screen.getByRole('checkbox');
     await user.click(radio);
 
     expect(radio).toBeDisabled();
@@ -92,7 +92,7 @@ describe('Radio', () => {
       </Checkbox>,
     );
 
-    const radio = screen.getByRole('radio');
+    const radio = screen.getByRole('checkbox');
     await user.click(radio);
 
     expect(radio).toHaveAttribute('readonly');

--- a/packages/react/src/components/form/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 import { Checkbox } from './Checkbox';
 
-describe('Radio', () => {
+describe('Checkbox', () => {
   test('has correct value and label', () => {
     render(<Checkbox value='test'>label</Checkbox>);
     expect(screen.getByLabelText('label')).toBeDefined();

--- a/packages/react/src/components/form/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Checkbox } from './Checkbox';
+
+describe('Radio', () => {
+  test('has correct value and label', () => {
+    render(<Checkbox value='test'>label</Checkbox>);
+    expect(screen.getByLabelText('label')).toBeDefined();
+    expect(screen.getByDisplayValue('test')).toBeDefined();
+  });
+
+  test('has correct description', () => {
+    render(
+      <Checkbox
+        value='test'
+        description='description'
+      >
+        test
+      </Checkbox>,
+    );
+    expect(
+      screen.getByRole('radio', { description: 'description' }),
+    ).toBeDefined();
+  });
+  it('calls onChange and onClick when user clicks', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const onClick = jest.fn();
+
+    const value = 'test';
+
+    render(
+      <Checkbox
+        value={value}
+        onChange={onChange}
+        onClick={onClick}
+      >
+        label
+      </Checkbox>,
+    );
+
+    const radio = screen.getByRole<HTMLInputElement>('radio');
+
+    expect(radio.checked).toBeFalsy();
+
+    await user.click(radio);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(radio.checked).toBeTruthy();
+  });
+
+  it('does not call onChange or onClick when user clicks and the radio is disabled', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const onClick = jest.fn();
+
+    render(
+      <Checkbox
+        value='test'
+        disabled
+        onClick={onClick}
+        onChange={onChange}
+      >
+        disabled radio
+      </Checkbox>,
+    );
+
+    const radio = screen.getByRole('radio');
+    await user.click(radio);
+
+    expect(radio).toBeDisabled();
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not call onChange or onClick when user clicks and the radio is readOnly', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const onClick = jest.fn();
+
+    render(
+      <Checkbox
+        value='test'
+        readOnly
+        onClick={onClick}
+        onChange={onChange}
+      >
+        readonly radio
+      </Checkbox>,
+    );
+
+    const radio = screen.getByRole('radio');
+    await user.click(radio);
+
+    expect(radio).toHaveAttribute('readonly');
+    expect(onClick).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  //TODO is there a good way to test size?
+});

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -51,8 +51,13 @@ export type CheckboxProps = {
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (props, ref) => {
     const { children, description, ...rest } = props;
-    const { inputProps, descriptionId, hasError, size, readOnly } =
-      useCheckbox(props);
+    const {
+      inputProps,
+      descriptionId,
+      hasError,
+      size = 'medium',
+      readOnly,
+    } = useCheckbox(props);
 
     return (
       <Paragraph
@@ -78,7 +83,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
         {children && (
           <Label
-            className={classes.label}
+            className={cn(classes.label, classes[size])}
             htmlFor={inputProps.id}
             size={size}
           >

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -83,9 +83,10 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
         {children && (
           <Label
-            className={cn(classes.label, classes[size])}
+            className={classes.label}
             htmlFor={inputProps.id}
             size={size}
+            weight='regular'
           >
             <span>{children}</span>
           </Label>

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -1,0 +1,93 @@
+import type { InputHTMLAttributes, ReactNode, SVGAttributes } from 'react';
+import React, { forwardRef } from 'react';
+import cn from 'classnames';
+
+import { omit } from '../../../utils';
+import { Label, Paragraph } from '../../Typography';
+import type { FormFieldProps } from '../useFormField';
+
+import classes from './Checkbox.module.css';
+import { useCheckbox } from './useCheckbox';
+
+const CheckboxIcon = (props: SVGAttributes<SVGElement>) => (
+  <svg
+    width='23'
+    height='22'
+    viewBox='0 0 23 22'
+    fill='none'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <rect
+      x='1.00764'
+      y='1'
+      width='20'
+      height='20'
+      rx='3'
+      fill='white'
+      stroke='#00315D'
+      strokeWidth='2'
+      className={classes.box}
+    />
+  </svg>
+);
+
+export type CheckboxProps = {
+  /** Checkbox label */
+  children?: ReactNode;
+  /** Value of the `input` element */
+  value: string | ReadonlyArray<string> | number | undefined;
+} & Omit<FormFieldProps, 'error' | 'errorId'> &
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'value'>;
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
+  (props, ref) => {
+    const { children, description, ...rest } = props;
+    const { inputProps, descriptionId, hasError, size, readOnly } =
+      useCheckbox(props);
+
+    return (
+      <Paragraph
+        as='div'
+        size={size}
+        className={cn(
+          classes.container,
+          inputProps.disabled && classes.disabled,
+          hasError && classes.error,
+          readOnly && classes.readonly,
+          rest.className,
+        )}
+      >
+        <span className={cn(classes.control, classes.radio)}>
+          <input
+            {...omit(['size', 'error'], rest)}
+            {...inputProps}
+            className={classes.input}
+            ref={ref}
+          />
+          <CheckboxIcon className={classes.icon} />
+        </span>
+
+        {children && (
+          <Label
+            className={classes.label}
+            htmlFor={inputProps.id}
+            size={size}
+          >
+            <span>{children}</span>
+          </Label>
+        )}
+        {description && (
+          <Paragraph
+            id={descriptionId}
+            as='div'
+            size={size}
+            className={classes.description}
+          >
+            {description}
+          </Paragraph>
+        )}
+      </Paragraph>
+    );
+  },
+);

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -31,13 +31,15 @@ const CheckboxIcon = (props: SVGAttributes<SVGElement>) => (
       strokeLinejoin='round'
       className={classes.box}
     /> */}
-
     <rect
       x='1'
       y='1'
       width='20'
       height='20'
       rx='2px'
+      ry='2px'
+      strokeWidth='2'
+      strokeLinejoin='round'
       className={classes.box}
     />
     <path

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -44,7 +44,7 @@ export type CheckboxProps = {
   /** Checkbox label */
   children?: ReactNode;
   /** Value of the `input` element */
-  value: string | number;
+  value: string;
 } & Omit<FormFieldProps, 'error' | 'errorId'> &
   Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'value'>;
 

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -18,19 +18,6 @@ const CheckboxIcon = (props: SVGAttributes<SVGElement>) => (
     xmlns='http://www.w3.org/2000/svg'
     {...props}
   >
-    {/* <rect
-      x='1'
-      y='1'
-      width='20'
-      height='20'
-      rx='2px'
-      ry='2px'
-      fill='white'
-      stroke='#00315D'
-      strokeWidth='2'
-      strokeLinejoin='round'
-      className={classes.box}
-    /> */}
     <rect
       x='1'
       y='1'
@@ -38,6 +25,7 @@ const CheckboxIcon = (props: SVGAttributes<SVGElement>) => (
       height='20'
       rx='2px'
       ry='2px'
+      fill='white'
       strokeWidth='2'
       strokeLinejoin='round'
       className={classes.box}
@@ -56,7 +44,7 @@ export type CheckboxProps = {
   /** Checkbox label */
   children?: ReactNode;
   /** Value of the `input` element */
-  value: string | ReadonlyArray<string> | number | undefined;
+  value: string | number;
 } & Omit<FormFieldProps, 'error' | 'errorId'> &
   Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'value'>;
 

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -11,22 +11,24 @@ import { useCheckbox } from './useCheckbox';
 
 const CheckboxIcon = (props: SVGAttributes<SVGElement>) => (
   <svg
-    width='23'
+    width='22'
     height='22'
-    viewBox='0 0 23 22'
+    viewBox='0 0 22 22'
     fill='none'
     xmlns='http://www.w3.org/2000/svg'
     {...props}
   >
     <rect
-      x='1.00764'
+      x='1'
       y='1'
       width='20'
       height='20'
-      rx='3'
+      rx='2px'
+      ry='2px'
       fill='white'
       stroke='#00315D'
       strokeWidth='2'
+      strokeLinejoin='round'
       className={classes.box}
     />
   </svg>
@@ -58,7 +60,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           rest.className,
         )}
       >
-        <span className={cn(classes.control, classes.radio)}>
+        <span className={cn(classes.control, classes.checkbox)}>
           <input
             {...omit(['size', 'error'], rest)}
             {...inputProps}

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -18,7 +18,7 @@ const CheckboxIcon = (props: SVGAttributes<SVGElement>) => (
     xmlns='http://www.w3.org/2000/svg'
     {...props}
   >
-    <rect
+    {/* <rect
       x='1'
       y='1'
       width='20'
@@ -30,6 +30,22 @@ const CheckboxIcon = (props: SVGAttributes<SVGElement>) => (
       strokeWidth='2'
       strokeLinejoin='round'
       className={classes.box}
+    /> */}
+
+    <rect
+      x='1'
+      y='1'
+      width='20'
+      height='20'
+      rx='2px'
+      className={classes.box}
+    />
+    <path
+      fillRule='evenodd'
+      clipRule='evenodd'
+      d='M17.7876 6.27838C18.1171 6.60788 18.1171 7.14212 17.7876 7.47162L9.99591 15.2633C9.6664 15.5928 9.13217 15.5928 8.80267 15.2633L4.67767 11.1383C4.34816 10.8088 4.34816 10.2745 4.67767 9.94505C5.00717 9.61554 5.5414 9.61554 5.87091 9.94505L9.39929 13.4734L16.5943 6.27838C16.9238 5.94887 17.4581 5.94887 17.7876 6.27838Z'
+      fill='white'
+      className={classes.checked}
     />
   </svg>
 );

--- a/packages/react/src/components/form/Checkbox/Group/Group.module.css
+++ b/packages/react/src/components/form/Checkbox/Group/Group.module.css
@@ -1,0 +1,11 @@
+.xsmall,
+.small,
+.medium {
+  margin-left: calc(var(--fds-spacing-2) * -1);
+}
+
+.inline {
+  display: flex;
+  flex-direction: row;
+  gap: var(--fds-spacing-2);
+}

--- a/packages/react/src/components/form/Checkbox/Group/Group.module.css
+++ b/packages/react/src/components/form/Checkbox/Group/Group.module.css
@@ -3,9 +3,3 @@
 .medium {
   margin-left: calc(var(--fds-spacing-2) * -1);
 }
-
-.inline {
-  display: flex;
-  flex-direction: row;
-  gap: var(--fds-spacing-2);
-}

--- a/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
@@ -62,7 +62,7 @@ export const Controlled: StoryFn<typeof Checkbox> = () => {
         legend='Velg pizza'
         description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
         value={value}
-        onChangeValue={(value) => setValue(value)}
+        onChange={(value) => setValue(value)}
       >
         <Checkbox value='ost'>Bare ost</Checkbox>
         <Checkbox

--- a/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
@@ -35,7 +35,7 @@ export const Error: StoryFn<typeof Checkbox> = () => (
   <Checkbox.Group
     legend='Velg pizza '
     description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
-    error='Du må velge minst en pizza for å legge inn bestilling'
+    error='Du må velge minst én pizza for å legge inn bestilling'
   >
     <Checkbox value='ost'>Bare ost</Checkbox>
     <Checkbox value='Dobbeldekker'>Dobbeldekker</Checkbox>

--- a/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
@@ -37,7 +37,6 @@ export const Error: StoryFn<typeof Checkbox> = () => (
     legend='Velg pizza (påkreved)'
     description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
     error='Du må velge en av våre pizzaer for å legge inn bestilling'
-    value={'flammen'}
   >
     <Checkbox value='ost'>Bare ost</Checkbox>
     <Checkbox

--- a/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
@@ -1,32 +1,31 @@
 import React, { useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { Button, Label, Paragraph } from '../../..';
+import { Button, Paragraph } from '../../..';
 import { Checkbox } from '../';
 
 export default {
   title: 'ikke utgitt/Checkbox/Group',
   component: Checkbox.Group,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 } as Meta;
 
 export const Preview: StoryFn<typeof Checkbox.Group> = (args) => (
   <Checkbox.Group {...args}>
-    <Checkbox value='vanilje'>Vanilje</Checkbox>
-    <Checkbox value='jordbær'>Jordbær</Checkbox>
-    <Checkbox value='sjokolade'>Sjokolade</Checkbox>
-    <Checkbox value='spiser-ikke-is'>Jeg spiser ikke iskrem</Checkbox>
+    <Checkbox value='pizza'>Pizza</Checkbox>
+    <Checkbox value='burger'>Burger</Checkbox>
+    <Checkbox
+      value='vegetarburger'
+      description='Burgeren er laget av kikerter'
+    >
+      Vegetarburger
+    </Checkbox>
+    <Checkbox value='sushi'>Sushi</Checkbox>
   </Checkbox.Group>
 );
 
 Preview.args = {
-  legend: 'Hvilken iskremsmak er best?',
-  description: 'Velg din favorittsmak blant alternativene.',
+  legend: 'Middag',
+  description: 'Mat servers klokken 18:00',
   readOnly: false,
   disabled: false,
   error: '',
@@ -34,9 +33,9 @@ Preview.args = {
 
 export const Error: StoryFn<typeof Checkbox> = () => (
   <Checkbox.Group
-    legend='Velg pizza (påkreved)'
+    legend='Velg pizza '
     description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
-    error='Du må velge en av våre pizzaer for å legge inn bestilling'
+    error='Du må velge minst en pizza for å legge inn bestilling'
   >
     <Checkbox value='ost'>Bare ost</Checkbox>
     <Checkbox value='Dobbeldekker'>Dobbeldekker</Checkbox>
@@ -60,7 +59,7 @@ export const Controlled: StoryFn<typeof Checkbox> = () => {
         <Paragraph spacing>Du har valgt: {value.toString()}</Paragraph>
       </span>
       <Checkbox.Group
-        legend='Velg pizza (påkreved)'
+        legend='Velg pizza'
         description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
         value={value}
         onChangeValue={(value) => setValue(value)}
@@ -84,7 +83,7 @@ export const ReadOnly = Preview.bind({});
 ReadOnly.args = {
   ...Preview.args,
   readOnly: true,
-  value: ['sjokolade'],
+  value: ['burger'],
 };
 
 export const Disabled = Preview.bind({});
@@ -92,5 +91,5 @@ export const Disabled = Preview.bind({});
 Disabled.args = {
   ...Preview.args,
   disabled: true,
-  value: ['jordbær'],
+  value: ['pizza'],
 };

--- a/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+
+import { Button, Paragraph } from '../../..';
+import { Checkbox } from '../';
+
+export default {
+  title: 'ikke utgitt/Radio/Group',
+  component: Checkbox.Group,
+  parameters: {
+    status: {
+      type: 'beta',
+      url: 'http://www.url.com/status',
+    },
+  },
+} as Meta;
+
+export const Preview: StoryFn<typeof Checkbox.Group> = (args) => (
+  <Checkbox.Group {...args}>
+    <Checkbox value='vanilje'>Vanilje</Checkbox>
+    <Checkbox value='jordbær'>Jordbær</Checkbox>
+    <Checkbox value='sjokolade'>Sjokolade</Checkbox>
+    <Checkbox value='spiser-ikke-is'>Jeg spiser ikke iskrem</Checkbox>
+  </Checkbox.Group>
+);
+
+Preview.args = {
+  legend: 'Hvilken iskremsmak er best?',
+  description: 'Velg din favorittsmak blant alternativene.',
+  readOnly: false,
+  disabled: false,
+  error: '',
+};
+
+export const Error: StoryFn<typeof Checkbox> = () => (
+  <Checkbox.Group
+    legend='Velg pizza (påkreved)'
+    description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
+    error='Du må velge en av våre pizzaer for å legge inn bestilling'
+  >
+    <Checkbox value='ost'>Bare ost</Checkbox>
+    <Checkbox
+      value='Dobbeldekker'
+      description='Chorizo spesial med kokkens luksuskylling'
+    >
+      Dobbeldekker
+    </Checkbox>
+    <Checkbox value='flammen'>Flammen</Checkbox>
+    <Checkbox value='snadder'>Snadder</Checkbox>
+  </Checkbox.Group>
+);
+
+export const Controlled: StoryFn<typeof Checkbox> = () => {
+  const [value, setValue] = useState<string>();
+
+  return (
+    <>
+      <span style={{ display: 'flex', gap: '1rem' }}>
+        <Button onClick={() => setValue('flammen')}>Velg Flammen</Button>
+        <Button onClick={() => setValue('snadder')}>Velg Snadder</Button>
+        <Paragraph spacing>Du har valgt: {value}</Paragraph>
+      </span>
+      <Checkbox.Group
+        legend='Velg pizza (påkreved)'
+        description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      >
+        <Checkbox value='ost'>Bare ost</Checkbox>
+        <Checkbox
+          value='Dobbeldekker'
+          description='Chorizo spesial med kokkens luksuskylling'
+        >
+          Dobbeldekker
+        </Checkbox>
+        <Checkbox value='flammen'>Flammen</Checkbox>
+        <Checkbox value='snadder'>Snadder</Checkbox>
+      </Checkbox.Group>
+    </>
+  );
+};
+
+export const ReadOnly = Preview.bind({});
+
+ReadOnly.args = {
+  ...Preview.args,
+  readOnly: true,
+};
+
+export const Disabled = Preview.bind({});
+
+Disabled.args = {
+  ...Preview.args,
+  disabled: true,
+};

--- a/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
@@ -5,7 +5,7 @@ import { Button, Paragraph } from '../../..';
 import { Checkbox } from '../';
 
 export default {
-  title: 'ikke utgitt/Radio/Group',
+  title: 'ikke utgitt/Checkbox/Group',
   component: Checkbox.Group,
   parameters: {
     status: {

--- a/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
@@ -37,6 +37,7 @@ export const Error: StoryFn<typeof Checkbox> = () => (
     legend='Velg pizza (påkreved)'
     description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
     error='Du må velge en av våre pizzaer for å legge inn bestilling'
+    value={'flammen'}
   >
     <Checkbox value='ost'>Bare ost</Checkbox>
     <Checkbox
@@ -85,6 +86,7 @@ export const ReadOnly = Preview.bind({});
 ReadOnly.args = {
   ...Preview.args,
   readOnly: true,
+  value: 'sjokolade',
 };
 
 export const Disabled = Preview.bind({});
@@ -92,4 +94,5 @@ export const Disabled = Preview.bind({});
 Disabled.args = {
   ...Preview.args,
   disabled: true,
+  value: 'jordbær',
 };

--- a/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
@@ -51,20 +51,24 @@ export const Error: StoryFn<typeof Checkbox> = () => (
 );
 
 export const Controlled: StoryFn<typeof Checkbox> = () => {
-  const [value, setValue] = useState<string>();
+  const [value, setValue] = useState<string[]>([]);
 
+  const myToggle = (val: string) =>
+    setValue(
+      value.includes(val) ? value.filter((x) => x !== val) : [...value, val],
+    );
   return (
     <>
       <span style={{ display: 'flex', gap: '1rem' }}>
-        <Button onClick={() => setValue('flammen')}>Velg Flammen</Button>
-        <Button onClick={() => setValue('snadder')}>Velg Snadder</Button>
-        <Paragraph spacing>Du har valgt: {value}</Paragraph>
+        <Button onClick={() => myToggle('flammen')}>Toggle Flammen</Button>
+        <Button onClick={() => myToggle('snadder')}>Toggle Snadder</Button>
+        <Paragraph spacing>Du har valgt: {value.toString()}</Paragraph>
       </span>
       <Checkbox.Group
         legend='Velg pizza (påkreved)'
         description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChangeValue={(value) => setValue(value as string[])}
       >
         <Checkbox value='ost'>Bare ost</Checkbox>
         <Checkbox

--- a/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { Button, Paragraph } from '../../..';
+import { Button, Label, Paragraph } from '../../..';
 import { Checkbox } from '../';
 
 export default {
@@ -39,12 +39,7 @@ export const Error: StoryFn<typeof Checkbox> = () => (
     error='Du må velge en av våre pizzaer for å legge inn bestilling'
   >
     <Checkbox value='ost'>Bare ost</Checkbox>
-    <Checkbox
-      value='Dobbeldekker'
-      description='Chorizo spesial med kokkens luksuskylling'
-    >
-      Dobbeldekker
-    </Checkbox>
+    <Checkbox value='Dobbeldekker'>Dobbeldekker</Checkbox>
     <Checkbox value='flammen'>Flammen</Checkbox>
     <Checkbox value='snadder'>Snadder</Checkbox>
   </Checkbox.Group>
@@ -68,7 +63,7 @@ export const Controlled: StoryFn<typeof Checkbox> = () => {
         legend='Velg pizza (påkreved)'
         description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
         value={value}
-        onChangeValue={(value) => setValue(value as string[])}
+        onChangeValue={(value) => setValue(value)}
       >
         <Checkbox value='ost'>Bare ost</Checkbox>
         <Checkbox
@@ -89,7 +84,7 @@ export const ReadOnly = Preview.bind({});
 ReadOnly.args = {
   ...Preview.args,
   readOnly: true,
-  value: 'sjokolade',
+  value: ['sjokolade'],
 };
 
 export const Disabled = Preview.bind({});
@@ -97,5 +92,5 @@ export const Disabled = Preview.bind({});
 Disabled.args = {
   ...Preview.args,
   disabled: true,
-  value: 'jordbær',
+  value: ['jordbær'],
 };

--- a/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { Checkbox } from '..';
+
+import { CheckboxGroup } from './Group';
+
+describe('RadioGroup', () => {
+  test('has generated name for Radio children', () => {
+    render(
+      <CheckboxGroup>
+        <Checkbox value='test'>test</Checkbox>
+      </CheckboxGroup>,
+    );
+
+    const radio = screen.getByRole('radio');
+    expect(radio).toHaveAttribute('name');
+  });
+  test('has passed name to Radio children', (): void => {
+    render(
+      <CheckboxGroup name='my name'>
+        <Checkbox value='test'>test</Checkbox>
+      </CheckboxGroup>,
+    );
+
+    const radio = screen.getByRole<HTMLInputElement>('radio');
+    expect(radio.name).toEqual('my name');
+  });
+  test('has passed required to Radio children', (): void => {
+    render(
+      <CheckboxGroup required>
+        <Checkbox value='test'>test</Checkbox>
+      </CheckboxGroup>,
+    );
+
+    const radio = screen.getByRole<HTMLInputElement>('radio');
+    expect(radio).toHaveAttribute('required');
+  });
+  test('has correct Radio defaultChecked & checked when defaultValue is used', () => {
+    render(
+      <CheckboxGroup defaultValue='test2'>
+        <Checkbox value='test1'>test1</Checkbox>
+        <Checkbox value='test2'>test2</Checkbox>
+        <Checkbox value='test3'>test3</Checkbox>
+      </CheckboxGroup>,
+    );
+
+    const radio = screen.getByDisplayValue<HTMLInputElement>('test2');
+    expect(radio.defaultChecked).toBeTruthy();
+    expect(radio.checked).toBeTruthy();
+  });
+  test('has passed clicked Radio element to onChange', async () => {
+    const user = userEvent.setup();
+    let onChangeValue = '';
+
+    render(
+      <CheckboxGroup onChange={(e) => (onChangeValue = e.currentTarget.value)}>
+        <Checkbox value='test1'>test1</Checkbox>
+        <Checkbox value='test2'>test2</Checkbox>
+        <Checkbox value='test3'>test3</Checkbox>
+      </CheckboxGroup>,
+    );
+
+    const radio = screen.getByDisplayValue<HTMLInputElement>('test2');
+
+    await user.click(radio);
+
+    expect(onChangeValue).toEqual('test2');
+    expect(radio.checked).toBeTruthy();
+  });
+});

--- a/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
@@ -36,9 +36,9 @@ describe('CheckboxGroup', () => {
 
     await user.click(checkbox2);
 
-    expect(onChangeValue.includes('test2')).toBeTruthy();
-    expect(onChangeValue.length === 1).toBeTruthy();
-    expect(checkbox2.checked).toBeTruthy();
+    expect(onChangeValue).toContain('test2');
+    expect(onChangeValue).toHaveLength(1);
+    expect(checkbox2).toBeChecked();
   });
 
   test('has removed clicked Checkbox in value passed to onChange', async () => {

--- a/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
@@ -6,38 +6,18 @@ import { Checkbox } from '..';
 
 import { CheckboxGroup } from './Group';
 
-describe('RadioGroup', () => {
-  test('has generated name for Radio children', () => {
-    render(
-      <CheckboxGroup>
-        <Checkbox value='test'>test</Checkbox>
-      </CheckboxGroup>,
-    );
-
-    const radio = screen.getByRole('radio');
-    expect(radio).toHaveAttribute('name');
-  });
-  test('has passed name to Radio children', (): void => {
-    render(
-      <CheckboxGroup name='my name'>
-        <Checkbox value='test'>test</Checkbox>
-      </CheckboxGroup>,
-    );
-
-    const radio = screen.getByRole<HTMLInputElement>('radio');
-    expect(radio.name).toEqual('my name');
-  });
-  test('has passed required to Radio children', (): void => {
+describe('CheckboxGroup', () => {
+  test('has passed required to Checkbox children', (): void => {
     render(
       <CheckboxGroup required>
         <Checkbox value='test'>test</Checkbox>
       </CheckboxGroup>,
     );
 
-    const radio = screen.getByRole<HTMLInputElement>('radio');
-    expect(radio).toHaveAttribute('required');
+    const checkbox = screen.getByRole<HTMLInputElement>('checkbox');
+    expect(checkbox).toHaveAttribute('required');
   });
-  test('has correct Radio defaultChecked & checked when defaultValue is used', () => {
+  test('has correct Checkbox defaultChecked & checked when defaultValue is used', () => {
     render(
       <CheckboxGroup defaultValue='test2'>
         <Checkbox value='test1'>test1</Checkbox>
@@ -46,11 +26,11 @@ describe('RadioGroup', () => {
       </CheckboxGroup>,
     );
 
-    const radio = screen.getByDisplayValue<HTMLInputElement>('test2');
-    expect(radio.defaultChecked).toBeTruthy();
-    expect(radio.checked).toBeTruthy();
+    const checkbox = screen.getByDisplayValue<HTMLInputElement>('test2');
+    expect(checkbox.defaultChecked).toBeTruthy();
+    expect(checkbox.checked).toBeTruthy();
   });
-  test('has passed clicked Radio element to onChange', async () => {
+  test('has passed clicked Checkbox element to onChange', async () => {
     const user = userEvent.setup();
     let onChangeValue = '';
 
@@ -62,11 +42,11 @@ describe('RadioGroup', () => {
       </CheckboxGroup>,
     );
 
-    const radio = screen.getByDisplayValue<HTMLInputElement>('test2');
+    const checkbox = screen.getByDisplayValue<HTMLInputElement>('test2');
 
-    await user.click(radio);
+    await user.click(checkbox);
 
     expect(onChangeValue).toEqual('test2');
-    expect(radio.checked).toBeTruthy();
+    expect(checkbox.checked).toBeTruthy();
   });
 });

--- a/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
@@ -20,23 +20,50 @@ describe('CheckboxGroup', () => {
     expect(checkbox.defaultChecked).toBeTruthy();
     expect(checkbox.checked).toBeTruthy();
   });
-  test('has passed clicked Checkbox element to onChange', async () => {
+  test('has added clicked Checkbox in value passed to onChange', async () => {
     const user = userEvent.setup();
-    let onChangeValue = '';
+    let onChangeValue: string[] = [];
 
     render(
-      <CheckboxGroup onChange={(e) => (onChangeValue = e.currentTarget.value)}>
+      <CheckboxGroup onChange={(value) => (onChangeValue = value)}>
         <Checkbox value='test1'>test1</Checkbox>
         <Checkbox value='test2'>test2</Checkbox>
         <Checkbox value='test3'>test3</Checkbox>
       </CheckboxGroup>,
     );
 
-    const checkbox = screen.getByDisplayValue<HTMLInputElement>('test2');
+    const checkbox2 = screen.getByDisplayValue<HTMLInputElement>('test2');
 
-    await user.click(checkbox);
+    await user.click(checkbox2);
 
-    expect(onChangeValue).toEqual('test2');
-    expect(checkbox.checked).toBeTruthy();
+    expect(onChangeValue.includes('test2')).toBeTruthy();
+    expect(onChangeValue.length === 1).toBeTruthy();
+    expect(checkbox2.checked).toBeTruthy();
+  });
+
+  test('has removed clicked Checkbox in value passed to onChange', async () => {
+    const user = userEvent.setup();
+    let onChangeValue: string[] = [];
+
+    render(
+      <CheckboxGroup onChange={(value) => (onChangeValue = value)}>
+        <Checkbox value='test1'>test1</Checkbox>
+        <Checkbox value='test2'>test2</Checkbox>
+        <Checkbox value='test3'>test3</Checkbox>
+      </CheckboxGroup>,
+    );
+
+    const checkbox2 = screen.getByDisplayValue<HTMLInputElement>('test2');
+
+    await user.click(checkbox2);
+
+    expect(onChangeValue.includes('test2')).toBeTruthy();
+    expect(onChangeValue.length === 1).toBeTruthy();
+    expect(checkbox2.checked).toBeTruthy();
+
+    await user.click(checkbox2);
+
+    expect(onChangeValue.length === 0).toBeTruthy();
+    expect(checkbox2.checked).toBeFalsy();
   });
 });

--- a/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
@@ -57,13 +57,13 @@ describe('CheckboxGroup', () => {
 
     await user.click(checkbox2);
 
-    expect(onChangeValue.includes('test2')).toBeTruthy();
-    expect(onChangeValue.length === 1).toBeTruthy();
-    expect(checkbox2.checked).toBeTruthy();
+    expect(onChangeValue).toContain('test2');
+    expect(onChangeValue).toHaveLength(1);
+    expect(checkbox2).toBeChecked();
 
     await user.click(checkbox2);
 
-    expect(onChangeValue.length === 0).toBeTruthy();
-    expect(checkbox2.checked).toBeFalsy();
+    expect(onChangeValue).toHaveLength(0);
+    expect(checkbox2).not.toBeChecked();
   });
 });

--- a/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
@@ -7,19 +7,9 @@ import { Checkbox } from '..';
 import { CheckboxGroup } from './Group';
 
 describe('CheckboxGroup', () => {
-  test('has passed required to Checkbox children', (): void => {
-    render(
-      <CheckboxGroup required>
-        <Checkbox value='test'>test</Checkbox>
-      </CheckboxGroup>,
-    );
-
-    const checkbox = screen.getByRole<HTMLInputElement>('checkbox');
-    expect(checkbox).toHaveAttribute('required');
-  });
   test('has correct Checkbox defaultChecked & checked when defaultValue is used', () => {
     render(
-      <CheckboxGroup defaultValue='test2'>
+      <CheckboxGroup defaultValue={['test2']}>
         <Checkbox value='test1'>test1</Checkbox>
         <Checkbox value='test2'>test2</Checkbox>
         <Checkbox value='test3'>test3</Checkbox>

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -54,7 +54,9 @@ export const CheckboxGroup = forwardRef<
         ? currentValue.filter((x) => x !== checkboxValue)
         : [...currentValue, checkboxValue];
 
-      value ?? setInternalValue(updatedValue);
+      if (typeof value !== 'undefined' || value !== null) {
+        setInternalValue(updatedValue);
+      }
       onChange?.(updatedValue);
     };
 

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -26,6 +26,8 @@ export type CheckboxGroupProps = {
   defaultValue?: ReadonlyArray<string | number>;
   /** Callback event with changed `Checkbox` */
   onChange?: ChangeEventHandler<HTMLInputElement>;
+  /** Callback event with changed balue */
+  onChangeValue?: (value: Array<string | number>) => void;
   /** Toggle if collection of `Checkbox` are required  */
   required?: boolean;
 } & Omit<FieldsetProps, 'onChange'>;
@@ -42,6 +44,7 @@ export const CheckboxGroup = forwardRef<
       readOnly,
       defaultValue,
       size = 'medium',
+      onChangeValue,
       ...rest
     },
     ref,
@@ -51,12 +54,15 @@ export const CheckboxGroup = forwardRef<
     >(defaultValue ?? []);
 
     const toggleValue: CheckboxGroupContextProps['toggleValue'] = (value) => {
-      const updatedCheckedValues = checkedValues.includes(value)
-        ? checkedValues.filter((x) => x !== value)
-        : [...checkedValues, value];
+      const newValue = value ?? checkedValues;
+      const updatedCheckedValues = checkedValues.includes(newValue)
+        ? checkedValues.filter((x) => x !== newValue)
+        : [...checkedValues, newValue];
 
       setCheckedValues(updatedCheckedValues);
+      onChangeValue?.(updatedCheckedValues);
     };
+
     return (
       <Fieldset
         {...rest}

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -9,9 +9,9 @@ import type { CheckboxProps } from '../Checkbox';
 import classes from './Group.module.css';
 
 export type CheckboxGroupContextProps = {
-  value?: ReadonlyArray<string | number>;
-  defaultValue?: ReadonlyArray<string | number>;
-  toggleValue: (value: string | number) => void;
+  value?: string[];
+  defaultValue?: string[];
+  toggleValue: (value: string) => void;
 } & Pick<CheckboxProps, 'onChange'>;
 
 export const CheckboxGroupContext =
@@ -20,16 +20,14 @@ export const CheckboxGroupContext =
 export type CheckboxGroupProps = {
   /** Collection of `Checkbox` components */
   children?: ReactNode;
-  /** Controlled state for `Checkbox` */
-  value?: ReadonlyArray<string | number>;
-  /** Default checked `Checkbox` */
-  defaultValue?: ReadonlyArray<string | number>;
-  /** Callback event with changed `Checkbox` */
+  /** Controlled state for  `Checkbox`'s */
+  value?: string[];
+  /** Default checked `Checkbox`'s */
+  defaultValue?: string[];
+  /** Callback event with changed `Checkbox` element */
   onChange?: ChangeEventHandler<HTMLInputElement>;
-  /** Callback event with changed balue */
-  onChangeValue?: (value: Array<string | number>) => void;
-  /** Toggle if collection of `Checkbox` are required  */
-  required?: boolean;
+  /** Callback event with changed value */
+  onChangeValue?: (value: string[]) => void;
 } & Omit<FieldsetProps, 'onChange'>;
 
 export const CheckboxGroup = forwardRef<
@@ -49,18 +47,20 @@ export const CheckboxGroup = forwardRef<
     },
     ref,
   ) => {
-    const [checkedValues, setCheckedValues] = useState<
-      ReadonlyArray<string | number>
-    >(defaultValue ?? []);
+    const [internalValue, setInternalValue] = useState<string[]>(
+      defaultValue ?? [],
+    );
 
-    const toggleValue: CheckboxGroupContextProps['toggleValue'] = (value) => {
-      const newValue = value ?? checkedValues;
-      const updatedCheckedValues = checkedValues.includes(newValue)
-        ? checkedValues.filter((x) => x !== newValue)
-        : [...checkedValues, newValue];
+    const toggleValue: CheckboxGroupContextProps['toggleValue'] = (
+      checkboxValue,
+    ) => {
+      const currentValue = value ?? internalValue;
+      const updatedValue = currentValue.includes(checkboxValue)
+        ? currentValue.filter((x) => x !== checkboxValue)
+        : [...currentValue, checkboxValue];
 
-      setCheckedValues(updatedCheckedValues);
-      onChangeValue?.(updatedCheckedValues);
+      value ?? setInternalValue(updatedValue);
+      onChangeValue?.(updatedValue);
     };
 
     return (

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -1,0 +1,71 @@
+import type { ChangeEventHandler, ReactNode } from 'react';
+import React, { forwardRef, createContext } from 'react';
+import cn from 'classnames';
+
+import type { FieldsetProps } from '../../Fieldset';
+import { Fieldset } from '../../Fieldset';
+import type { CheckboxProps } from '../Checkbox';
+
+import classes from './Group.module.css';
+
+export type CheckboxGroupContextProps = {
+  value?: string | ReadonlyArray<string> | number;
+  defaultValue?: string | ReadonlyArray<string> | number;
+  required?: boolean;
+} & Pick<CheckboxProps, 'onChange'>;
+
+export const CheckboxGroupContext =
+  createContext<CheckboxGroupContextProps | null>(null);
+
+export type CheckboxGroupProps = {
+  /** Collection of `Checkbox` components */
+  children?: ReactNode;
+  /** Controlled state for `Checkbox` */
+  value?: string | ReadonlyArray<string> | number;
+  /** Default checked `Checkbox` */
+  defaultValue?: string | ReadonlyArray<string> | number;
+  /** Callback event with changed `Checkbox` */
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  /** Toggle if collection of `Checkbox` are required  */
+  required?: boolean;
+} & Omit<FieldsetProps, 'onChange'>;
+
+export const CheckboxGroup = forwardRef<
+  HTMLFieldSetElement,
+  CheckboxGroupProps
+>(
+  (
+    {
+      onChange,
+      children,
+      value,
+      readOnly,
+      defaultValue,
+      size = 'medium',
+      required,
+      ...rest
+    },
+    ref,
+  ) => {
+    return (
+      <Fieldset
+        {...rest}
+        readOnly={readOnly}
+        size={size}
+        className={cn(rest.className)}
+        ref={ref}
+      >
+        <CheckboxGroupContext.Provider
+          value={{
+            value,
+            defaultValue,
+            onChange,
+            required,
+          }}
+        >
+          <div className={cn(classes[size])}>{children}</div>
+        </CheckboxGroupContext.Provider>
+      </Fieldset>
+    );
+  },
+);

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -1,9 +1,8 @@
-import type { ChangeEventHandler, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import React, { useState, forwardRef, createContext } from 'react';
 
 import type { FieldsetProps } from '../../Fieldset';
 import { Fieldset } from '../../Fieldset';
-import type { CheckboxProps } from '../Checkbox';
 
 import classes from './Group.module.css';
 
@@ -11,7 +10,7 @@ export type CheckboxGroupContextProps = {
   value?: string[];
   defaultValue?: string[];
   toggleValue: (value: string) => void;
-} & Pick<CheckboxProps, 'onChange'>;
+};
 
 export const CheckboxGroupContext =
   createContext<CheckboxGroupContextProps | null>(null);
@@ -23,10 +22,8 @@ export type CheckboxGroupProps = {
   value?: string[];
   /** Default checked `Checkbox`'s */
   defaultValue?: string[];
-  /** Callback event with changed `Checkbox` element */
-  onChange?: ChangeEventHandler<HTMLInputElement>;
-  /** Callback event with changed value */
-  onChangeValue?: (value: string[]) => void;
+  /** Callback event with checked `Checkbox` values */
+  onChange?: (value: string[]) => void;
 } & Omit<FieldsetProps, 'onChange'>;
 
 export const CheckboxGroup = forwardRef<
@@ -41,7 +38,6 @@ export const CheckboxGroup = forwardRef<
       readOnly,
       defaultValue,
       size = 'medium',
-      onChangeValue,
       ...rest
     },
     ref,
@@ -59,7 +55,7 @@ export const CheckboxGroup = forwardRef<
         : [...currentValue, checkboxValue];
 
       value ?? setInternalValue(updatedValue);
-      onChangeValue?.(updatedValue);
+      onChange?.(updatedValue);
     };
 
     return (
@@ -73,7 +69,6 @@ export const CheckboxGroup = forwardRef<
           value={{
             value,
             defaultValue,
-            onChange,
             toggleValue,
           }}
         >

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -1,6 +1,5 @@
 import type { ChangeEventHandler, ReactNode } from 'react';
 import React, { useState, forwardRef, createContext } from 'react';
-import cn from 'classnames';
 
 import type { FieldsetProps } from '../../Fieldset';
 import { Fieldset } from '../../Fieldset';
@@ -78,7 +77,7 @@ export const CheckboxGroup = forwardRef<
             toggleValue,
           }}
         >
-          <div className={cn(classes[size])}>{children}</div>
+          <div className={classes[size]}>{children}</div>
         </CheckboxGroupContext.Provider>
       </Fieldset>
     );

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -52,7 +52,6 @@ export const CheckboxGroup = forwardRef<
         {...rest}
         readOnly={readOnly}
         size={size}
-        className={cn(rest.className)}
         ref={ref}
       >
         <CheckboxGroupContext.Provider

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEventHandler, ReactNode } from 'react';
-import React, { forwardRef, createContext } from 'react';
+import React, { useState, forwardRef, createContext } from 'react';
 import cn from 'classnames';
 
 import type { FieldsetProps } from '../../Fieldset';
@@ -9,9 +9,9 @@ import type { CheckboxProps } from '../Checkbox';
 import classes from './Group.module.css';
 
 export type CheckboxGroupContextProps = {
-  value?: string | ReadonlyArray<string> | number;
-  defaultValue?: string | ReadonlyArray<string> | number;
-  required?: boolean;
+  value?: ReadonlyArray<string | number>;
+  defaultValue?: ReadonlyArray<string | number>;
+  toggleValue: (value: string | number) => void;
 } & Pick<CheckboxProps, 'onChange'>;
 
 export const CheckboxGroupContext =
@@ -21,9 +21,9 @@ export type CheckboxGroupProps = {
   /** Collection of `Checkbox` components */
   children?: ReactNode;
   /** Controlled state for `Checkbox` */
-  value?: string | ReadonlyArray<string> | number;
+  value?: ReadonlyArray<string | number>;
   /** Default checked `Checkbox` */
-  defaultValue?: string | ReadonlyArray<string> | number;
+  defaultValue?: ReadonlyArray<string | number>;
   /** Callback event with changed `Checkbox` */
   onChange?: ChangeEventHandler<HTMLInputElement>;
   /** Toggle if collection of `Checkbox` are required  */
@@ -42,11 +42,21 @@ export const CheckboxGroup = forwardRef<
       readOnly,
       defaultValue,
       size = 'medium',
-      required,
       ...rest
     },
     ref,
   ) => {
+    const [checkedValues, setCheckedValues] = useState<
+      ReadonlyArray<string | number>
+    >(defaultValue ?? []);
+
+    const toggleValue: CheckboxGroupContextProps['toggleValue'] = (value) => {
+      const updatedCheckedValues = checkedValues.includes(value)
+        ? checkedValues.filter((x) => x !== value)
+        : [...checkedValues, value];
+
+      setCheckedValues(updatedCheckedValues);
+    };
     return (
       <Fieldset
         {...rest}
@@ -59,7 +69,7 @@ export const CheckboxGroup = forwardRef<
             value,
             defaultValue,
             onChange,
-            required,
+            toggleValue,
           }}
         >
           <div className={cn(classes[size])}>{children}</div>

--- a/packages/react/src/components/form/Checkbox/Group/index.ts
+++ b/packages/react/src/components/form/Checkbox/Group/index.ts
@@ -1,0 +1,1 @@
+export * from './Group';

--- a/packages/react/src/components/form/Checkbox/index.ts
+++ b/packages/react/src/components/form/Checkbox/index.ts
@@ -1,0 +1,27 @@
+import type { CheckboxProps } from './Checkbox';
+import type { CheckboxGroupProps } from './Group';
+import { Checkbox as CheckboxParent } from './Checkbox';
+import { CheckboxGroup } from './Group';
+
+type CheckboxComponent = typeof CheckboxParent & {
+  /**
+   * Grouping  multiple `Radio` together.
+   * @example
+   * <Radio.Group legend="Are you 18 years or older?">
+   *    <Radio value="Yes">Yes</Radio>
+   *    <Radio value="No">No</Radio>
+   * </Radio.Group>
+   */
+  Group: typeof CheckboxGroup;
+};
+
+/** `<input> element with `type="radio"` used for selecting one option */
+const Checkbox = CheckboxParent as CheckboxComponent;
+
+Checkbox.Group = CheckboxGroup;
+
+Checkbox.Group.displayName = 'Checkbox.Group';
+
+export type { CheckboxProps, CheckboxGroupProps };
+
+export { Checkbox };

--- a/packages/react/src/components/form/Checkbox/index.ts
+++ b/packages/react/src/components/form/Checkbox/index.ts
@@ -5,12 +5,14 @@ import { CheckboxGroup } from './Group';
 
 type CheckboxComponent = typeof CheckboxParent & {
   /**
-   * Grouping  multiple `Radio` together.
+   * Grouping  multiple `Checkbox` together.
    * @example
-   * <Radio.Group legend="Are you 18 years or older?">
-   *    <Radio value="Yes">Yes</Radio>
-   *    <Radio value="No">No</Radio>
-   * </Radio.Group>
+   * <Checkbox.Group legend="What would your D&D party like to eat?">
+   *    <Checkbox value="elfsalad">Wood Elf forest salad</Checkbox>
+   *    <Checkbox value="firecakes">Fire breath rice cakes</Checkbox>
+   *    <Checkbox value="dumplings">Chicken-something dumplings</Checkbox>
+   *    <Checkbox value="ribs">Sembian honey-glazed rothè ribs</Checkbox>
+   * </Checkbox.Group>
    */
   Group: typeof CheckboxGroup;
 };

--- a/packages/react/src/components/form/Checkbox/index.ts
+++ b/packages/react/src/components/form/Checkbox/index.ts
@@ -15,7 +15,7 @@ type CheckboxComponent = typeof CheckboxParent & {
   Group: typeof CheckboxGroup;
 };
 
-/** `<input> element with `type="radio"` used for selecting one option */
+/** `<input> element with `type="checkbox"` used for selecting one option */
 const Checkbox = CheckboxParent as CheckboxComponent;
 
 Checkbox.Group = CheckboxGroup;

--- a/packages/react/src/components/form/Checkbox/useCheckbox.ts
+++ b/packages/react/src/components/form/Checkbox/useCheckbox.ts
@@ -53,7 +53,6 @@ export const useCheckbox: UseCheckbox = (props) => {
           return;
         }
         props?.onChange?.(e);
-        checkboxGroup?.onChange?.(e);
         checkboxGroup?.toggleValue(props.value);
       },
     },

--- a/packages/react/src/components/form/Checkbox/useCheckbox.ts
+++ b/packages/react/src/components/form/Checkbox/useCheckbox.ts
@@ -22,7 +22,7 @@ type UseCheckbox = (props: CheckboxProps) => FormField & {
 };
 /** Handles props for `Checkbox` in context with `Radio.Group` (and `Fieldset`) */
 export const useCheckbox: UseCheckbox = (props) => {
-  const radioGroup = useContext(CheckboxGroupContext);
+  const checkboxGroup = useContext(CheckboxGroupContext);
   const { inputProps, readOnly, ...rest } = useFormField(props, 'radio');
 
   return {
@@ -31,16 +31,16 @@ export const useCheckbox: UseCheckbox = (props) => {
     inputProps: {
       ...inputProps,
       readOnly,
-      type: 'radio',
-      required: radioGroup?.required,
+      type: 'checkbox',
+      required: checkboxGroup?.required,
       defaultChecked:
-        radioGroup?.defaultValue === undefined
+        checkboxGroup?.defaultValue === undefined
           ? undefined
-          : radioGroup?.defaultValue === props.value,
+          : checkboxGroup?.defaultValue === props.value,
       checked:
-        radioGroup?.value === undefined
+        checkboxGroup?.value === undefined
           ? undefined
-          : radioGroup?.value === props.value,
+          : checkboxGroup?.value === props.value,
       onClick: (e) => {
         if (readOnly) {
           e.preventDefault();
@@ -54,7 +54,7 @@ export const useCheckbox: UseCheckbox = (props) => {
           return;
         }
         props?.onChange?.(e);
-        radioGroup?.onChange?.(e);
+        checkboxGroup?.onChange?.(e);
       },
     },
   };

--- a/packages/react/src/components/form/Checkbox/useCheckbox.ts
+++ b/packages/react/src/components/form/Checkbox/useCheckbox.ts
@@ -32,15 +32,14 @@ export const useCheckbox: UseCheckbox = (props) => {
       ...inputProps,
       readOnly,
       type: 'checkbox',
-      required: checkboxGroup?.required,
       defaultChecked:
         checkboxGroup?.defaultValue === undefined
           ? undefined
-          : checkboxGroup?.defaultValue === props.value,
+          : checkboxGroup?.defaultValue.includes(props.value),
       checked:
         checkboxGroup?.value === undefined
           ? undefined
-          : checkboxGroup?.value === props.value,
+          : checkboxGroup?.value.includes(props.value),
       onClick: (e) => {
         if (readOnly) {
           e.preventDefault();
@@ -55,6 +54,7 @@ export const useCheckbox: UseCheckbox = (props) => {
         }
         props?.onChange?.(e);
         checkboxGroup?.onChange?.(e);
+        checkboxGroup?.toggleValue(e.target.value);
       },
     },
   };

--- a/packages/react/src/components/form/Checkbox/useCheckbox.ts
+++ b/packages/react/src/components/form/Checkbox/useCheckbox.ts
@@ -54,7 +54,7 @@ export const useCheckbox: UseCheckbox = (props) => {
         }
         props?.onChange?.(e);
         checkboxGroup?.onChange?.(e);
-        checkboxGroup?.toggleValue(e.target.value);
+        checkboxGroup?.toggleValue(props.value);
       },
     },
   };

--- a/packages/react/src/components/form/Checkbox/useCheckbox.ts
+++ b/packages/react/src/components/form/Checkbox/useCheckbox.ts
@@ -20,7 +20,7 @@ type UseCheckbox = (props: CheckboxProps) => FormField & {
     | 'onChange'
   >;
 };
-/** Handles props for `Checkbox` in context with `Radio.Group` (and `Fieldset`) */
+/** Handles props for `Checkbox` in context with `Checkbox.Group` (and `Fieldset`) */
 export const useCheckbox: UseCheckbox = (props) => {
   const checkboxGroup = useContext(CheckboxGroupContext);
   const { inputProps, readOnly, ...rest } = useFormField(props, 'radio');

--- a/packages/react/src/components/form/Checkbox/useCheckbox.ts
+++ b/packages/react/src/components/form/Checkbox/useCheckbox.ts
@@ -1,0 +1,61 @@
+import type { InputHTMLAttributes } from 'react';
+import { useContext } from 'react';
+
+import type { FormField } from '../useFormField';
+import { useFormField } from '../useFormField';
+
+import type { CheckboxProps } from './Checkbox';
+import { CheckboxGroupContext } from './Group';
+
+type UseCheckbox = (props: CheckboxProps) => FormField & {
+  inputProps?: Pick<
+    InputHTMLAttributes<HTMLInputElement>,
+    | 'readOnly'
+    | 'type'
+    | 'name'
+    | 'required'
+    | 'defaultChecked'
+    | 'checked'
+    | 'onClick'
+    | 'onChange'
+  >;
+};
+/** Handles props for `Checkbox` in context with `Radio.Group` (and `Fieldset`) */
+export const useCheckbox: UseCheckbox = (props) => {
+  const radioGroup = useContext(CheckboxGroupContext);
+  const { inputProps, readOnly, ...rest } = useFormField(props, 'radio');
+
+  return {
+    ...rest,
+    readOnly,
+    inputProps: {
+      ...inputProps,
+      readOnly,
+      type: 'radio',
+      required: radioGroup?.required,
+      defaultChecked:
+        radioGroup?.defaultValue === undefined
+          ? undefined
+          : radioGroup?.defaultValue === props.value,
+      checked:
+        radioGroup?.value === undefined
+          ? undefined
+          : radioGroup?.value === props.value,
+      onClick: (e) => {
+        if (readOnly) {
+          e.preventDefault();
+          return;
+        }
+        props?.onClick?.(e);
+      },
+      onChange: (e) => {
+        if (readOnly) {
+          e.preventDefault();
+          return;
+        }
+        props?.onChange?.(e);
+        radioGroup?.onChange?.(e);
+      },
+    },
+  };
+};

--- a/packages/react/src/components/form/Checkbox/useCheckbox.ts
+++ b/packages/react/src/components/form/Checkbox/useCheckbox.ts
@@ -23,7 +23,7 @@ type UseCheckbox = (props: CheckboxProps) => FormField & {
 /** Handles props for `Checkbox` in context with `Checkbox.Group` (and `Fieldset`) */
 export const useCheckbox: UseCheckbox = (props) => {
   const checkboxGroup = useContext(CheckboxGroupContext);
-  const { inputProps, readOnly, ...rest } = useFormField(props, 'radio');
+  const { inputProps, readOnly, ...rest } = useFormField(props, 'checkbox');
 
   return {
     ...rest,

--- a/packages/react/src/components/form/Fieldset/Fieldset.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.tsx
@@ -4,6 +4,7 @@ import cn from 'classnames';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 
 import { Label, Paragraph, ErrorMessage } from '../../Typography';
+import utilityclasses from '../../../utils/utility.module.css';
 
 import { useFieldset } from './useFieldset';
 import classes from './Fieldset.module.css';
@@ -32,11 +33,13 @@ export type FieldsetProps = {
   /** Toggle `readOnly` on fieldset context.
    * @note This does not prevent fieldset values from being submited */
   readOnly?: boolean;
+  /** Visually hide `legend` and `description` (still available for screen readers)  */
+  hideLegend?: boolean;
 } & FieldsetHTMLAttributes<HTMLFieldSetElement>;
 
 export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
   (props, ref) => {
-    const { children, legend, description, error, ...rest } = props;
+    const { children, legend, description, error, hideLegend, ...rest } = props;
 
     const { fieldsetProps, size, readOnly, errorId, hasError, descriptionId } =
       useFieldset(props);
@@ -67,7 +70,10 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
           <Label
             as='legend'
             size={size}
-            className={classes.legend}
+            className={cn(
+              classes.legend,
+              hideLegend && utilityclasses.visuallyHidden,
+            )}
           >
             {readOnly && (
               <PadlockLockedFillIcon
@@ -80,7 +86,10 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
           {description && (
             <Paragraph
               id={descriptionId}
-              className={classes.description}
+              className={cn(
+                classes.description,
+                hideLegend && utilityclasses.visuallyHidden,
+              )}
               size={size}
               as='div'
               short

--- a/packages/react/src/components/form/useFormField.test.tsx
+++ b/packages/react/src/components/form/useFormField.test.tsx
@@ -14,11 +14,24 @@ const createWrapper = (Wrapper: typeof Fieldset, props?: FieldsetProps) => {
 };
 
 describe('useFormField', () => {
-  test('has correct error props', () => {
+  test('has correct error props when error is string', () => {
     const { result } = renderHook(
       () => useFormField({ error: 'error' }, 'test'),
       { wrapper: createWrapper(Fieldset) },
     );
+
+    const field = result.current;
+
+    expect(field.hasError).toBeTruthy();
+    expect(field.errorId).toBeDefined();
+    expect(field.inputProps['aria-invalid']).toBeTruthy();
+    expect(field.inputProps['aria-describedby']).toEqual(field.errorId);
+  });
+
+  test('has correct error props when error is boolean', () => {
+    const { result } = renderHook(() => useFormField({ error: true }, 'test'), {
+      wrapper: createWrapper(Fieldset),
+    });
 
     const field = result.current;
 


### PR DESCRIPTION
resolves #630 
- New `Checkbox` component
- Added `hideLabel` to `Fieldset` which visually hides `legend` and `description`. This features is enabled for both `Checkbox.Group` and `Radio.Group`
- Did some changes to `Radio` to conform #691   
- Updated `label` to use regular font weight to Figma and have a distinction from `legend`