### PR TITLE
feat(ToggleGroup): Support `form` when `name` is provided

### DIFF
--- a/packages/react/src/components/ToggleGroup/ToggleGroup.test.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.test.tsx
@@ -128,4 +128,40 @@ describe('ToggleGroup', () => {
     expect(onChangeValue).toEqual('test2');
     expect(item2).toHaveAttribute('aria-checked', 'true');
   });
+
+  test('if we pass a name, we should have a hidden input with that name', () => {
+    render(
+      <ToggleGroup name='my-name'>
+        <ToggleGroup.Item value='test'>test</ToggleGroup.Item>
+      </ToggleGroup>,
+    );
+
+    const input = document.querySelector('input[type="hidden"]');
+    expect(input).toHaveAttribute('name', 'my-name');
+  });
+
+  test('if we pass a name, we should have a hidden input with that name and value', () => {
+    render(
+      <ToggleGroup
+        name='my-name'
+        defaultValue='test'
+      >
+        <ToggleGroup.Item value='test'>test</ToggleGroup.Item>
+      </ToggleGroup>,
+    );
+
+    const input = document.querySelector('input[type="hidden"]');
+    expect(input).toHaveAttribute('value', 'test');
+  });
+
+  test('if we dont pass a name, we should not have a hidden input', () => {
+    render(
+      <ToggleGroup>
+        <ToggleGroup.Item value='test'>test</ToggleGroup.Item>
+      </ToggleGroup>,
+    );
+
+    const input = document.querySelector('input[type="hidden"]');
+    expect(input).toBeNull();
+  });
 });

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.test.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.test.tsx
@@ -154,6 +154,34 @@ describe('ToggleGroup', () => {
     expect(input).toHaveAttribute('value', 'test');
   });
 
+  test('should send the value to a form when the form is submitted', async () => {
+    const formSubmitPromise = new Promise<FormData>((resolve) => {
+      const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        resolve(new FormData(event.currentTarget));
+      };
+
+      render(
+        <form onSubmit={handleSubmit}>
+          <ToggleGroup
+            name='test'
+            defaultValue='test2'
+          >
+            <ToggleGroup.Item value='test1'>test1</ToggleGroup.Item>
+            <ToggleGroup.Item value='test2'>test2</ToggleGroup.Item>
+          </ToggleGroup>
+          <button type='submit'>Submit</button>
+        </form>,
+      );
+    });
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    await user.click(submitButton);
+
+    const formData = await formSubmitPromise;
+    expect(formData.get('test')).toBe('test2');
+  });
+
   test('if we dont pass a name, we should not have a hidden input', () => {
     render(
       <ToggleGroup>

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
@@ -74,6 +74,13 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
             size,
           }}
         >
+          {name && (
+            <input
+              type='hidden'
+              name={name}
+              value={value}
+            />
+          )}
           <RovingTabindexRoot
             as='div'
             valueId={value}


### PR DESCRIPTION
Resolves #1214