### PR TITLE
docs: :fire: Remove Storybook status badge

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -6,7 +6,6 @@ const config: StorybookConfig = {
     '@storybook/addon-a11y',
     '@storybook/addon-links',
     '@storybook/addon-interactions',
-    '@etchteam/storybook-addon-status',
     '@storybook/addon-essentials',
     '@etchteam/storybook-addon-css-variables-theme',
     {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -34,20 +34,6 @@ const viewports: Viewport[] = metadata.tokenSetOrder
 const preview: Preview = {
   decorators: [cssVariablesTheme],
   parameters: {
-    status: {
-      statuses: {
-        new: {
-          background: '#0000ff',
-          color: '#ffffff',
-          description: 'This component is stable and released',
-        },
-        beta: {
-          background: '#6544c5',
-          color: '#ffffff',
-          description: 'This component is stable and released',
-        },
-      },
-    },
     cssVariables: {
       files: {
         Altinn: altinn,

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@digdir/design-system-react": "*",
     "@digdir/design-system-tokens": "*",
     "@etchteam/storybook-addon-css-variables-theme": "^1.5.1",
-    "@etchteam/storybook-addon-status": "^4.2.2",
     "@next/eslint-plugin-next": "^13.2.4",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-image": "^3.0.1",

--- a/packages/react/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react/src/components/Accordion/Accordion.stories.tsx
@@ -7,10 +7,6 @@ export default {
   title: 'Kjernekomponenter/Accordion',
   component: Accordion,
   parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
     layout: 'padded',
   },
 } as Meta;

--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -12,10 +12,6 @@ export default {
   title: 'Kjernekomponenter/Alert',
   component: Alert,
   parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
     layout: 'padded',
   },
 } as Meta;

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -13,12 +13,6 @@ type Story = StoryObj<typeof Button>;
 const meta: Meta<typeof Button> = {
   title: 'Kjernekomponenter/Button',
   component: Button,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 };
 
 export default meta;

--- a/packages/react/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.tsx
@@ -8,12 +8,6 @@ type Story = StoryObj<typeof Checkbox>;
 export default {
   title: 'Utgår/Checkbox',
   component: Checkbox,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 } as Meta;
 
 export const Preview: Story = {

--- a/packages/react/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
+++ b/packages/react/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
@@ -7,12 +7,6 @@ import { ArgsTable } from '@storybook/addon-docs';
 <Meta
   title='Utgår/CheckboxGroup'
   component={CheckboxGroup}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
   argTypes={{
     items: {
       description: 'Liste over valg som skal vises.',

--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -7,12 +7,6 @@ type Story = StoryObj<typeof Chip.Toggle>;
 export default {
   title: 'Kjernekomponenter/Chip',
   component: Chip.Toggle,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 } as Meta;
 
 export const Preview: Story = {

--- a/packages/react/src/components/FieldSet/FieldSet.stories.tsx
+++ b/packages/react/src/components/FieldSet/FieldSet.stories.tsx
@@ -8,12 +8,6 @@ import { FieldSet } from './FieldSet';
 export default {
   title: 'Utgår/FieldSet',
   component: FieldSet,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 } as Meta;
 
 export const Eksempel: StoryFn<typeof FieldSet> = (args) => (

--- a/packages/react/src/components/HelpText/HelpText.stories.mdx
+++ b/packages/react/src/components/HelpText/HelpText.stories.mdx
@@ -7,12 +7,6 @@ import { ArgsTable } from '@storybook/addon-docs';
 <Meta
   title='Kjernekomponenter/HelpText'
   component={HelpText}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
   argTypes={{
     children: {
       description: 'Innholdet som vises i hjelpeteksten.',

--- a/packages/react/src/components/List/List.stories.tsx
+++ b/packages/react/src/components/List/List.stories.tsx
@@ -7,12 +7,6 @@ import { List, ListItem } from '.';
 const meta: Meta<typeof List> = {
   title: 'Kjernekomponenter/List',
   component: List,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
   args: {
     // Just to make the default option pre-selected i <Controls />
     borderStyle: 'solid',

--- a/packages/react/src/components/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/react/src/components/NativeSelect/NativeSelect.stories.tsx
@@ -7,10 +7,6 @@ export default {
   title: 'Kjernekomponenter/NativeSelect',
   component: NativeSelect,
   parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
     layout: 'padded',
   },
 } as Meta;

--- a/packages/react/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/Pagination/Pagination.stories.tsx
@@ -6,12 +6,6 @@ import { Pagination } from '.';
 export default {
   title: 'Kjernekomponenter/Pagination',
   component: Pagination,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 } as Meta;
 
 export const Preview: StoryFn<typeof Pagination> = (args) => {

--- a/packages/react/src/components/Popover/Popover.stories.mdx
+++ b/packages/react/src/components/Popover/Popover.stories.mdx
@@ -9,13 +9,8 @@ import { ArgsTable } from '@storybook/addon-docs';
 <Meta
   title='Kjernekomponenter/Popover'
   component={Popover}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
-  argTypes={{
+
+argTypes={{
     trigger: {
       description:
         'En `ReactNode` som brukes til å åpne og lukke popoveren. Fungerer også som ankringspunkt til popoverens posisjon. Denne komponenten må ha en `ref`. Dette er en egenskap som finnes på alle primitive React-komponenter, men dersom det er en egendefinert komponent, må man bruke `React.forwardRef` i definisjonen av komponenten til å sette `ref`-egenskapen på riktig plass.',

--- a/packages/react/src/components/RadioButton/RadioButton.stories.mdx
+++ b/packages/react/src/components/RadioButton/RadioButton.stories.mdx
@@ -7,12 +7,6 @@ import { ArgsTable } from '@storybook/addon-docs';
 <Meta
   title='Utgår/RadioButton'
   component={RadioButton}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
   argTypes={{
     checked: {
       description: 'Trykker inn radioknappen.',

--- a/packages/react/src/components/RadioGroup/RadioGroup.stories.mdx
+++ b/packages/react/src/components/RadioGroup/RadioGroup.stories.mdx
@@ -7,12 +7,6 @@ import { ArgsTable } from '@storybook/addon-docs';
 <Meta
   title='Utgår/RadioGroup'
   component={RadioGroup}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
   argTypes={{
     items: {
       description: 'Liste over valg som skal vises.',

--- a/packages/react/src/components/Select/MultiSelect.stories.mdx
+++ b/packages/react/src/components/Select/MultiSelect.stories.mdx
@@ -6,12 +6,6 @@ import { ArgsTable } from '@storybook/addon-docs';
 <Meta
   title='Kjernekomponenter/Select/Flervalgsmeny'
   component={Select}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
   argTypes={{
     multiple: {
       description:

--- a/packages/react/src/components/Select/SingleSelect.stories.mdx
+++ b/packages/react/src/components/Select/SingleSelect.stories.mdx
@@ -6,12 +6,6 @@ import { ArgsTable } from '@storybook/addon-docs';
 <Meta
   title='Kjernekomponenter/Select/Enkel'
   component={Select}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
   argTypes={{
     label: {
       description: 'Tekst som vises over feltet.',

--- a/packages/react/src/components/Spinner/Spinner.stories.mdx
+++ b/packages/react/src/components/Spinner/Spinner.stories.mdx
@@ -6,12 +6,6 @@ import { ArgsTable } from '@storybook/addon-docs';
 <Meta
   title='Kjernekomponenter/Spinner'
   component={Spinner}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
   argTypes={{
     size: {
       control: {

--- a/packages/react/src/components/Table/ResponsiveTable.stories.mdx
+++ b/packages/react/src/components/Table/ResponsiveTable.stories.mdx
@@ -7,12 +7,6 @@ import classes from './Table.stories.module.css';
 <Meta
   title='Kjernekomponenter/Table/ResponsiveTable'
   component={ResponsiveTable}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
 />
 
 export const Template = () => (

--- a/packages/react/src/components/Table/Table.stories.mdx
+++ b/packages/react/src/components/Table/Table.stories.mdx
@@ -14,12 +14,6 @@ import classes from './Table.stories.module.css';
 <Meta
   title='Kjernekomponenter/Table'
   component={Table}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
 />
 
 export const Template = (args) => (

--- a/packages/react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/Tabs/Tabs.stories.tsx
@@ -6,12 +6,6 @@ import { Tabs } from './Tabs';
 export default {
   title: 'Kjernekomponenter/Tabs',
   component: Tabs,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 } as Meta;
 
 export const Eksempel: StoryFn<typeof Tabs> = (args) => <Tabs {...args} />;

--- a/packages/react/src/components/Tag/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/Tag.stories.tsx
@@ -11,12 +11,6 @@ type Story = StoryObj<typeof Tag>;
 export default {
   title: 'Kjernekomponenter/Tag',
   component: Tag,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
   decorators: [
     (Story) => (
       <Stack style={{ justifyContent: 'start' }}>

--- a/packages/react/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/react/src/components/TextArea/TextArea.stories.tsx
@@ -11,12 +11,6 @@ type Story = StoryObj<typeof TextArea>;
 const meta: Meta = {
   title: 'Kjernekomponenter/TextArea',
   component: TextArea,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 };
 
 export default meta;

--- a/packages/react/src/components/TextField/TextField.stories.tsx
+++ b/packages/react/src/components/TextField/TextField.stories.tsx
@@ -11,12 +11,6 @@ type Story = StoryObj<typeof TextField>;
 const meta: Meta<typeof TextField> = {
   title: 'Kjernekomponenter/TextField',
   component: TextField,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 };
 
 export default meta;

--- a/packages/react/src/components/ToggleButtonGroup/ToggleButtonGroup.stories.mdx
+++ b/packages/react/src/components/ToggleButtonGroup/ToggleButtonGroup.stories.mdx
@@ -5,12 +5,6 @@ import { ToggleButtonGroup } from './ToggleButtonGroup';
 <Meta
   title='Kjernekomponenter/ToggleButtonGroup'
   component={ToggleButtonGroup}
-  parameters={{
-    status: {
-      type: 'beta', // 'beta' | 'stable' | 'deprecated' | 'releaseCandidate'
-      url: 'http://www.url.com/status',
-    },
-  }}
 />
 
 export const defaultArgs = {

--- a/packages/react/src/components/Typography/Typography.stories.tsx
+++ b/packages/react/src/components/Typography/Typography.stories.tsx
@@ -5,12 +5,6 @@ import { Paragraph, Heading, Ingress } from './';
 
 const meta: Meta = {
   title: 'Kjernekomponenter/Typography',
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 };
 
 export default meta;

--- a/packages/react/src/components/form/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.stories.tsx
@@ -7,12 +7,6 @@ type Story = StoryObj<typeof Checkbox>;
 export default {
   title: 'ikke utgitt/Checkbox',
   component: Checkbox,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 } as Meta;
 
 export const Preview: Story = {

--- a/packages/react/src/components/form/Radio/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Radio/Group/Group.stories.tsx
@@ -7,12 +7,6 @@ import { Radio } from '../';
 export default {
   title: 'ikke utgitt/Radio/Group',
   component: Radio.Group,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 } as Meta;
 
 export const Preview: StoryFn<typeof Radio.Group> = (args) => (

--- a/packages/react/src/components/form/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/form/Radio/Radio.stories.tsx
@@ -7,12 +7,6 @@ type Story = StoryObj<typeof Radio>;
 export default {
   title: 'ikke utgitt/Radio',
   component: Radio,
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 } as Meta;
 
 export const Preview: Story = {

--- a/scripts/generate-component/fileTemplates.ts
+++ b/scripts/generate-component/fileTemplates.ts
@@ -49,12 +49,6 @@ type Story = StoryObj<typeof ${componentName}>;
 export default {
   title: 'Kjernekomponenter/${componentName}',
   component: ${componentName},
-  parameters: {
-    status: {
-      type: 'beta',
-      url: 'http://www.url.com/status',
-    },
-  },
 } as Meta;
 
 // Simple story

--- a/yarn.lock
+++ b/yarn.lock
@@ -4001,26 +4001,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@etchteam/storybook-addon-status@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@etchteam/storybook-addon-status@npm:4.2.2"
-  dependencies:
-    "@storybook/addons": ^6.2.9
-    "@storybook/api": ^6.2.9
-    "@storybook/client-logger": ^6.2.9
-    "@storybook/components": ^6.2.9
-    "@storybook/core-events": ^6.2.9
-    "@storybook/theming": ^6.2.9
-    core-js: ^3.0.1
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.3 || ^17.0.2 || ^18.0.0
-  checksum: 5507d9b70cda3dd08972fe4d1c9ce7de2232e21a7e15965f78c4ffe867745944418c6c054afee35200f256ae22b527d84ace15ba8d85707c2fe758b9bc88395f
-  languageName: node
-  linkType: hard
-
 "@fal-works/esbuild-plugin-global-externals@npm:^2.1.2":
   version: 2.1.2
   resolution: "@fal-works/esbuild-plugin-global-externals@npm:2.1.2"
@@ -7283,28 +7263,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addons@npm:^6.2.9":
-  version: 6.5.14
-  resolution: "@storybook/addons@npm:6.5.14"
-  dependencies:
-    "@storybook/api": 6.5.14
-    "@storybook/channels": 6.5.14
-    "@storybook/client-logger": 6.5.14
-    "@storybook/core-events": 6.5.14
-    "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/router": 6.5.14
-    "@storybook/theming": 6.5.14
-    "@types/webpack-env": ^1.16.0
-    core-js: ^3.8.2
-    global: ^4.4.0
-    regenerator-runtime: ^0.13.7
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 99d06641bab06a3cc2821f309589d062c0efd8707b451ae24017449034da408bfddce3beda1ccdedadf59669d7d13348bee127f6fd4fc057200c84ff43288312
-  languageName: node
-  linkType: hard
-
 "@storybook/addons@npm:^7.0.0-beta.49":
   version: 7.2.1
   resolution: "@storybook/addons@npm:7.2.1"
@@ -7316,34 +7274,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 9d70c16e07f89be698c632c2eff683b59c7f803414b3b9d19bc47b92e775143af6bd594462d278a9413424f6405c4fce8dd5a6febe432d96c2071e3992012b0e
-  languageName: node
-  linkType: hard
-
-"@storybook/api@npm:6.5.14, @storybook/api@npm:^6.2.9":
-  version: 6.5.14
-  resolution: "@storybook/api@npm:6.5.14"
-  dependencies:
-    "@storybook/channels": 6.5.14
-    "@storybook/client-logger": 6.5.14
-    "@storybook/core-events": 6.5.14
-    "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/router": 6.5.14
-    "@storybook/semver": ^7.3.2
-    "@storybook/theming": 6.5.14
-    core-js: ^3.8.2
-    fast-deep-equal: ^3.1.3
-    global: ^4.4.0
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-    regenerator-runtime: ^0.13.7
-    store2: ^2.12.0
-    telejson: ^6.0.8
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 0d421c3211a49cb8910dea647b898edd60af79755108ed321626a8fc134713dd1b018c830f15c2fc6c863f0528b571c2e2b34bb79df3c2f43497f5ab36fa9bbf
   languageName: node
   linkType: hard
 
@@ -7511,17 +7441,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/channels@npm:6.5.14":
-  version: 6.5.14
-  resolution: "@storybook/channels@npm:6.5.14"
-  dependencies:
-    core-js: ^3.8.2
-    ts-dedent: ^2.0.0
-    util-deprecate: ^1.0.2
-  checksum: ff1ee3fea3c7b8591280ba7eabe13c999fc3e12a483ff2c0467cc9cca027662cbbc4676438da567865919157521df8a9a50bd20b35daed6896f39a3a7251a1e5
-  languageName: node
-  linkType: hard
-
 "@storybook/channels@npm:7.1.0":
   version: 7.1.0
   resolution: "@storybook/channels@npm:7.1.0"
@@ -7611,16 +7530,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/client-logger@npm:6.5.14, @storybook/client-logger@npm:^6.2.9":
-  version: 6.5.14
-  resolution: "@storybook/client-logger@npm:6.5.14"
-  dependencies:
-    core-js: ^3.8.2
-    global: ^4.4.0
-  checksum: 29cc0b58db7a8dc90484320c86b386975580c0e534791b29f6a8c00ce5b156f2bff9513994202f9f9ef99787e8d793988048ae88d2780ba151c6782f3bbf97ff
-  languageName: node
-  linkType: hard
-
 "@storybook/client-logger@npm:7.1.0":
   version: 7.1.0
   resolution: "@storybook/client-logger@npm:7.1.0"
@@ -7677,25 +7586,6 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 10d8e12203e6435bfbfb10d1bc80545e47d9af2e9fad12443e82867dff5d1887e094290cfe8491b3149d626d1172831971c454240b8fdc27525237ba91b7d28a
-  languageName: node
-  linkType: hard
-
-"@storybook/components@npm:^6.2.9":
-  version: 6.5.14
-  resolution: "@storybook/components@npm:6.5.14"
-  dependencies:
-    "@storybook/client-logger": 6.5.14
-    "@storybook/csf": 0.0.2--canary.4566f4d.1
-    "@storybook/theming": 6.5.14
-    core-js: ^3.8.2
-    memoizerific: ^1.11.3
-    qs: ^6.10.0
-    regenerator-runtime: ^0.13.7
-    util-deprecate: ^1.0.2
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 73d0ff418f2c5b1fc9f421f089ebee2342ef0684905e4959397a8bc6f67f32ff97f4ec3587847980cb7e4fc8e40278d8ecea11a8d267fea8d94ad3d8265a0c21
   languageName: node
   linkType: hard
 
@@ -7757,15 +7647,6 @@ __metadata:
     resolve-from: ^5.0.0
     ts-dedent: ^2.0.0
   checksum: 2b72b5241a88dd5e9838aedf8c2046bba4e678bde2abf7e5a888dc5769539bf77ab6dd069a5600571fa7caa79a31c2a58e4a1f4d6dfa32a5c9750070bf3ee880
-  languageName: node
-  linkType: hard
-
-"@storybook/core-events@npm:6.5.14, @storybook/core-events@npm:^6.2.9":
-  version: 6.5.14
-  resolution: "@storybook/core-events@npm:6.5.14"
-  dependencies:
-    core-js: ^3.8.2
-  checksum: 6787925c520a6ee5aee748d4b7e2ec599c5ee16a87dbb62a94eeec88003ef42683d8e7ac8b98b49ea2a33205e0648805410c4759d16a997ba2f4215f6c8784ce
   languageName: node
   linkType: hard
 
@@ -7870,15 +7751,6 @@ __metadata:
     recast: ^0.23.1
     ts-dedent: ^2.0.0
   checksum: fe47fec7761f9983c77e02dc91dda5e3ff60206592fdf8f8f6a003efab2310d77f7932096b435f3f5add035cbf8cdf48a2b49dfd6d26d7e51db496e5634415a7
-  languageName: node
-  linkType: hard
-
-"@storybook/csf@npm:0.0.2--canary.4566f4d.1":
-  version: 0.0.2--canary.4566f4d.1
-  resolution: "@storybook/csf@npm:0.0.2--canary.4566f4d.1"
-  dependencies:
-    lodash: ^4.17.15
-  checksum: afac948e1eae72f020b3708538dd2553524f291bc129ecb2941983668fd62b17448e52f9c9be5b8edeea7a64d96f620bbac78b8acc10ece11b8279930a1deb03
   languageName: node
   linkType: hard
 
@@ -8193,22 +8065,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/router@npm:6.5.14":
-  version: 6.5.14
-  resolution: "@storybook/router@npm:6.5.14"
-  dependencies:
-    "@storybook/client-logger": 6.5.14
-    core-js: ^3.8.2
-    memoizerific: ^1.11.3
-    qs: ^6.10.0
-    regenerator-runtime: ^0.13.7
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: ec2550568c02f45de5307e77928eaeb39413049944e994adbc397d9c7e083ac7e110886e40517ddae40e3879c172f458167682f1d73d0bb150bc93ab9dd61514
-  languageName: node
-  linkType: hard
-
 "@storybook/router@npm:7.1.0":
   version: 7.1.0
   resolution: "@storybook/router@npm:7.1.0"
@@ -8237,18 +8093,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/semver@npm:^7.3.2":
-  version: 7.3.2
-  resolution: "@storybook/semver@npm:7.3.2"
-  dependencies:
-    core-js: ^3.6.5
-    find-up: ^4.1.0
-  bin:
-    semver: bin/semver.js
-  checksum: c98225817af5539654ef547e33e4496edccc04a88b6091d4a5601f81b71743109074dc71cc444813f43c112273c9d54d5f99416e9ad08ee89b4913318e6aea90
-  languageName: node
-  linkType: hard
-
 "@storybook/store@npm:7.1.0":
   version: 7.1.0
   resolution: "@storybook/store@npm:7.1.0"
@@ -8272,21 +8116,6 @@ __metadata:
     fs-extra: ^11.1.0
     read-pkg-up: ^7.0.1
   checksum: cfb0bd5f1f7fa67a870c76a76b496c5e812d0194e4a6f1b255833a988cdcbcedb84d882b931418ba988ecdd634dc215f24c8333754f0bf34697af20a770d10b6
-  languageName: node
-  linkType: hard
-
-"@storybook/theming@npm:6.5.14, @storybook/theming@npm:^6.2.9":
-  version: 6.5.14
-  resolution: "@storybook/theming@npm:6.5.14"
-  dependencies:
-    "@storybook/client-logger": 6.5.14
-    core-js: ^3.8.2
-    memoizerific: ^1.11.3
-    regenerator-runtime: ^0.13.7
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: d139325dd51e8dfa58458a5c033104123b019fc02ddc899898e02de2b5d1358fd318b5def7ef82e6138420f9198e90d50b0fdfbea926987ac6852fc3a2e77c6d
   languageName: node
   linkType: hard
 
@@ -9072,13 +8901,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/is-function@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "@types/is-function@npm:1.0.1"
-  checksum: dfbb591936dfebd4686b109603bc3e2d23a17087d6ec913fb35cd6b5a4ef908ed68ab93cb27d508f1546d312edf03e663cb6738d3b67d420c68da961ac2b3d1f
-  languageName: node
-  linkType: hard
-
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
   version: 2.0.4
   resolution: "@types/istanbul-lib-coverage@npm:2.0.4"
@@ -9428,13 +9250,6 @@ __metadata:
   version: 2.0.6
   resolution: "@types/unist@npm:2.0.6"
   checksum: 25cb860ff10dde48b54622d58b23e66214211a61c84c0f15f88d38b61aa1b53d4d46e42b557924a93178c501c166aa37e28d7f6d994aba13d24685326272d5db
-  languageName: node
-  linkType: hard
-
-"@types/webpack-env@npm:^1.16.0":
-  version: 1.18.0
-  resolution: "@types/webpack-env@npm:1.18.0"
-  checksum: ecf4daa31cb37d474ac0ce058d83a3cadeb9881ca8107ae93c2299eaa9954943aae09b43e143c62ccbe4288a14db00c918c9debd707afe17c3998f873eaabc59
   languageName: node
   linkType: hard
 
@@ -11910,7 +11725,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js@npm:^3.0.1, core-js@npm:^3.6.5, core-js@npm:^3.8.2":
+"core-js@npm:^3.0.1":
   version: 3.26.1
   resolution: "core-js@npm:3.26.1"
   checksum: 0a01149f51ff1e9f41d1ea49cc4c9222047949ea597189ede7c4cf8cde3b097766b9c7615acc77c86fe65b4002f20b638a133dfba7b41dba830d707aeeed45ad
@@ -12621,13 +12436,6 @@ __metadata:
     domhandler: ^4.2.0
     entities: ^2.0.0
   checksum: fbb0b01f87a8a2d18e6e5a388ad0f7ec4a5c05c06d219377da1abc7bb0f674d804f4a8a94e3f71ff15f6cb7dcfc75704a54b261db672b9b3ab03da6b758b0b22
-  languageName: node
-  linkType: hard
-
-"dom-walk@npm:^0.1.0":
-  version: 0.1.2
-  resolution: "dom-walk@npm:0.1.2"
-  checksum: 19eb0ce9c6de39d5e231530685248545d9cd2bd97b2cb3486e0bfc0f2a393a9addddfd5557463a932b52fdfcf68ad2a619020cd2c74a5fe46fbecaa8e80872f3
   languageName: node
   linkType: hard
 
@@ -14576,16 +14384,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"global@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "global@npm:4.4.0"
-  dependencies:
-    min-document: ^2.19.0
-    process: ^0.11.10
-  checksum: 9c057557c8f5a5bcfbeb9378ba4fe2255d04679452be504608dd5f13b54edf79f7be1db1031ea06a4ec6edd3b9f5f17d2d172fb47e6c69dae57fd84b7e72b77f
-  languageName: node
-  linkType: hard
-
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -15585,13 +15383,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-function@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "is-function@npm:1.0.2"
-  checksum: 7d564562e07b4b51359547d3ccc10fb93bb392fd1b8177ae2601ee4982a0ece86d952323fc172a9000743a3971f09689495ab78a1d49a9b14fc97a7e28521dc0
-  languageName: node
-  linkType: hard
-
 "is-generator-fn@npm:^2.0.0":
   version: 2.1.0
   resolution: "is-generator-fn@npm:2.1.0"
@@ -15789,7 +15580,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-regex@npm:^1.1.2, is-regex@npm:^1.1.4":
+"is-regex@npm:^1.1.4":
   version: 1.1.4
   resolution: "is-regex@npm:1.1.4"
   dependencies:
@@ -15952,13 +15743,6 @@ __metadata:
   version: 3.0.1
   resolution: "isobject@npm:3.0.1"
   checksum: db85c4c970ce30693676487cca0e61da2ca34e8d4967c2e1309143ff910c207133a969f9e4ddb2dc6aba670aabce4e0e307146c310350b298e74a31f7d464703
-  languageName: node
-  linkType: hard
-
-"isobject@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "isobject@npm:4.0.0"
-  checksum: bbcb522e46d54fb22418ba49fb9a82057ffa201c8401fb6e018c042e2c98cf7d9c7b185aff88e035ec8adea0814506dc2aeff2d08891bbc158e1671a49e99c06
   languageName: node
   linkType: hard
 
@@ -18368,15 +18152,6 @@ __metadata:
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
-  languageName: node
-  linkType: hard
-
-"min-document@npm:^2.19.0":
-  version: 2.19.0
-  resolution: "min-document@npm:2.19.0"
-  dependencies:
-    dom-walk: ^0.1.0
-  checksum: da6437562ea2228041542a2384528e74e22d1daa1a4ec439c165abf0b9d8a63e17e3b8a6dc6e0c731845e85301198730426932a0e813d23f932ca668340c9623
   languageName: node
   linkType: hard
 
@@ -21328,7 +21103,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.13.11, regenerator-runtime@npm:^0.13.7":
+"regenerator-runtime@npm:^0.13.11":
   version: 0.13.11
   resolution: "regenerator-runtime@npm:0.13.11"
   checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
@@ -21838,7 +21613,6 @@ __metadata:
     "@digdir/design-system-react": "*"
     "@digdir/design-system-tokens": "*"
     "@etchteam/storybook-addon-css-variables-theme": ^1.5.1
-    "@etchteam/storybook-addon-status": ^4.2.2
     "@next/eslint-plugin-next": ^13.2.4
     "@rollup/plugin-commonjs": ^22.0.2
     "@rollup/plugin-image": ^3.0.1
@@ -22535,7 +22309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"store2@npm:^2.12.0, store2@npm:^2.14.2":
+"store2@npm:^2.14.2":
   version: 2.14.2
   resolution: "store2@npm:2.14.2"
   checksum: 6f270fc5bab99b63f45fcc7bd8b99c2714b4adf880f557ed7ffb5ed3987131251165bccde425a00928aaf044870aee79ddeef548576d093c68703ed2edec45d7
@@ -23200,22 +22974,6 @@ __metadata:
     mkdirp: ^1.0.3
     yallist: ^4.0.0
   checksum: 8a278bed123aa9f53549b256a36b719e317c8b96fe86a63406f3c62887f78267cea9b22dc6f7007009738509800d4a4dccc444abd71d762287c90f35b002eb1c
-  languageName: node
-  linkType: hard
-
-"telejson@npm:^6.0.8":
-  version: 6.0.8
-  resolution: "telejson@npm:6.0.8"
-  dependencies:
-    "@types/is-function": ^1.0.0
-    global: ^4.4.0
-    is-function: ^1.0.2
-    is-regex: ^1.1.2
-    is-symbol: ^1.0.3
-    isobject: ^4.0.0
-    lodash: ^4.17.21
-    memoizerific: ^1.11.3
-  checksum: 7411a5e78a35720bd0654a544409d3ce467b1dbb2073c73f36476b4c0905d97dbf539d6cbae737bb1fd8c872c2058f2a5450163a15117ed3fa031b2a2b8b33f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With new updates to Storybook the status "badge" is only visible in story view and not docs anymore. It was often forgotten to update to correct status. We also have the `Information` component now on the page that serves the same purpose