### PR TITLE
fix(Accordion): Make border styling overridable

### DIFF
--- a/packages/react/src/components/Accordion/Accordion.module.css
+++ b/packages/react/src/components/Accordion/Accordion.module.css
@@ -21,6 +21,8 @@
   --fdsc-accordion-header-color-hover: var(--fds-semantic-text-action-first-default);
   --fdsc-accordion-content-border: var(--fds-semantic-border-neutral-subtle);
   --fdsc-accordion-content-border-open: var(--fds-semantic-border-neutral-strong);
+
+  border-bottom: 1px solid var(--fdsc-accordion-content-border);
 }
 
 .border {
@@ -39,10 +41,6 @@
   background-color: #ffffff50;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.item:last-child .contentWrapper {
-  border-bottom: 1px solid var(--fdsc-accordion-content-border);
 }
 
 .header {

--- a/packages/react/src/components/Accordion/AccordionContent/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent/AccordionContent.tsx
@@ -29,7 +29,6 @@ export const AccordionContent = forwardRef<
     <AnimateHeight
       id={context.contentId}
       open={context.open}
-      className={classes.contentWrapper}
     >
       <Paragraph
         {...rest}


### PR DESCRIPTION
This pull request solves two issues:
- It is not possible to override the bottom border styling of the accordion using a custom class name directly (it is necessary to either use complex selectors like `> div` or hard code the generated `contentWrapper` class name, which is not ideal).
- When using the bordered variant of the accordion, the bottom border is doubled.