### PR TITLE
fix(InputWrapper): isValid works now independent of charLimit validation

### DIFF
--- a/packages/react/src/components/_InputWrapper/InputWrapper.test.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.test.tsx
@@ -253,50 +253,6 @@ describe('InputWrapper', () => {
         'aria-describedby',
       );
     });
-
-    it('should display error variant when character-limit exceeds', () => {
-      render({
-        label: 'Comment',
-        value: 'Hello',
-        isValid: false,
-        characterLimit: {
-          maxCount: 2,
-          label: (count: number) => `${count} signs left`,
-          srLabel: '2 signs allowed',
-        },
-      });
-
-      expect(screen.queryByTestId('input-icon-error')).toBeInTheDocument();
-    });
-
-    it('should not display error variant when 0 characters left', () => {
-      render({
-        label: 'Comment',
-        value: 'He',
-        characterLimit: {
-          maxCount: 2,
-          label: (count: number) => `${count} signs left`,
-          srLabel: '2 signs allowed',
-        },
-      });
-
-      expect(screen.queryByTestId('input-icon-error')).not.toBeInTheDocument();
-    });
-
-    it('isValid should override character-limit error', () => {
-      render({
-        label: 'Comment',
-        value: 'Hello',
-        isValid: true,
-        characterLimit: {
-          maxCount: 2,
-          label: (count: number) => `${count} signs left`,
-          srLabel: '2 signs allowed',
-        },
-      });
-
-      expect(screen.queryByTestId('input-icon-error')).not.toBeInTheDocument();
-    });
   });
 });
 

--- a/packages/react/src/components/_InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/components/_InputWrapper/InputWrapper.tsx
@@ -104,15 +104,10 @@ export const InputWrapper = ({
     : undefined;
   const currentInputValue = value ? value.toString() : '';
 
-  const isFieldValid =
-    isValid ||
-    (characterLimit && currentInputValue.length <= characterLimit.maxCount) ||
-    false;
-
   const { variant, iconVariant } = getVariant({
     disabled,
     isSearch,
-    isValid: isFieldValid,
+    isValid,
     readOnly,
   });
 


### PR DESCRIPTION
resolves: #731 

Only isValid prop should decide the variant of the input field. (error or not)