### PR TITLE
Fix(Link): Underline not thicker on hover in safari

### DIFF
--- a/packages/react/src/components/Link/Link.module.css
+++ b/packages/react/src/components/Link/Link.module.css
@@ -18,7 +18,7 @@
 
 .link:hover {
   color: var(--fds-semantic-text-action-first-default);
-  text-decoration-thickness: max(2px, 0.125rem, 0.12em);
+  box-shadow: 0 max(2px, 0.125rem, 0.12em) var(--fds-semantic-text-action-first-default);
 }
 
 .link:active,
@@ -33,7 +33,5 @@
 .link.inverted:not(:focus, :active),
 .link.inverted:not(:focus, :active):hover,
 .link.inverted:not(:focus, :active):visited {
-  --fdsc-link-hover-underline-color: white;
-
   color: white;
 }


### PR DESCRIPTION
Fixes: #1145 

Only way I found to make the line thicker, I see focused links do the same