### PR TITLE
ci: add storybook vercel github action

### DIFF
--- a/.github/workflows/storybook-deploy-vercel.yml
+++ b/.github/workflows/storybook-deploy-vercel.yml
@@ -9,7 +9,6 @@ on:
       - main
 jobs:
   Deploy-Preview:
-    if: ${{ github.event_name == 'workflow_dispatch' || contains( github.event.pull_request.labels.*.name, '📔 storybook') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/storybook-deploy-vercel.yml
+++ b/.github/workflows/storybook-deploy-vercel.yml
@@ -8,8 +8,10 @@ on:
     branches:
       - main
 jobs:
-  Deploy-Preview:
+  deploy:
+    name: Build & deploy to Vercel
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/storybook-deploy-vercel.yml
+++ b/.github/workflows/storybook-deploy-vercel.yml
@@ -1,0 +1,40 @@
+name: Deploy Storybook Production
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_STORYBOOK }}
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  Deploy-Preview:
+    if: ${{ github.event_name == 'workflow_dispatch' || contains( github.event.pull_request.labels.*.name, '📔 storybook') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use node 20 and yarn cache
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Install Vercel CLI
+        run: yarn add vercel@latest
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - id: deploy
+        name: Deploy Project Artifacts to Vercel
+        run: echo "url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Add a github action for storybook vercel deployment so we can test it on storybook.designsystemet.no when DNS is ready.
Then we can replace `storybook-deploy.yml` with this when we are happy (remove action for gh-pages).

This action is identical to the storybook preview action except I:
*  Changed to trigger on main changes
*  Remove if checks
* Changed environment to production
*  Removed comment to PR feature