### PR TITLE
docs: :memo: Clarify use of tokens npms package in storefront

### DIFF
--- a/storefront/pages/grunnleggende/designelementer/design-tokens.mdx
+++ b/storefront/pages/grunnleggende/designelementer/design-tokens.mdx
@@ -37,4 +37,4 @@ Videoen over viser at når settet for «Tilsynet» slås på, overstyres både f
 
 ### Design tokens for utviklere
 
-Installer NPM-pakken [@digdir/design-system-tokens](https://www.npmjs.com/package/@digdir/design-system-tokens) og importer inn tokens. Overstyres ved behov.
+Installer NPM-pakken [@digdir/design-system-tokens](https://www.npmjs.com/package/@digdir/design-system-tokens) og følg beskrivelsen der på bruk av tokens. Overstyres ved behov.

--- a/storefront/pages/grunnleggende/designelementer/design-tokens.mdx
+++ b/storefront/pages/grunnleggende/designelementer/design-tokens.mdx
@@ -22,8 +22,6 @@ export default ({ children, menu }) => (
 
 Design tokens er fleksible verdier som sikrer at designere og utviklere jobber med de samme reglene og retningslinjene. Dette gjelder for eksempel variabler for farger, typografi, størrelser, avstander og andre stilegenskaper. Design tokens fungerer som bindeleddet mellom alle flater og verktøy.
 
-Ved bruk av pakken [@digdir/design-system-tokens](https://www.npmjs.com/package/@digdir/design-system-tokens) har man tilgang på alle gjenbrukbare verdier som skal brukes i designet.
-
 ## Design tokens i Figma
 
 Vi bruker Figma-pluginen "Tokens Studio", da denne lar oss administrere flere stiler og egenskaper enn Figma i seg selv kan.
@@ -39,33 +37,4 @@ Videoen over viser at når settet for «Tilsynet» slås på, overstyres både f
 
 ### Design tokens for utviklere
 
-Installer NPM-pakken `@digdir/design-system-tokens` med NPM, Yarn eller PNPM og importer inn tokens med CSS-, SCSS- eller Javascript-variabler. Overstyres ved behov.
-
-#### CSS
-
-<CodeSnippet
-  children='
-@import "@digdir/design-system-tokens/build/tokens.css";
-:root {
-  --my-text-color: var(--color-text-background-light);
-}'
-  language='css'
-/>
-
-#### SCSS
-
-<CodeSnippet
-  children='
-@use "@digdir/design-system-tokens/build/tokens.scss" as tokens;
-$my-text-color: tokens.$color-text-background-light;'
-  language='scss'
-/>
-
-#### Javascript
-
-<CodeSnippet
-  children='
-import tokens from "@digdir/design-system-tokens/build/tokens"
-const myTextColor = tokens.color.text.background.light'
-  language='javascript'
-/>
+Installer NPM-pakken [@digdir/design-system-tokens](https://www.npmjs.com/package/@digdir/design-system-tokens) og importer inn tokens. Overstyres ved behov.

--- a/storefront/pages/grunnleggende/designelementer/design-tokens.mdx
+++ b/storefront/pages/grunnleggende/designelementer/design-tokens.mdx
@@ -1,7 +1,6 @@
 import { Meta } from '@components';
 import { MenuPageLayout } from '@layouts';
 import { Figma } from 'mdx-embed';
-import { CodeSnippet } from '@components';
 
 <Meta
   title='Design Tokens'


### PR DESCRIPTION
The description for use of tokens for developers was wrong in the storefront. 

Changed it so that it links to the npm package. How to use tokens should follow the README on npm to avoid duplicate docs that will become out of sync