### PR TITLE
style(focus): Use correct color tokens for `.focusable`

### DIFF
--- a/packages/react/src/utils/utility.module.css
+++ b/packages/react/src/utils/utility.module.css
@@ -16,11 +16,9 @@
  * Apply a focus outline on an element when it is focused with keyboard
  */
 .focusable:focus-visible {
-  --fds-inner-focus-border-color: #1e2b3c;
-  --fds-outer-focus-border-color: #fadf4b;
   --fds-focus-border-width: 3px;
 
-  outline: var(--fds-focus-border-width) solid var(--fds-outer-focus-border-color);
+  outline: var(--fds-focus-border-width) solid var(--fds-semantic-border-focus-outline);
   outline-offset: var(--fds-focus-border-width);
-  box-shadow: 0 0 0 var(--fds-focus-border-width) var(--fds-inner-focus-border-color);
+  box-shadow: 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow);
 }


### PR DESCRIPTION
Resolves #1015