### PR TITLE
chore: ➕ Add `eslint-plugin-storybook`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ coverage/
 storybook-static/
 packages/tokens/brand/**/*
 tsc-build/
+.storybook

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
     'plugin:prettier/recommended',
+    'plugin:storybook/recommended',
   ],
   plugins: ['import', 'react', 'jsx-a11y', 'prettier'],
   overrides: [

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.31.6",
     "eslint-plugin-react-hooks": "4.6.0",
+    "eslint-plugin-storybook": "^0.6.15",
     "esno": "^0.17.0",
     "identity-obj-proxy": "3.0.0",
     "jest": "^29.0.3",

--- a/packages/react/src/components/Button/Button.mdx
+++ b/packages/react/src/components/Button/Button.mdx
@@ -38,15 +38,15 @@ Sett `as="a"` dersom du trenger å bruke knappen som en lenke. Vurder først om 
 
 ### Knapp med ikon
 
-<Canvas of={ButtonStories.withIcon} />
+<Canvas of={ButtonStories.WithIcon} />
 
 ### Knapp med tekst og ikon
 
-<Canvas of={ButtonStories.withIconAndText} />
+<Canvas of={ButtonStories.WithIconAndText} />
 
 ### Full bredde
 
-<Canvas of={ButtonStories.fullWidth} />
+<Canvas of={ButtonStories.FullWidth} />
 
 ### Bruk av Spinner til å lage en knapp som laster
 
@@ -59,4 +59,4 @@ Slik vil bl.a. skjermlesere bli informert om at knappen eksisterer (men ikke er 
 Det er imidlertid viktig å vite at denne egenskapen ikke automatisk stopper knappen fra å utløse sin `onCLick`-metode.
 Det er opp til deg som programmerer å passe på at ikke callback-funksjonen din kjører når knappen ikke skal være aktiv.
 
-<Canvas of={ButtonStories.withSpinner} />
+<Canvas of={ButtonStories.WithSpinner} />

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -131,7 +131,7 @@ Variants.decorators = [
   ),
 ];
 
-export const withIcon: StoryFn<typeof Button> = () => (
+export const WithIcon: StoryFn<typeof Button> = () => (
   <>
     <Button
       icon={icon}
@@ -205,7 +205,7 @@ export const withIcon: StoryFn<typeof Button> = () => (
   </>
 );
 
-withIcon.decorators = [
+WithIcon.decorators = [
   (Story) => (
     <Stack
       style={{
@@ -218,7 +218,7 @@ withIcon.decorators = [
   ),
 ];
 
-export const withIconAndText: StoryFn<typeof Button> = () => (
+export const WithIconAndText: StoryFn<typeof Button> = () => (
   <>
     <Button
       icon={icon}
@@ -241,9 +241,9 @@ export const withIconAndText: StoryFn<typeof Button> = () => (
   </>
 );
 
-withIconAndText.decorators = [stack];
+WithIconAndText.decorators = [stack];
 
-export const withSpinner: StoryFn<typeof Button> = () => (
+export const WithSpinner: StoryFn<typeof Button> = () => (
   <>
     <Button
       icon={icon}
@@ -281,9 +281,9 @@ export const withSpinner: StoryFn<typeof Button> = () => (
   </>
 );
 
-withSpinner.decorators = [stack];
+WithSpinner.decorators = [stack];
 
-export const fullWidth: Story = {
+export const FullWidth: Story = {
   name: 'Full bredde',
   args: {
     children: 'Full bredde',

--- a/packages/react/src/components/form/Switch/Switch.mdx
+++ b/packages/react/src/components/form/Switch/Switch.mdx
@@ -26,14 +26,14 @@ import { Switch, Fieldset } from '@digdir/design-system-react';
 
 Bruker [Fieldset](/docs/felles-fieldset--docs) til gruppering.
 
-<Canvas of={SwitchStories.fullWidth} />
+<Canvas of={SwitchStories.FullWidth} />
 
 ### Høyrejustert
 
 Bruk `position="right"` til å plassere `Switch` på høyre side av label dersom
 du har behov for det.
 
-<Canvas of={SwitchStories.fullWidthRight} />
+<Canvas of={SwitchStories.FullWidthRight} />
 
 ## Retningslinjer
 

--- a/packages/react/src/components/form/Switch/Switch.stories.tsx
+++ b/packages/react/src/components/form/Switch/Switch.stories.tsx
@@ -20,7 +20,7 @@ export const Preview: Story = {
   },
 };
 
-export const fullWidth: StoryFn<typeof Switch> = (args) => (
+export const FullWidth: StoryFn<typeof Switch> = (args) => (
   <Fieldset legend='Skru av/på en eller flere instillinger'>
     <Switch
       value='alt1'
@@ -43,8 +43,8 @@ export const fullWidth: StoryFn<typeof Switch> = (args) => (
   </Fieldset>
 );
 
-export const fullWidthRight = fullWidth.bind({});
+export const FullWidthRight = FullWidth.bind({});
 
-fullWidthRight.args = {
+FullWidthRight.args = {
   position: 'right',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7750,6 +7750,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/csf@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "@storybook/csf@npm:0.0.1"
+  dependencies:
+    lodash: ^4.17.15
+  checksum: fb57fa028b08a51edf44e1a2bf4be40a4607f5c6ccb58aae8924f476a42b9bbd61a0ad521cfc82196f23e6a912caae0a615e70a755e6800b284c91c509fd2de6
+  languageName: node
+  linkType: hard
+
 "@storybook/csf@npm:^0.1.0":
   version: 0.1.0
   resolution: "@storybook/csf@npm:0.1.0"
@@ -9362,6 +9371,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.3.12":
+  version: 7.5.4
+  resolution: "@types/semver@npm:7.5.4"
+  checksum: 120c0189f6fec5f2d12d0d71ac8a4cfa952dc17fa3d842e8afddb82bba8828a4052f8799c1653e2b47ae1977435f38e8985658fde971905ce5afb8e23ee97ecf
+  languageName: node
+  linkType: hard
+
 "@types/semver@npm:^7.3.4":
   version: 7.3.13
   resolution: "@types/semver@npm:7.3.13"
@@ -9484,6 +9500,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:5.62.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.62.0"
+  dependencies:
+    "@typescript-eslint/types": 5.62.0
+    "@typescript-eslint/visitor-keys": 5.62.0
+  checksum: 6062d6b797fe1ce4d275bb0d17204c827494af59b5eaf09d8a78cdd39dadddb31074dded4297aaf5d0f839016d601032857698b0e4516c86a41207de606e9573
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:6.7.3":
   version: 6.7.3
   resolution: "@typescript-eslint/scope-manager@npm:6.7.3"
@@ -9511,10 +9537,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:5.62.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/types@npm:5.62.0"
+  checksum: 48c87117383d1864766486f24de34086155532b070f6264e09d0e6139449270f8a9559cfef3c56d16e3bcfb52d83d42105d61b36743626399c7c2b5e0ac3b670
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/types@npm:6.7.3":
   version: 6.7.3
   resolution: "@typescript-eslint/types@npm:6.7.3"
   checksum: 4adb6177ec710e7438610fee553839a7abecc498dbb36d0170786bab66c5e5415cd720ac06419fd905458ad88c39b661603af5f013adc299137ccb4c51c4c879
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:5.62.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.62.0"
+  dependencies:
+    "@typescript-eslint/types": 5.62.0
+    "@typescript-eslint/visitor-keys": 5.62.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.3.7
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 3624520abb5807ed8f57b1197e61c7b1ed770c56dfcaca66372d584ff50175225798bccb701f7ef129d62c5989070e1ee3a0aa2d84e56d9524dcf011a2bb1a52
   languageName: node
   linkType: hard
 
@@ -9550,6 +9601,34 @@ __metadata:
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0
   checksum: 685b7c9fa95ad085f30e26431dc41b3059a42a16925defe2a94b32fb46974bfc168000de7d4d9ad4a1d0568a983f9d3c01ea6bc6cfa9a798e482719af9e9165b
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^5.45.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/utils@npm:5.62.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.2.0
+    "@types/json-schema": ^7.0.9
+    "@types/semver": ^7.3.12
+    "@typescript-eslint/scope-manager": 5.62.0
+    "@typescript-eslint/types": 5.62.0
+    "@typescript-eslint/typescript-estree": 5.62.0
+    eslint-scope: ^5.1.1
+    semver: ^7.3.7
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: ee9398c8c5db6d1da09463ca7bf36ed134361e20131ea354b2da16a5fdb6df9ba70c62a388d19f6eebb421af1786dbbd79ba95ddd6ab287324fc171c3e28d931
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:5.62.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.62.0"
+  dependencies:
+    "@typescript-eslint/types": 5.62.0
+    eslint-visitor-keys: ^3.3.0
+  checksum: 976b05d103fe8335bef5c93ad3f76d781e3ce50329c0243ee0f00c0fcfb186c81df50e64bfdd34970148113f8ade90887f53e3c4938183afba830b4ba8e30a35
   languageName: node
   linkType: hard
 
@@ -13494,7 +13573,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:5.1.1":
+"eslint-plugin-storybook@npm:^0.6.15":
+  version: 0.6.15
+  resolution: "eslint-plugin-storybook@npm:0.6.15"
+  dependencies:
+    "@storybook/csf": ^0.0.1
+    "@typescript-eslint/utils": ^5.45.0
+    requireindex: ^1.1.0
+    ts-dedent: ^2.2.0
+  peerDependencies:
+    eslint: ">=6"
+  checksum: e2c4d7be3e695c88d7194c363fba8ac644b36583bf9d608aa59dcd53cc5e422f7828611ee49c7934639ce827c0206d33fa94b3ea452ffbd2c8e7254ed90bc412
+  languageName: node
+  linkType: hard
+
+"eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
   dependencies:
@@ -21861,6 +21954,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"requireindex@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "requireindex@npm:1.2.0"
+  checksum: 50d8b10a1ff1fdf6aea7a1870bc7bd238b0fb1917d8d7ca17fd03afc38a65dcd7a8a4eddd031f89128b5f0065833d5c92c4fef67f2c04e8624057fe626c9cf94
+  languageName: node
+  linkType: hard
+
 "requires-port@npm:^1.0.0":
   version: 1.0.0
   resolution: "requires-port@npm:1.0.0"
@@ -22187,6 +22287,7 @@ __metadata:
     eslint-plugin-prettier: 4.2.1
     eslint-plugin-react: 7.31.6
     eslint-plugin-react-hooks: 4.6.0
+    eslint-plugin-storybook: ^0.6.15
     esno: ^0.17.0
     identity-obj-proxy: 3.0.0
     jest: ^29.0.3
@@ -23913,7 +24014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.13.0":
+"tslib@npm:^1.13.0, tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -23931,6 +24032,17 @@ __metadata:
   version: 2.5.0
   resolution: "tslib@npm:2.5.0"
   checksum: ae3ed5f9ce29932d049908ebfdf21b3a003a85653a9a140d614da6b767a93ef94f460e52c3d787f0e4f383546981713f165037dc2274df212ea9f8a4541004e1
+  languageName: node
+  linkType: hard
+
+"tsutils@npm:^3.21.0":
+  version: 3.21.0
+  resolution: "tsutils@npm:3.21.0"
+  dependencies:
+    tslib: ^1.8.1
+  peerDependencies:
+    typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+  checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When upgrading to latest Storybook a recommendation for installing their eslint plugin popped up. 

Suggest using this to keep things consistens in accordance with Storybook guidelines.