### PR TITLE
chore: fix timezone in github action preview comments

### DIFF
--- a/.github/workflows/storefront-preview.yml
+++ b/.github/workflows/storefront-preview.yml
@@ -80,6 +80,6 @@ jobs:
 
             ${{ steps.regex-storybook.outputs.match }}
 
-            🖥 [Storefront](https://storefront-pr-${{ env.PR_NUMBER }}.dev.designsystemet.no) `${{ steps.current-time.outputs.formattedTime }} (OSLO time)`
+            🖥 [Storefront](https://storefront-pr-${{ env.PR_NUMBER }}.dev.designsystemet.no) `${{ steps.current-time.outputs.formattedTime }} (Norwegian time)`
 
             See all deployments at [https://dev.designsystemet.no](https://dev.designsystemet.no)

--- a/.github/workflows/storefront-preview.yml
+++ b/.github/workflows/storefront-preview.yml
@@ -80,6 +80,6 @@ jobs:
 
             ${{ steps.regex-storybook.outputs.match }}
 
-            🖥 [Storefront](https://storefront-pr-${{ env.PR_NUMBER }}.dev.designsystemet.no) `${{ steps.current-time.outputs.formattedTime }} (CEST)`
+            🖥 [Storefront](https://storefront-pr-${{ env.PR_NUMBER }}.dev.designsystemet.no) `${{ steps.current-time.outputs.formattedTime }} (OSLO time)`
 
             See all deployments at [https://dev.designsystemet.no](https://dev.designsystemet.no)

--- a/.github/workflows/storefront-preview.yml
+++ b/.github/workflows/storefront-preview.yml
@@ -66,7 +66,7 @@ jobs:
         id: current-time
         with:
           format: D. MMM YYYY - HH:mm
-          utcOffset: '+02:00'
+          timezone: Europe/Oslo
 
       - name: Update comment with deployment
         uses: peter-evans/create-or-update-comment@v3

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -67,7 +67,7 @@ jobs:
         id: current-time
         with:
           format: D. MMM YYYY - HH:mm
-          utcOffset: '+02:00'
+          timezone: Europe/Oslo
 
       - name: Update comment with deployment
         uses: peter-evans/create-or-update-comment@v3

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -79,7 +79,7 @@ jobs:
           body: |
             **Preview deployments for this pull request:**
 
-            📖 [Storybook](https://storybook-pr-${{ env.PR_NUMBER }}.dev.designsystemet.no) `${{ steps.current-time.outputs.formattedTime }} (CEST)`
+            📖 [Storybook](https://storybook-pr-${{ env.PR_NUMBER }}.dev.designsystemet.no) `${{ steps.current-time.outputs.formattedTime }} (OSLO time)`
 
             ${{ steps.regex-storefront.outputs.match }}
 

--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -79,7 +79,7 @@ jobs:
           body: |
             **Preview deployments for this pull request:**
 
-            📖 [Storybook](https://storybook-pr-${{ env.PR_NUMBER }}.dev.designsystemet.no) `${{ steps.current-time.outputs.formattedTime }} (OSLO time)`
+            📖 [Storybook](https://storybook-pr-${{ env.PR_NUMBER }}.dev.designsystemet.no) `${{ steps.current-time.outputs.formattedTime }} (Norwegian time)`
 
             ${{ steps.regex-storefront.outputs.match }}
 

--- a/apps/storefront/pages/index.mdx
+++ b/apps/storefront/pages/index.mdx
@@ -17,7 +17,7 @@ import {
 export default ({ children }) => <FrontpageLayout content={children} />;
 
 <Meta
-  title='Velkommen2'
+  title='Velkommen'
   description='Velkommen til Felles designsystem. Her vil du finne grunnleggende designelementer og komponenter du kan bruke når du utvikler tjenester'
 />
 

--- a/apps/storefront/pages/index.mdx
+++ b/apps/storefront/pages/index.mdx
@@ -17,7 +17,7 @@ import {
 export default ({ children }) => <FrontpageLayout content={children} />;
 
 <Meta
-  title='Velkommen'
+  title='Velkommen2'
   description='Velkommen til Felles designsystem. Her vil du finne grunnleggende designelementer og komponenter du kan bruke når du utvikler tjenester'
 />
 


### PR DESCRIPTION
I used UTC offset initially to set the timezone but that will not work throughout the year.
Changed to using the `timezone` config: https://github.com/josStorer/get-current-time#timezone
Tested that it works in this PR.