### PR TITLE
fix(Radio, Checkbox, Switch): :bug: Remove z-index on selection control icon

### DIFF
--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -13,7 +13,6 @@
   pointer-events: none;
   height: 1.75em;
   width: 1.75em;
-  z-index: 1;
   margin: auto;
   overflow: visible;
 }

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -13,7 +13,6 @@
   pointer-events: none;
   height: 1.75em;
   width: 1.75em;
-  z-index: 1;
   margin: auto;
   overflow: visible;
 }

--- a/packages/react/src/components/form/Switch/Switch.module.css
+++ b/packages/react/src/components/form/Switch/Switch.module.css
@@ -35,7 +35,6 @@
   pointer-events: none;
   height: 1.75em;
   width: auto;
-  z-index: 1;
   margin: auto;
   overflow: visible;
   border-radius: 16px;


### PR DESCRIPTION
fixes #789

Seems to me it still works as before, can't remember why that z-index was there to begin with, might be leftover code.