### PR TITLE
chore(storefront): Added Image component to be able to toggle boxShadow

### DIFF
--- a/apps/storefront/components/Image/Image.module.css
+++ b/apps/storefront/components/Image/Image.module.css
@@ -1,0 +1,14 @@
+.container {
+  display: flex;
+  max-width: 800px;
+  margin: var(--fds-spacing-7) 0;
+}
+
+.container .img {
+  box-shadow: none;
+  margin: 0;
+}
+
+.boxShadow {
+  box-shadow: var(--fds-shadow-medium);
+}

--- a/apps/storefront/components/Image/Image.module.css
+++ b/apps/storefront/components/Image/Image.module.css
@@ -2,6 +2,7 @@
   display: flex;
   max-width: 800px;
   margin: var(--fds-spacing-7) 0;
+  border-radius: var(--fds-border_radius-medium);
 }
 
 .container .img {

--- a/apps/storefront/components/Image/Image.tsx
+++ b/apps/storefront/components/Image/Image.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import cn from 'classnames';
+
+import classes from './Image.module.css';
+
+interface ImageProps {
+  alt: string;
+  src: string;
+  boxShadow: boolean;
+}
+
+const Image = ({ alt, src, boxShadow, ...rest }: ImageProps) => {
+  return (
+    <div className={cn(classes.container, { [classes.boxShadow]: boxShadow })}>
+      <img
+        className={classes.img}
+        src={src}
+        alt={alt}
+        {...rest}
+      ></img>
+    </div>
+  );
+};
+
+export { Image };

--- a/apps/storefront/components/Image/index.ts
+++ b/apps/storefront/components/Image/index.ts
@@ -1,0 +1,1 @@
+export { Image } from './Image';

--- a/apps/storefront/components/index.ts
+++ b/apps/storefront/components/index.ts
@@ -20,3 +20,4 @@ export { SidebarMenu } from './SidebarMenu';
 export { Tag } from './Tag';
 export { TeaserCard } from './TeaserCard';
 export { TokenList } from './Tokens';
+export { Image } from './Image';

--- a/apps/storefront/pages/grunnleggende/for-designere/kom-i-gang.mdx
+++ b/apps/storefront/pages/grunnleggende/for-designere/kom-i-gang.mdx
@@ -1,4 +1,4 @@
-import { Meta, ResponsiveIframe } from '@components';
+import { Meta, ResponsiveIframe, Image } from '@components';
 import { MenuPageLayout } from '@layouts';
 
 <Meta
@@ -30,7 +30,11 @@ Sjekk at du har aktivert de 3 fellesbibliotekene:
 - [Felles tokens](https://www.figma.com/file/eeznFkuH7UletQmhN174VR/Felles---Design-Tokens?type=design&node-id=2%3A193&mode=design&t=vJ1dV7QQyAAq6EPC-1)
 - [Felles ikonbibliotek](<https://www.figma.com/file/zixZT8aTsPEUSb41LIcsRr/Core-Icons-3-(Community)?type=design&node-id=774%3A2351&mode=design&t=FFPI6NYOtONV1lk4-1>)
 
-![Skjermbilde av Figma. Stegene for å aktivere bibliotekene.](/img/activate-library.png)
+<Image
+  src='/img/activate-library.png'
+  alt='Skjermbilde av Figma. Stegene for å aktivere bibliotekene.'
+  boxShadow={true}
+/>
 
 1. Trykk på bok-symbolet under "Assets"
 2. Aktiver "Felles komponenter", "Felles tokens", "Felles ikonbibliotek"


### PR DESCRIPTION
Feature request from @mrosvik:

Added an `Image` component so that editors can toggle boxShadow and maybe other preperties in the future in MDX.

Styling:
* Images have a boxShadow by default in MDX, so I reset it in the `.container .img` selector and also moved the margin to the `.container` class.