### PR TITLE
chore(storefront): remove link tag, Inter is already in globals.css

### DIFF
--- a/storefront/components/Meta/Meta.tsx
+++ b/storefront/components/Meta/Meta.tsx
@@ -21,10 +21,6 @@ const Meta = ({ title, description }: MetaProps) => {
         content='width=device-width, initial-scale=1'
       />
       <link
-        rel='stylesheet'
-        href='https://altinncdn.no/fonts/inter/inter.css'
-      />
-      <link
         rel='shortcut icon'
         href='/favicon.ico'
       />

--- a/storefront/components/Meta/Meta.tsx
+++ b/storefront/components/Meta/Meta.tsx
@@ -28,7 +28,7 @@ const Meta = ({ title, description }: MetaProps) => {
   );
 };
 
-// let's set a default title
+// Let's set a default title
 Meta.defaultProps = {
   title: 'Felles Designsystem',
 };


### PR DESCRIPTION
Resolves #874
An import to Inter was already in `globals.css`, so I just removed the link tag in head.