### PR TITLE
fix(Checkbox, Radio, Search): 🐛 Styling interferences 

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -2,9 +2,6 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import postcss from 'rollup-plugin-postcss';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
-import cssnano from 'cssnano';
-
-import { generateScopedName } from './scripts/name';
 
 const input = './tsc-build/index.js';
 
@@ -17,16 +14,12 @@ export default [
         dir: './dist/cjs',
         format: 'cjs',
         banner: "'use client';",
-        // preserveModules: true,
-        // preserveModulesRoot: 'tsc-build',
       },
       {
         input,
         dir: './dist/esm',
         format: 'es',
         banner: "'use client';",
-        // preserveModules: true,
-        // preserveModulesRoot: 'tsc-build',
       },
     ],
     external: [
@@ -38,22 +31,6 @@ export default [
       /leaflet/,
       /@navikt\/ds-icons/,
     ],
-    plugins: [
-      peerDepsExternal(),
-      resolve(),
-      commonjs(),
-      postcss(),
-      // This is to make sure names match those in built css files
-      // {
-      //   // extract: true, // disabled until our css package is released and people are informed of new setup
-      //   modules: {
-      //     generateScopedName,
-      //   },
-      //   plugins: [cssnano({ preset: 'default' })],
-      //   inject: {
-      //     insertAt: 'top',
-      //   },
-      // },
-    ],
+    plugins: [peerDepsExternal(), resolve(), commonjs(), postcss()],
   },
 ];

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -17,16 +17,16 @@ export default [
         dir: './dist/cjs',
         format: 'cjs',
         banner: "'use client';",
-        preserveModules: true,
-        preserveModulesRoot: 'tsc-build',
+        // preserveModules: true,
+        // preserveModulesRoot: 'tsc-build',
       },
       {
         input,
         dir: './dist/esm',
         format: 'es',
         banner: "'use client';",
-        preserveModules: true,
-        preserveModulesRoot: 'tsc-build',
+        // preserveModules: true,
+        // preserveModulesRoot: 'tsc-build',
       },
     ],
     external: [
@@ -42,19 +42,18 @@ export default [
       peerDepsExternal(),
       resolve(),
       commonjs(),
-      postcss(
-        // This is to make sure names match those in built css files
-        {
-          // extract: true, // disabled until our css package is released and people are informed of new setup
-          modules: {
-            generateScopedName,
-          },
-          plugins: [cssnano({ preset: 'default' })],
-          inject: {
-            insertAt: 'top',
-          },
-        },
-      ),
+      postcss(),
+      // This is to make sure names match those in built css files
+      // {
+      //   // extract: true, // disabled until our css package is released and people are informed of new setup
+      //   modules: {
+      //     generateScopedName,
+      //   },
+      //   plugins: [cssnano({ preset: 'default' })],
+      //   inject: {
+      //     insertAt: 'top',
+      //   },
+      // },
     ],
   },
 ];

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -2,6 +2,9 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import postcss from 'rollup-plugin-postcss';
 import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import cssnano from 'cssnano';
+
+import { generateScopedName } from './scripts/name';
 
 const input = './tsc-build/index.js';
 
@@ -14,12 +17,16 @@ export default [
         dir: './dist/cjs',
         format: 'cjs',
         banner: "'use client';",
+        // preserveModules: true,
+        // preserveModulesRoot: 'tsc-build',
       },
       {
         input,
         dir: './dist/esm',
         format: 'es',
         banner: "'use client';",
+        // preserveModules: true,
+        // preserveModulesRoot: 'tsc-build',
       },
     ],
     external: [
@@ -31,6 +38,18 @@ export default [
       /leaflet/,
       /@navikt\/ds-icons/,
     ],
-    plugins: [peerDepsExternal(), resolve(), commonjs(), postcss()],
+    plugins: [
+      peerDepsExternal(),
+      resolve(),
+      commonjs(),
+      postcss({
+        // disabled until our css package is released and people are informed of new setup
+        // extract: true,
+        modules: {
+          generateScopedName,
+        },
+        plugins: [cssnano({ preset: 'default' })],
+      }),
+    ],
   },
 ];

--- a/packages/react/scripts/name.js
+++ b/packages/react/scripts/name.js
@@ -1,13 +1,24 @@
 import path from 'path';
 
+export function hashCode(input) {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    const chr = input.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0;
+  }
+  return (hash + 2147483648).toString(16);
+}
+
 /**
  *  @url https://github.com/madyankin/postcss-modules#generating-scoped-names
- * @param {string} selector
+ * @param {string} name
  * @param {string} fileNames
  * @returns
  */
-export function generateScopedName(selector, fileNames) {
+export function generateScopedName(name, fileNames) {
   const componentName = path.basename(fileNames, '.module.css').toLowerCase();
+  const hash = hashCode(fileNames);
 
-  return `fds-${componentName}-${selector}`;
+  return `fds-${componentName}-${name}-${hash}`;
 }


### PR DESCRIPTION
Trying to fix #1110 again

- Disabling tree-shaking until we get our css-package published to reduce (hopefully negate) css-in-jss being injected in the wrong order when components are internally dependant on each other. 
  - One drawback is that this will result in potential bigger bundles for our end users for the time being. 
- Added hash for our generated css classnames as we were getting duplicates, exampled being `LegacyPopover` vs `Popover`
