### PR TITLE
fix(Accordion): hide content in Accordions from screen readers when Accordion is closed

### DIFF
--- a/packages/react/src/utility-components/AnimateHeight/AnimateHeight.module.css
+++ b/packages/react/src/utility-components/AnimateHeight/AnimateHeight.module.css
@@ -9,4 +9,5 @@
 
 .root.closed .content {
   height: 0;
+  display: none;
 }


### PR DESCRIPTION
This PR adds the `aria-hidden` attribute to content in Accordions when they are closed.

- Closes #814