### PR TITLE
feat(ToggleGroup): Add accessible title for items with only icon

### DIFF
--- a/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
@@ -60,14 +60,17 @@ export const OnlyIcons: StoryFn<typeof ToggleGroup> = () => {
       <ToggleGroup.Item
         value={'option-1'}
         icon={<AkselIcon3 />}
+        iconTitle='Braille'
       />
       <ToggleGroup.Item
         value={'option-2'}
         icon={<AkselIcon2 />}
+        iconTitle='Newspaper'
       />
       <ToggleGroup.Item
         value={'option-3'}
         icon={<AkselIcon4 />}
+        iconTitle='Backpack'
       />
     </ToggleGroup>
   );

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
@@ -59,18 +59,15 @@ export const OnlyIcons: StoryFn<typeof ToggleGroup> = () => {
     >
       <ToggleGroup.Item
         value={'option-1'}
-        icon={<AkselIcon3 />}
-        iconTitle='Braille'
+        icon={<AkselIcon3 title='Braille' />}
       />
       <ToggleGroup.Item
         value={'option-2'}
-        icon={<AkselIcon2 />}
-        iconTitle='Newspaper'
+        icon={<AkselIcon2 title='Newspaper' />}
       />
       <ToggleGroup.Item
         value={'option-3'}
-        icon={<AkselIcon4 />}
-        iconTitle='Backpack'
+        icon={<AkselIcon4 title='Backpack' />}
       />
     </ToggleGroup>
   );

--- a/packages/react/src/components/ToggleGroup/ToggleGroupItem/ToggleGroupItem.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroupItem/ToggleGroupItem.tsx
@@ -14,7 +14,7 @@ export type ToggleGroupItemProps = {
   value?: string;
   /** Icon to be displayed on the ToggleGroupItem */
   icon?: React.ReactNode;
-  /** Title for icon when only icons are used */
+  /** Title for icon when only icon is used */
   iconTitle?: string;
   /** The text to be displayed on the ToggleGroupItem */
   children?: string;

--- a/packages/react/src/components/ToggleGroup/ToggleGroupItem/ToggleGroupItem.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroupItem/ToggleGroupItem.tsx
@@ -4,7 +4,6 @@ import cn from 'classnames';
 
 import { Button } from '../../Button';
 import { RovingTabindexItem } from '../../../utility-components/RovingTabIndex';
-import utilityClasses from '../../../utils/utility.module.css';
 
 import classes from './ToggleGroupItem.module.css';
 import { useToggleGroupItem } from './useToggleGroupitem';
@@ -14,8 +13,6 @@ export type ToggleGroupItemProps = {
   value?: string;
   /** Icon to be displayed on the ToggleGroupItem */
   icon?: React.ReactNode;
-  /** Title for icon when only icon is used */
-  iconTitle?: string;
   /** The text to be displayed on the ToggleGroupItem */
   children?: string;
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value' | 'children'>;
@@ -24,7 +21,7 @@ export const ToggleGroupItem = forwardRef<
   HTMLButtonElement,
   ToggleGroupItemProps
 >((props, ref) => {
-  const { children, icon, iconTitle, ...rest } = props;
+  const { children, icon, ...rest } = props;
   const { active, size = 'medium', buttonProps } = useToggleGroupItem(props);
   return (
     <RovingTabindexItem
@@ -44,9 +41,6 @@ export const ToggleGroupItem = forwardRef<
       iconPlacement='left'
       ref={ref}
     >
-      {iconTitle && (
-        <span className={utilityClasses.visuallyHidden}>{iconTitle}</span>
-      )}
       {children}
     </RovingTabindexItem>
   );

--- a/packages/react/src/components/ToggleGroup/ToggleGroupItem/ToggleGroupItem.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroupItem/ToggleGroupItem.tsx
@@ -4,6 +4,7 @@ import cn from 'classnames';
 
 import { Button } from '../../Button';
 import { RovingTabindexItem } from '../../../utility-components/RovingTabIndex';
+import utilityClasses from '../../../utils/utility.module.css';
 
 import classes from './ToggleGroupItem.module.css';
 import { useToggleGroupItem } from './useToggleGroupitem';
@@ -13,6 +14,8 @@ export type ToggleGroupItemProps = {
   value?: string;
   /** Icon to be displayed on the ToggleGroupItem */
   icon?: React.ReactNode;
+  /** Title for icon when only icons are used */
+  iconTitle?: string;
   /** The text to be displayed on the ToggleGroupItem */
   children?: string;
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'value' | 'children'>;
@@ -21,7 +24,7 @@ export const ToggleGroupItem = forwardRef<
   HTMLButtonElement,
   ToggleGroupItemProps
 >((props, ref) => {
-  const { children, icon, ...rest } = props;
+  const { children, icon, iconTitle, ...rest } = props;
   const { active, size = 'medium', buttonProps } = useToggleGroupItem(props);
   return (
     <RovingTabindexItem
@@ -41,6 +44,9 @@ export const ToggleGroupItem = forwardRef<
       iconPlacement='left'
       ref={ref}
     >
+      {iconTitle && (
+        <span className={utilityClasses.visuallyHidden}>{iconTitle}</span>
+      )}
       {children}
     </RovingTabindexItem>
   );


### PR DESCRIPTION
Adds accessible tilte for ToggleGroupItems to be used when only icons are displayed.