### PR TITLE
refactor(Radio): :recycle: Changes to `Radio` to conform with new `Checkbox`

### DIFF
--- a/packages/react/src/components/form/Radio/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Radio/Group/Group.stories.tsx
@@ -69,7 +69,7 @@ export const Controlled: StoryFn<typeof Radio> = () => {
         legend='Velg pizza (påkreved)'
         description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(v) => setValue(v)}
       >
         <Radio value='ost'>Bare ost</Radio>
         <Radio

--- a/packages/react/src/components/form/Radio/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Radio/Group/Group.stories.tsx
@@ -69,7 +69,7 @@ export const Controlled: StoryFn<typeof Radio> = () => {
         legend='Velg pizza (påkreved)'
         description='Alle pizzaene er laget på våre egne nybakte bunner og serveres med kokkens egen osteblanding og tomatsaus.'
         value={value}
-        onChange={(v) => setValue(v)}
+        onChange={setValue}
       >
         <Radio value='ost'>Bare ost</Radio>
         <Radio

--- a/packages/react/src/components/form/Radio/Group/Group.test.tsx
+++ b/packages/react/src/components/form/Radio/Group/Group.test.tsx
@@ -55,7 +55,7 @@ describe('RadioGroup', () => {
     let onChangeValue = '';
 
     render(
-      <RadioGroup onChange={(e) => (onChangeValue = e.currentTarget.value)}>
+      <RadioGroup onChange={(value) => (onChangeValue = value)}>
         <Radio value='test1'>test1</Radio>
         <Radio value='test2'>test2</Radio>
         <Radio value='test3'>test3</Radio>

--- a/packages/react/src/components/form/Radio/Group/Group.tsx
+++ b/packages/react/src/components/form/Radio/Group/Group.tsx
@@ -1,10 +1,9 @@
-import type { ChangeEventHandler, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import React, { forwardRef, createContext, useId } from 'react';
 import cn from 'classnames';
 
 import type { FieldsetProps } from '../../Fieldset';
 import { Fieldset } from '../../Fieldset';
-import type { RadioProps } from '../Radio';
 
 import classes from './Group.module.css';
 
@@ -13,7 +12,8 @@ export type RadioGroupContextProps = {
   value?: string | ReadonlyArray<string> | number;
   defaultValue?: string | ReadonlyArray<string> | number;
   required?: boolean;
-} & Pick<RadioProps, 'onChange'>;
+  onChange?: (value: string) => void;
+};
 
 export const RadioGroupContext = createContext<RadioGroupContextProps | null>(
   null,
@@ -26,8 +26,8 @@ export type RadioGroupProps = {
   value?: string | ReadonlyArray<string> | number;
   /** Default checked `Radio` */
   defaultValue?: string | ReadonlyArray<string> | number;
-  /** Callback event with changed `Radio` */
-  onChange?: ChangeEventHandler<HTMLInputElement>;
+  /** Callback event with checked `Radio` value */
+  onChange?: (value: string) => void;
   /** Toggle if collection of `Radio` are required  */
   required?: boolean;
   /** Orientation of `Radio` components.

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -26,21 +26,6 @@
   cursor: pointer;
 }
 
-.label.medium {
-  font: var(--fds-typography-label-radio_and_checkbox-medium);
-  font-family: inherit;
-}
-
-.label.small {
-  font: var(--fds-typography-label-radio_and_checkbox-small);
-  font-family: inherit;
-}
-
-.label.xsmall {
-  font: var(--fds-typography-label-radio_and_checkbox-xsmall);
-  font-family: inherit;
-}
-
 .description {
   padding-left: 3px;
   margin-top: calc(var(--fds-spacing-2) * -1);

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -26,6 +26,21 @@
   cursor: pointer;
 }
 
+.label.medium {
+  font: var(--fds-typography-label-radio_and_checkbox-medium);
+  font-family: inherit;
+}
+
+.label.small {
+  font: var(--fds-typography-label-radio_and_checkbox-small);
+  font-family: inherit;
+}
+
+.label.xsmall {
+  font: var(--fds-typography-label-radio_and_checkbox-xsmall);
+  font-family: inherit;
+}
+
 .description {
   padding-left: 3px;
   margin-top: calc(var(--fds-spacing-2) * -1);

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -44,7 +44,7 @@ export type RadioProps = {
   /** Radio label */
   children?: ReactNode;
   /** Value of the `input` element */
-  value: string | ReadonlyArray<string> | number | undefined;
+  value: string;
 } & Omit<FormFieldProps, 'error' | 'errorId'> &
   Omit<InputHTMLAttributes<HTMLInputElement>, 'size' | 'value'>;
 

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -82,7 +82,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
 
       {children && (
         <Label
-          className={cn(classes.label)}
+          className={classes.label}
           htmlFor={inputProps.id}
           size={size}
           weight='regular'

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -82,9 +82,10 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
 
       {children && (
         <Label
-          className={cn(classes.label, classes[size])}
+          className={cn(classes.label)}
           htmlFor={inputProps.id}
           size={size}
+          weight='regular'
         >
           <span>{children}</span>
         </Label>

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -50,8 +50,13 @@ export type RadioProps = {
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
   const { children, description, ...rest } = props;
-  const { inputProps, descriptionId, hasError, size, readOnly } =
-    useRadio(props);
+  const {
+    inputProps,
+    descriptionId,
+    hasError,
+    size = 'medium',
+    readOnly,
+  } = useRadio(props);
 
   return (
     <Paragraph
@@ -77,7 +82,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
 
       {children && (
         <Label
-          className={classes.label}
+          className={cn(classes.label, classes[size])}
           htmlFor={inputProps.id}
           size={size}
         >

--- a/packages/react/src/components/form/Radio/useRadio.ts
+++ b/packages/react/src/components/form/Radio/useRadio.ts
@@ -55,7 +55,7 @@ export const useRadio: UseRadio = (props) => {
           return;
         }
         props?.onChange?.(e);
-        radioGroup?.onChange?.(e);
+        radioGroup?.onChange?.(props.value);
       },
     },
   };


### PR DESCRIPTION
- Changed `onChange` in `Radio.Group` to return just value. Users can use `onChange` on `Radio` to get change event if needed
- Updated `label` to use regular font weight to Figma and have a distinction from `legend`