### PR TITLE
refactor(Textarea, Textfield): :rewind: Revert absolute `min-height` value

### DIFF
--- a/packages/react/src/components/form/Textarea/Textarea.module.css
+++ b/packages/react/src/components/form/Textarea/Textarea.module.css
@@ -30,7 +30,7 @@
   position: relative;
   box-sizing: border-box;
   flex: 0 1 auto;
-  min-height: 44px;
+  min-height: 2.5em;
   width: 100%;
   appearance: none;
   padding: var(--fds-spacing-3);

--- a/packages/react/src/components/form/Textfield/Textfield.module.css
+++ b/packages/react/src/components/form/Textfield/Textfield.module.css
@@ -31,7 +31,7 @@
   position: relative;
   box-sizing: border-box;
   flex: 0 1 auto;
-  min-height: 44px;
+  min-height: 2.5em;
   width: 100%;
   appearance: none;
   padding: 0 var(--fds-spacing-3);


### PR DESCRIPTION
Revert changes that had unintended consequences, preventing `size="small"` `input` from being "small" (36px).