### PR TITLE
fix: :bug: Temporary change order for injected CSS

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -45,8 +45,6 @@ export default [
       postcss(
         // This is to make sure names match those in built css files
         {
-          // to: 'css-react.css',
-
           // extract: true, // disabled until our css package is released and people are informed of new setup
           modules: {
             generateScopedName,

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -45,11 +45,16 @@ export default [
       postcss(
         // This is to make sure names match those in built css files
         {
+          // to: 'css-react.css',
+
           // extract: true, // disabled until our css package is released and people are informed of new setup
           modules: {
             generateScopedName,
           },
           plugins: [cssnano({ preset: 'default' })],
+          inject: {
+            insertAt: 'top',
+          },
         },
       ),
     ],


### PR DESCRIPTION
fixes #1110

Tested using `Search` and `Checkbox` codesandbox example @Magnusrm. Seems to fix the problem for now

This is a temporary fix for when components are tree-shaked and dependant components imported. This will reverse the order of when they are injected into `<head>` making so that we get the correct order for defining css classes.


Downside with this approach is that it puts our css at the very top in our users `<head>`. Hopefully this wont cause problems for their CSS as we dont have any "global" css, only our own classes. Note that the injection to top of `head` happens once the script tag in `<head>` with the component code is resolved by the browser. 

When we get our css package in order and remove reliance on CSS-in-JS we can remove this entirely.


After:
![image](https://github.com/digdir/designsystem/assets/1070981/23284c4a-a856-4cce-b657-0a714bbaa736)
