### PR TITLE
refactor(Button): render button text-content without wrapping in span

### DIFF
--- a/packages/react/src/components/Button/Button.module.css
+++ b/packages/react/src/components/Button/Button.module.css
@@ -66,6 +66,7 @@
   gap: var(--fds-sizing-2);
   min-width: var(--fdsc-button-size);
   font: var(--fds-typography-paragraph-small);
+  font-family: inherit;
 }
 
 .button.medium {
@@ -76,6 +77,7 @@
   gap: var(--fds-sizing-3);
   min-width: var(--fdsc-button-size);
   font: var(--fds-typography-paragraph-medium);
+  font-family: inherit;
 }
 
 .button.large {
@@ -86,6 +88,7 @@
   gap: var(--fds-sizing-3);
   min-width: var(--fdsc-button-size);
   font: var(--fds-typography-paragraph-large);
+  font-family: inherit;
 }
 
 .button.fullWidth {

--- a/packages/react/src/components/Button/Button.module.css
+++ b/packages/react/src/components/Button/Button.module.css
@@ -65,6 +65,7 @@
 
   gap: var(--fds-sizing-2);
   min-width: var(--fdsc-button-size);
+  font: var(--fds-typography-paragraph-small);
 }
 
 .button.medium {
@@ -74,6 +75,7 @@
 
   gap: var(--fds-sizing-3);
   min-width: var(--fdsc-button-size);
+  font: var(--fds-typography-paragraph-medium);
 }
 
 .button.large {
@@ -83,6 +85,7 @@
 
   gap: var(--fds-sizing-3);
   min-width: var(--fdsc-button-size);
+  font: var(--fds-typography-paragraph-large);
 }
 
 .button.fullWidth {
@@ -360,11 +363,4 @@
   --fdsc-font-and-icon-color: var(--fds-semantic-text-neutral-on_inverted);
 
   background: var(--fds-semantic-surface-on_inverted-no_fill-active);
-}
-
-.typography {
-  color: inherit;
-  display: flex;
-  align-items: center;
-  gap: var(--fds-sizing-2);
 }

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -65,15 +65,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           className={classes.icon}
         />
       )}
-      {children && (
-        <Paragraph
-          as='span'
-          size={size}
-          className={classes.typography}
-        >
-          {children}
-        </Paragraph>
-      )}
+      {children}
       {icon && iconPlacement === 'right' && (
         <SvgIcon
           svgIconComponent={icon}

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -3,7 +3,6 @@ import React, { forwardRef, type ButtonHTMLAttributes } from 'react';
 import cn from 'classnames';
 
 import { SvgIcon } from '../SvgIcon';
-import { Paragraph } from '../Typography';
 
 import classes from './Button.module.css';
 


### PR DESCRIPTION
resolves: #684 

Avoid wrapping text content within <span> tags. This practice has led to problems when creating Cypress tests. The root cause is that Cypress identifies elements based on their text content, and encounters a non-clickable element such as a <span>. This led to the test breaking because Cypress does not click on non-clickable elements.