### PR TITLE
refactor(InputWrapper): isValid should override the characterLimit

### DIFF
--- a/packages/react/src/components/_InputWrapper/InputWrapper.test.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.test.tsx
@@ -258,6 +258,7 @@ describe('InputWrapper', () => {
       render({
         label: 'Comment',
         value: 'Hello',
+        isValid: false,
         characterLimit: {
           maxCount: 2,
           label: (count: number) => `${count} signs left`,
@@ -272,6 +273,21 @@ describe('InputWrapper', () => {
       render({
         label: 'Comment',
         value: 'He',
+        characterLimit: {
+          maxCount: 2,
+          label: (count: number) => `${count} signs left`,
+          srLabel: '2 signs allowed',
+        },
+      });
+
+      expect(screen.queryByTestId('input-icon-error')).not.toBeInTheDocument();
+    });
+
+    it('isValid should override character-limit error', () => {
+      render({
+        label: 'Comment',
+        value: 'Hello',
+        isValid: true,
         characterLimit: {
           maxCount: 2,
           label: (count: number) => `${count} signs left`,

--- a/packages/react/src/components/_InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.tsx
@@ -104,12 +104,15 @@ export const InputWrapper = ({
     : undefined;
   const currentInputValue = value ? value.toString() : '';
 
+  const isFieldValid =
+    isValid ||
+    (characterLimit && currentInputValue.length <= characterLimit.maxCount) ||
+    false;
+
   const { variant, iconVariant } = getVariant({
     disabled,
     isSearch,
-    isValid:
-      isValid ||
-      (characterLimit && currentInputValue.length <= characterLimit.maxCount),
+    isValid: isFieldValid,
     readOnly,
   });
 

--- a/packages/react/src/components/_InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.tsx
@@ -107,9 +107,9 @@ export const InputWrapper = ({
   const { variant, iconVariant } = getVariant({
     disabled,
     isSearch,
-    isValid: characterLimit
-      ? currentInputValue.length <= characterLimit.maxCount && isValid
-      : isValid,
+    isValid:
+      isValid ||
+      (characterLimit && currentInputValue.length <= characterLimit.maxCount),
     readOnly,
   });
 


### PR DESCRIPTION
resolves: #719 

If characterLimit is invalid but the isValid has been set to true by the consumer, it should override the characterLimit validation