### PR TITLE
chore: :building_construction: Fix IDE formatting and bugs after `apps/storefront` move

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,10 +11,10 @@ module.exports = {
     'plugin:jsx-a11y/recommended',
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
-    'plugin:prettier/recommended',
     'plugin:storybook/recommended',
+    'plugin:prettier/recommended',
   ],
-  plugins: ['import', 'react', 'jsx-a11y', 'prettier'],
+  plugins: ['import', 'react', 'jsx-a11y'],
   overrides: [
     {
       // Typescript
@@ -41,7 +41,10 @@ module.exports = {
     },
   ],
   rules: {
+    // https://github.com/prettier/eslint-plugin-prettier#recommended-configuration
     'prettier/prettier': ['error', { endOfLine: 'auto' }],
+    'arrow-body-style': 'off',
+    'prefer-arrow-callback': 'off',
     // Disabled because we use Typescript types for props
     'react/prop-types': ['off'],
     'react/jsx-no-bind': 'off',
@@ -49,7 +52,7 @@ module.exports = {
     'import/no-unresolved': 'error',
     'import/namespace': ['error', { allowComputed: true }],
     'import/no-named-as-default': 'off',
-    '@next/next/no-html-link-for-pages': ['error', '/storefront/pages/'],
+    '@next/next/no-html-link-for-pages': ['error', 'apps/storefront/pages/'],
     'import/order': [
       'warn',
       {

--- a/apps/storefront/pages/god-praksis/index.mdx
+++ b/apps/storefront/pages/god-praksis/index.mdx
@@ -23,7 +23,7 @@ export default ({ children, menu }) => (
         link: {
           text: 'Bidra med innhold',
           prefix: <BranchingIcon fontSize={26} />,
-          href: 'https://github.com/digdir/designsystem/tree/main/storefront/pages/god-praksis',
+          href: 'https://github.com/digdir/designsystem/tree/main/apps/storefront/pages/god-praksis',
         },
       },
     }}

--- a/apps/storefront/pages/grunnleggende/introduksjon/designprinsipper.mdx
+++ b/apps/storefront/pages/grunnleggende/introduksjon/designprinsipper.mdx
@@ -78,6 +78,6 @@ Eksempel på opplevelser vi ønsker at innbyggerne skal ha i møte med oss:
 \
 \
 \
-Bidra til denne oversikten i [Github](https://github.com/digdir/designsystem/tree/main/storefront/pages/god-praksis/brukerinnsikt/designprinsipper).
+Bidra til denne oversikten i [Github](https://github.com/digdir/designsystem/tree/main/apps/storefront/pages/god-praksis/brukerinnsikt/designprinsipper).
 
 ---

--- a/packages/tokens/scripts/build.ts
+++ b/packages/tokens/scripts/build.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 import StyleDictionary from 'style-dictionary';
 import type {
@@ -26,9 +27,11 @@ import {
 
 void registerTransforms(StyleDictionary);
 
-type Brands = 'Altinn' | 'Digdir' | 'Tilsynet' | 'Brreg';
+// File name under design-tokens/Brand
+const brands = ['Digdir', 'Tilsynet', 'Altinn', 'Brreg'] as const;
+type Brands = (typeof brands)[number];
+
 type Densities = 'Default' | 'Compact';
-const brands: Brands[] = ['Digdir', 'Tilsynet', 'Altinn', 'Brreg'];
 const prefix = 'fds';
 const basePxFontSize = 16;
 const fileheader: Named<{ fileHeader: FileHeader }> = {
@@ -39,7 +42,7 @@ const fileheader: Named<{ fileHeader: FileHeader }> = {
   ],
 };
 
-const storefrontTokensPath = '../../storefront/tokens';
+const storefrontTokensPath = path.resolve('../../apps/storefront/tokens');
 const packageTokensPath = 'brand';
 
 setupFormatters('./../../prettier.config.js');

--- a/packages/tokens/scripts/build.ts
+++ b/packages/tokens/scripts/build.ts
@@ -29,7 +29,7 @@ void registerTransforms(StyleDictionary);
 
 // File name under design-tokens/Brand
 const brands = ['Digdir', 'Tilsynet', 'Altinn', 'Brreg'] as const;
-type Brands = (typeof brands)[number];
+type Brands = typeof brands[number];
 
 type Densities = 'Default' | 'Compact';
 const prefix = 'fds';


### PR DESCRIPTION

- Fixed save path for token storefront build
- Simplified brand type used in tokens build so its easier to overwrite in fork
- Fixed eslint and prettier not cooperating when using format on save
- Fixed some typos in links to github storefront folder