### PR TITLE
Revert "fix(Select): Hide list when reference is hidden (#917)"

### DIFF
--- a/packages/react/src/components/Select/OptionList/OptionList.module.css
+++ b/packages/react/src/components/Select/OptionList/OptionList.module.css
@@ -33,10 +33,6 @@
   display: none;
 }
 
-.wrapper.referenceHidden {
-  visibility: hidden;
-}
-
 .optionList {
   display: flex;
   flex-direction: column;

--- a/packages/react/src/components/Select/OptionList/OptionList.test.tsx
+++ b/packages/react/src/components/Select/OptionList/OptionList.test.tsx
@@ -47,7 +47,6 @@ const defaultProps: OptionListProps = {
   onOptionClick: jest.fn(),
   optionId: jest.fn(),
   options: singleSelectOptions,
-  referenceHidden: false,
   selectedValues,
   setFloating: jest.fn(),
   x: 0,

--- a/packages/react/src/components/Select/OptionList/OptionList.tsx
+++ b/packages/react/src/components/Select/OptionList/OptionList.tsx
@@ -15,7 +15,6 @@ type OptionListPropsBase<T extends SingleSelectOption | MultiSelectOption> = {
   onOptionClick: (value: string) => void;
   optionId: (value: string) => string;
   options: T[];
-  referenceHidden?: boolean;
   selectedValues: string[];
   setFloating: (node: HTMLElement | null) => void;
   x: number;
@@ -34,7 +33,6 @@ const OptionList = ({
   onOptionClick,
   optionId,
   options,
-  referenceHidden = false,
   selectedValues,
   setFloating,
   x,
@@ -56,7 +54,6 @@ const OptionList = ({
           classes.wrapper,
           expanded && classes.expanded,
           usingKeyboard && classes.usingKeyboard,
-          referenceHidden && classes.referenceHidden,
         )}
         ref={setFloating}
         style={{ left: x, top: y, zIndex: 1500 }}

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -2,7 +2,7 @@ import type { ChangeEvent } from 'react';
 import React, { useCallback, useEffect, useId, useState } from 'react';
 import cn from 'classnames';
 import { autoUpdate, useFloating } from '@floating-ui/react';
-import { flip, size, hide } from '@floating-ui/dom';
+import { flip, size } from '@floating-ui/dom';
 
 import { InputWrapper } from '../_InputWrapper';
 import { useKeyboardEventListener, usePrevious, useUpdate } from '../../hooks';
@@ -114,28 +114,25 @@ const Select = (props: SelectProps) => {
     [setKeyword, multiple],
   );
 
-  const { x, y, elements, refs, middlewareData } = useFloating<HTMLSpanElement>(
-    {
-      placement: 'bottom',
-      whileElementsMounted: autoUpdate,
-      middleware: [
-        flip(),
-        size({
-          apply: ({ availableHeight, elements, rects }) => {
-            requestAnimationFrame(() => {
-              // This must be wrapped in requestAnimationFrame to avoid ResizeObserver loop error; https://github.com/floating-ui/floating-ui/issues/1740
-              // The error is difficult/impossible to reproduce in Storybook, but it appears in other apps when the component is used without a fixed width.
-              Object.assign(elements.floating.style, {
-                maxHeight: `min(${availableHeight}px, var(--option_list-max_height))`,
-                width: `${rects.reference.width}px`,
-              });
+  const { x, y, elements, refs } = useFloating<HTMLSpanElement>({
+    placement: 'bottom',
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      flip(),
+      size({
+        apply: ({ availableHeight, elements, rects }) => {
+          requestAnimationFrame(() => {
+            // This must be wrapped in requestAnimationFrame to avoid ResizeObserver loop error; https://github.com/floating-ui/floating-ui/issues/1740
+            // The error is difficult/impossible to reproduce in Storybook, but it appears in other apps when the component is used without a fixed width.
+            Object.assign(elements.floating.style, {
+              maxHeight: `min(${availableHeight}px, var(--option_list-max_height))`,
+              width: `${rects.reference.width}px`,
             });
-          },
-        }),
-        hide(),
-      ],
-    },
-  );
+          });
+        },
+      }),
+    ],
+  });
   const listboxWrapper = elements.floating as HTMLSpanElement;
   const selectField = elements.reference as HTMLSpanElement;
 
@@ -428,7 +425,6 @@ const Select = (props: SelectProps) => {
         onOptionClick={addOrRemoveSelectedValue}
         optionId={(val) => `${givenOrRandomInputId}-${val}`}
         options={sortedOptions}
-        referenceHidden={middlewareData.hide?.referenceHidden}
         selectedValues={selectedValues}
         setFloating={refs.setFloating}
         x={x}


### PR DESCRIPTION
The recent fix on hiding the option list did not not work in Altinn Studio, although I was able to reproduce the issue and fix it within Storybook. In Studio, it only made tests fail because React Testing Library interpreted the list as hidden by default. We need to dig deeper into this, but until we have a final fix, i think it is best to revert the current one, to avoid further troubles with automated testing.