### PR TITLE
fix(List): :label: Default type for `children`

### DIFF
--- a/packages/react/src/components/List/List.stories.tsx
+++ b/packages/react/src/components/List/List.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { List } from '.';
 import { Link } from '../Link';
+
+import { List } from '.';
 
 type Story = StoryFn<typeof List>;
 

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -34,7 +34,6 @@ export type ListProps = {
    * @default 2
    */
   headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
-  children: ReactNode;
 } & HTMLAttributes<HTMLElement>;
 
 export const List = ({


### PR DESCRIPTION
Suggest keeping it simple and just use the default type for `children`