### PR TITLE
perf: :zap: Replace `classnames` with `clsx`

### DIFF
--- a/apps/dev/src/components/SkeletonCard/SkeletonCard.tsx
+++ b/apps/dev/src/components/SkeletonCard/SkeletonCard.tsx
@@ -1,4 +1,4 @@
-import cn from 'classnames';
+import cl from 'clsx';
 import React from 'react';
 
 import classes from './SkeletonCard.module.css';
@@ -7,7 +7,7 @@ export const SkeletonCard = () => {
   return (
     <div className={classes.card}>
       <div className={classes.element}></div>
-      <div className={cn(classes.element, classes.shortElement)}></div>
+      <div className={cl(classes.element, classes.shortElement)}></div>
     </div>
   );
 };

--- a/apps/storefront/components/Banner/Banner.tsx
+++ b/apps/storefront/components/Banner/Banner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { Tag } from '../Tag/Tag';
 import { Container } from '../Container/Container';
@@ -28,10 +28,10 @@ const Banner = ({ title, desc }: BannerProps) => {
 
       <div className={classes.right}>
         <div className={classes.shapes}>
-          <div className={cn(classes.shape, classes.one)}></div>
-          <div className={cn(classes.shape, classes.two)}></div>
-          <div className={cn(classes.shape, classes.three)}></div>
-          <div className={cn(classes.shape, classes.four)}></div>
+          <div className={cl(classes.shape, classes.one)}></div>
+          <div className={cl(classes.shape, classes.two)}></div>
+          <div className={cl(classes.shape, classes.three)}></div>
+          <div className={cl(classes.shape, classes.four)}></div>
         </div>
       </div>
     </Container>

--- a/apps/storefront/components/Container/Container.tsx
+++ b/apps/storefront/components/Container/Container.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Container.module.css';
 
@@ -12,7 +12,7 @@ const Container = ({ children, className, ...props }: ContainerProps) => {
   return (
     <div
       {...props}
-      className={cn(className, classes.container)}
+      className={cl(className, classes.container)}
     >
       {children}
     </div>

--- a/apps/storefront/components/Header/Header.tsx
+++ b/apps/storefront/components/Header/Header.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { MenuHamburgerIcon, XMarkIcon } from '@navikt/aksel-icons';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Header.module.css';
 
@@ -82,7 +82,7 @@ const Header = () => {
               />
             )}
           </button>
-          <ul className={cn(classes.menu, { [classes.active]: open })}>
+          <ul className={cl(classes.menu, { [classes.active]: open })}>
             {menu.map((item, index) => (
               <li
                 className={classes.item}
@@ -92,7 +92,7 @@ const Header = () => {
                   href={item.url}
                   onClick={() => setOpen(false)}
                   prefetch={false}
-                  className={cn(
+                  className={cl(
                     isMenuItemActive(router.pathname, item.url)
                       ? classes.active
                       : '',

--- a/apps/storefront/components/Image/Image.tsx
+++ b/apps/storefront/components/Image/Image.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Image.module.css';
 
@@ -11,7 +11,7 @@ interface ImageProps {
 
 const Image = ({ alt, src, boxShadow, ...rest }: ImageProps) => {
   return (
-    <div className={cn(classes.container, { [classes.boxShadow]: boxShadow })}>
+    <div className={cl(classes.container, { [classes.boxShadow]: boxShadow })}>
       <img
         className={classes.img}
         src={src}

--- a/apps/storefront/components/ImageSection/ImageSection.tsx
+++ b/apps/storefront/components/ImageSection/ImageSection.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, createElement } from 'react';
 import Image from 'next/image';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { Container } from '../Container/Container';
 
@@ -53,7 +53,7 @@ const ImageSection = ({
 
   return (
     <div className={classes[backgroundColor]}>
-      <Container className={cn(classes.section)}>
+      <Container className={cl(classes.section)}>
         {imgPosition === 'left' && (
           <div className={classes.imgContainer}>
             <Image

--- a/apps/storefront/components/MdxContent/MdxContent.tsx
+++ b/apps/storefront/components/MdxContent/MdxContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './MdxContent.module.css';
 
@@ -9,7 +9,7 @@ interface MdxContentProps {
 }
 
 const MdxContent = ({ children, classname }: MdxContentProps) => {
-  return <div className={cn(classname, classes.content)}>{children}</div>;
+  return <div className={cl(classname, classes.content)}>{children}</div>;
 };
 
 export { MdxContent };

--- a/apps/storefront/components/NavigationCard/NavigationCard.tsx
+++ b/apps/storefront/components/NavigationCard/NavigationCard.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import cn from 'classnames';
+import cl from 'clsx';
 import React from 'react';
 
 import classes from './NavigationCard.module.css';
@@ -25,9 +25,9 @@ const NavigationCard = ({
     <Link
       href={url}
       prefetch={false}
-      className={cn(classes.card, classes[backgroundColor])}
+      className={cl(classes.card, classes[backgroundColor])}
     >
-      <div className={cn(classes.iconContainer, classes[color])}>{icon}</div>
+      <div className={cl(classes.iconContainer, classes[color])}>{icon}</div>
       <h3 className={classes.title}>{title}</h3>
       <div className={classes.desc}>{description}</div>
     </Link>

--- a/apps/storefront/components/ResponsiveIframe/ResponsiveIframe.tsx
+++ b/apps/storefront/components/ResponsiveIframe/ResponsiveIframe.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './ResponsiveIframe.module.css';
 
@@ -17,7 +17,7 @@ const ResponsiveIframe = ({
 }: ResponsiveIframeProps) => {
   return (
     <div
-      className={cn(classes.container, {
+      className={cl(classes.container, {
         [classes.aspectFourThree]: aspectRatio === '4-3',
       })}
     >

--- a/apps/storefront/components/Section/Section.tsx
+++ b/apps/storefront/components/Section/Section.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import Image from 'next/image';
 
 import { Container } from '../Container/Container';
@@ -20,7 +20,7 @@ const Section = ({
   detail,
 }: SectionProps) => {
   return (
-    <div className={cn(classes.section, classes[backgroundColor])}>
+    <div className={cl(classes.section, classes[backgroundColor])}>
       <Container>
         <div className={classes.header}>
           {title && <h2 className={classes.title}>{title}</h2>}

--- a/apps/storefront/components/SidebarMenu/SidebarMenu.tsx
+++ b/apps/storefront/components/SidebarMenu/SidebarMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
-import cn from 'classnames';
+import cl from 'clsx';
 import { Button } from '@digdir/design-system-react';
 
 import { SiteConfig } from '../../siteConfig';
@@ -49,7 +49,7 @@ const SidebarMenu = ({ routerPath }: SidebarMenuProps) => {
             {showMenu ? 'Skjul' : 'Vis'} side meny
           </Button>
 
-          <div className={cn(classes.menu, { [classes.activeMenu]: showMenu })}>
+          <div className={cl(classes.menu, { [classes.activeMenu]: showMenu })}>
             <h3 className={classes.title}>
               {SiteConfig.menu[activeIndex].name}
             </h3>
@@ -58,7 +58,7 @@ const SidebarMenu = ({ routerPath }: SidebarMenuProps) => {
                 (item: PageMenuItemType, index) => (
                   <li
                     key={index}
-                    className={cn(classes.listGroup, {
+                    className={cl(classes.listGroup, {
                       [classes.listGroupCompact]: !item.children,
                     })}
                   >
@@ -75,7 +75,7 @@ const SidebarMenu = ({ routerPath }: SidebarMenuProps) => {
                                 <Link
                                   href={'/' + item2.url}
                                   prefetch={false}
-                                  className={cn(classes.link, {
+                                  className={cl(classes.link, {
                                     [classes.linkActive]: isItemActive(
                                       item2.url,
                                       routerPath,
@@ -94,7 +94,7 @@ const SidebarMenu = ({ routerPath }: SidebarMenuProps) => {
                       <Link
                         href={'/' + item.url}
                         prefetch={false}
-                        className={cn(classes.link, classes.linkCompact, {
+                        className={cl(classes.link, classes.linkCompact, {
                           [classes.linkActive]: isItemActive(
                             item.url,
                             routerPath,

--- a/apps/storefront/components/Tag/Tag.tsx
+++ b/apps/storefront/components/Tag/Tag.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { capitalizeString } from '../../utils/StringHelpers';
 
@@ -13,7 +13,7 @@ interface TagProps {
 
 const Tag = ({ color, type, size = 'medium' }: TagProps) => {
   return (
-    <span className={cn(classes.tag, classes[color], classes[size])}>
+    <span className={cl(classes.tag, classes[color], classes[size])}>
       {capitalizeString(type)}
     </span>
   );

--- a/apps/storefront/components/Tokens/TokenList/TokenList.tsx
+++ b/apps/storefront/components/Tokens/TokenList/TokenList.tsx
@@ -1,7 +1,7 @@
 import type { HTMLAttributes } from 'react';
 import React, { useEffect, useState } from 'react';
 import { Dropdown, Button } from '@navikt/ds-react';
-import cn from 'classnames';
+import cl from 'clsx';
 import type { TransformedToken as Token } from 'style-dictionary';
 
 import { capitalizeString } from '../../../utils/StringHelpers';
@@ -153,9 +153,9 @@ const TokenList = ({
               return (
                 <div key={group}>
                   {!isSlim && <h4>{capitalizeString(group)}</h4>}
-                  <div className={cn(!isSlim && classes.group)}>
+                  <div className={cl(!isSlim && classes.group)}>
                     <div
-                      className={cn(classes.cards, {
+                      className={cl(classes.cards, {
                         [classes.cards2]: cardColumns === 2,
                       })}
                     >

--- a/docs-components/DoAndDont/DoAndDont.tsx
+++ b/docs-components/DoAndDont/DoAndDont.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { Heading, Paragraph } from '@digdir/design-system-react';
 import { CheckmarkIcon, XMarkIcon } from '@navikt/aksel-icons';
 
@@ -15,7 +15,7 @@ const Wrapper = ({ variant, description, image, alt }: WrapperProps) => {
 
   return (
     <figure
-      className={cn(
+      className={cl(
         styles.wrapper,
         styles[variant],
         aspectRatio > 2 && styles.landscape,

--- a/docs-components/LinkHeading/LinkHeading.tsx
+++ b/docs-components/LinkHeading/LinkHeading.tsx
@@ -1,7 +1,7 @@
 import { Heading, Link } from '@digdir/design-system-react';
 import type { HeadingProps } from '@digdir/design-system-react';
 import { LinkIcon } from '@navikt/aksel-icons';
-import cn from 'classnames';
+import cl from 'clsx';
 import React from 'react';
 
 import classes from './LinkHeading.module.css';
@@ -16,7 +16,7 @@ export const LinkHeading = ({ ...rest }: LinkHeadingProps) => {
   return (
     <Heading
       {...rest}
-      className={cn(classes.linkHeading, rest.className)}
+      className={cl(classes.linkHeading, rest.className)}
     >
       <Link
         aria-hidden='true'

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/rimraf": "^4.0.5",
     "@typescript-eslint/eslint-plugin": "6.15.0",
     "@typescript-eslint/parser": "6.15.0",
-    "classnames": "^2.3.2",
+    "clsx": "^2.0.0",
     "copyfiles": "^2.4.1",
     "eslint": "8.56.0",
     "eslint-config-prettier": "9.0.0",

--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Accordion.module.css';
 
@@ -19,7 +19,7 @@ export const Accordion = forwardRef<
 >(({ border = false, color = 'neutral', className, ...rest }, ref) => (
   <div
     {...rest}
-    className={cn(
+    className={cl(
       classes.accordion,
       classes[color],
       {

--- a/packages/react/src/components/Accordion/AccordionContent/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent/AccordionContent.tsx
@@ -1,4 +1,4 @@
-import cn from 'classnames';
+import cl from 'clsx';
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef, useContext } from 'react';
 
@@ -35,7 +35,7 @@ export const AccordionContent = forwardRef<
         as='div'
         size='small'
         ref={ref}
-        className={cn(classes.content, className)}
+        className={cl(classes.content, className)}
       >
         {children}
       </Paragraph>

--- a/packages/react/src/components/Accordion/AccordionHeader/AccordionHeader.tsx
+++ b/packages/react/src/components/Accordion/AccordionHeader/AccordionHeader.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon } from '@navikt/aksel-icons';
-import cn from 'classnames';
+import cl from 'clsx';
 import type { MouseEventHandler, HTMLAttributes } from 'react';
 import React, { forwardRef, useContext } from 'react';
 
@@ -41,7 +41,7 @@ export const AccordionHeader = forwardRef<
       ref={ref}
       size='xsmall'
       level={level}
-      className={cn(classes.header, className)}
+      className={cl(classes.header, className)}
     >
       <button
         type='button'

--- a/packages/react/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -1,4 +1,4 @@
-import cn from 'classnames';
+import cl from 'clsx';
 import type { HTMLAttributes } from 'react';
 import React, { createContext, forwardRef, useState, useId } from 'react';
 
@@ -33,7 +33,7 @@ export const AccordionItem = forwardRef<HTMLDivElement, AccordionItemProps>(
 
     return (
       <div
-        className={cn(classes.item, className, {
+        className={cl(classes.item, className, {
           [classes.open]: open ?? internalOpen,
         })}
         ref={ref}

--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -6,7 +6,7 @@ import {
   XMarkOctagonFillIcon,
   ExclamationmarkTriangleFillIcon,
 } from '@navikt/aksel-icons';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { Paragraph } from '..';
 
@@ -50,7 +50,7 @@ export const Alert = forwardRef<HTMLDivElement, AlertProps>(
       <div
         {...rest}
         ref={ref}
-        className={cn(
+        className={cl(
           classes.alert,
           classes[severity],
           elevated && classes.elevated,

--- a/packages/react/src/components/Box/Box.tsx
+++ b/packages/react/src/components/Box/Box.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import type { OverridableComponent } from '../../types/OverridableComponent';
 
@@ -45,7 +45,7 @@ export const Box: OverridableComponent<BoxProps, HTMLDivElement> = forwardRef(
     <Component
       {...rest}
       ref={ref}
-      className={cn(
+      className={cl(
         shadow && classes[shadow + 'Shadow'],
         borderRadius && classes[borderRadius + 'BorderRadius'],
         borderColor && classes[borderColor + 'BorderColor'],

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import type { ReactNode, ButtonHTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { SvgIcon } from '../SvgIcon';
 import utilityClasses from '../../utilities/utility.module.css';
@@ -48,7 +48,7 @@ export const Button: OverridableComponent<ButtonProps, HTMLButtonElement> =
         {...rest}
         ref={ref}
         type={type}
-        className={cn(
+        className={cl(
           classes.button,
           utilityClasses.focusable,
           classes[size],

--- a/packages/react/src/components/Card/Card.tsx
+++ b/packages/react/src/components/Card/Card.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import type { OverridableComponent } from '../../types/OverridableComponent';
 import utilityClasses from '../../utilities/utility.module.css';
@@ -25,7 +25,7 @@ export const Card: OverridableComponent<CardProps, HTMLDivElement> = forwardRef(
       <Component
         {...rest}
         ref={ref}
-        className={cn(
+        className={cl(
           classes.card,
           classes[color],
           isLink && classes.linkCard,

--- a/packages/react/src/components/Card/CardContent.tsx
+++ b/packages/react/src/components/Card/CardContent.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, type HTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Card.module.css';
 
@@ -9,7 +9,7 @@ export const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
   ({ children, ...rest }, ref) => (
     <div
       {...rest}
-      className={cn(classes.content, rest.className)}
+      className={cl(classes.content, rest.className)}
       ref={ref}
     >
       {children}

--- a/packages/react/src/components/Card/CardFooter.tsx
+++ b/packages/react/src/components/Card/CardFooter.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, type HTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Card.module.css';
 
@@ -9,7 +9,7 @@ export const CardFooter = forwardRef<HTMLDivElement, CardFooterProps>(
   ({ children, ...rest }, ref) => (
     <div
       {...rest}
-      className={cn(classes.footer, rest.className)}
+      className={cl(classes.footer, rest.className)}
       ref={ref}
     >
       {children}

--- a/packages/react/src/components/Card/CardHeader.tsx
+++ b/packages/react/src/components/Card/CardHeader.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, type HTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Card.module.css';
 
@@ -9,7 +9,7 @@ export const CardHeader = forwardRef<HTMLDivElement, CardHeaderProps>(
   ({ children, ...rest }, ref) => (
     <div
       {...rest}
-      className={cn(classes.header, rest.className)}
+      className={cl(classes.header, rest.className)}
       ref={ref}
     >
       {children}

--- a/packages/react/src/components/Card/CardMedia.tsx
+++ b/packages/react/src/components/Card/CardMedia.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, type HTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Card.module.css';
 
@@ -9,7 +9,7 @@ export const CardMedia = forwardRef<HTMLDivElement, CardMediaProps>(
   ({ children, ...rest }, ref) => (
     <div
       {...rest}
-      className={cn(classes.media, rest.className)}
+      className={cl(classes.media, rest.className)}
       ref={ref}
     >
       {children}

--- a/packages/react/src/components/Chip/Group/Group.tsx
+++ b/packages/react/src/components/Chip/Group/Group.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef, createContext } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from '../Chip.module.css';
 
@@ -22,7 +22,7 @@ export const Group = forwardRef<HTMLUListElement, ChipGroupProps>(
     <ul
       {...rest}
       ref={ref}
-      className={cn(classes.groupContainer, classes[size], rest.className)}
+      className={cl(classes.groupContainer, classes[size], rest.className)}
     >
       <ChipGroupContext.Provider value={{ size }}>
         {React.Children.toArray(children).map((child, index) =>

--- a/packages/react/src/components/Chip/Removable/Removable.tsx
+++ b/packages/react/src/components/Chip/Removable/Removable.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes } from 'react';
 import React, { useContext, forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { XMarkIcon } from '@navikt/aksel-icons';
 
 import classes from '../Chip.module.css';
@@ -25,7 +25,7 @@ export const RemovableChip = forwardRef<HTMLButtonElement, RemovableChipProps>(
         {...rest}
         type='button'
         ref={ref}
-        className={cn(
+        className={cl(
           classes.chipButton,
           utilityClasses.focusable,
           classes[group?.size || size],

--- a/packages/react/src/components/Chip/Toggle/Toggle.tsx
+++ b/packages/react/src/components/Chip/Toggle/Toggle.tsx
@@ -1,7 +1,7 @@
 import type { ButtonHTMLAttributes } from 'react';
 import React, { forwardRef, useContext } from 'react';
 import { CheckmarkIcon } from '@navikt/aksel-icons';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { Paragraph } from '../../Typography';
 import { ChipGroupContext } from '../Group/Group';
@@ -44,7 +44,7 @@ export const ToggleChip = forwardRef<HTMLButtonElement, ToggleChipProps>(
         ref={ref}
         type='button'
         aria-pressed={selected}
-        className={cn(
+        className={cl(
           classes.chipButton,
           utilityClasses.focusable,
           classes[group?.size || size],

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Divider.module.css';
 
@@ -15,7 +15,7 @@ export const Divider = ({ color = 'default', ...rest }: DividerProps) => {
   return (
     <hr
       {...rest}
-      className={cn(classes.divider, classes[color], rest.className)}
+      className={cl(classes.divider, classes[color], rest.className)}
     />
   );
 };

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.tsx
@@ -4,7 +4,7 @@ import React, {
   useLayoutEffect,
   useRef,
 } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import type { Placement } from '@floating-ui/react';
 import {
   useFloating,
@@ -127,7 +127,7 @@ export const DropdownMenu = forwardRef<HTMLUListElement, DropdownMenuProps>(
                 ref: floatingRef,
                 tabIndex: undefined,
               })}
-              className={cn(classes.dropdown, classes[size], rest.className)}
+              className={cl(classes.dropdown, classes[size], rest.className)}
             >
               {children}
             </ul>

--- a/packages/react/src/components/DropdownMenu/DropdownMenuGroup/DropdownMenuGroup.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenuGroup/DropdownMenuGroup.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext, useId } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { Paragraph } from '../../Typography';
 import { DropdownMenuContext } from '../DropdownMenu';
@@ -27,14 +27,14 @@ export const DropdownMenuGroup = forwardRef<
         {...rest}
         ref={ref}
         role='group'
-        className={cn(classes.section, rest.className)}
+        className={cl(classes.section, rest.className)}
       >
         {heading && (
           <Paragraph
             as='h2'
             id={headingId}
             size={size}
-            className={cn(classes.heading, rest.className)}
+            className={cl(classes.heading, rest.className)}
           >
             {heading}
           </Paragraph>

--- a/packages/react/src/components/DropdownMenu/DropdownMenuItem/DropdownMenuItem.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenuItem/DropdownMenuItem.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import type { ButtonProps } from '../../Button';
 import { Button } from '../../Button';
@@ -24,7 +24,7 @@ export const DropdownMenuItem: OverridableComponent<
         variant='tertiary'
         size={menu.size}
         fullWidth
-        className={cn(classes.item, rest.className)}
+        className={cl(classes.item, rest.className)}
         role='menuitem'
       >
         {children}

--- a/packages/react/src/components/HelpText/HelpText.tsx
+++ b/packages/react/src/components/HelpText/HelpText.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes } from 'react';
 import React, { useRef, useState } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import type { Placement } from '@floating-ui/utils';
 
 import { Popover } from '../Popover';
@@ -44,7 +44,7 @@ const HelpText = ({
       <button
         {...rest}
         ref={buttonRef}
-        className={cn(classes.helpTextButton, utilClasses.focusable, className)}
+        className={cl(classes.helpTextButton, utilClasses.focusable, className)}
         aria-expanded={open}
         onClick={(event) => {
           setOpen((isOpen) => !isOpen);
@@ -53,7 +53,7 @@ const HelpText = ({
       >
         <HelpTextIcon
           filled
-          className={cn(
+          className={cl(
             classes.helpTextIcon,
             classes.helpTextIconFilled,
             classes[size],
@@ -62,7 +62,7 @@ const HelpText = ({
           openState={open}
         />
         <HelpTextIcon
-          className={cn(classes.helpTextIcon, classes[size], className)}
+          className={cl(classes.helpTextIcon, classes[size], className)}
           openState={open}
         />
         <span className={utilClasses.visuallyHidden}>{title}</span>

--- a/packages/react/src/components/Link/Link.tsx
+++ b/packages/react/src/components/Link/Link.tsx
@@ -1,6 +1,6 @@
 import type { AnchorHTMLAttributes, ElementType, ReactNode } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import type { OverridableComponent } from '../../types/OverridableComponent';
 
@@ -31,7 +31,7 @@ export const Link: OverridableComponent<LinkProps, HTMLAnchorElement> =
     ) => (
       <Component
         {...rest}
-        className={cn(classes.link, inverted && classes.inverted, className)}
+        className={cl(classes.link, inverted && classes.inverted, className)}
         ref={ref}
       >
         {children}

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes, ReactNode } from 'react';
 import React, { useId, useMemo } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import type { HeadingProps } from '../Typography';
 import { Heading, Paragraph } from '../Typography';
@@ -63,7 +63,7 @@ export const List = ({
       <Paragraph
         as={as}
         size={size}
-        className={cn(classes.list)}
+        className={cl(classes.list)}
         role='list'
         {...(heading ? { 'aria-labelledby': headingId } : {})}
       >

--- a/packages/react/src/components/List/ListItem/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem/ListItem.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { HTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './ListItem.module.css';
 
@@ -9,7 +9,7 @@ export type ListItemProps = HTMLAttributes<HTMLLIElement>;
 export const ListItem = ({ children, ...rest }: ListItemProps) => (
   <li
     {...rest}
-    className={cn(classes.listItem, rest.className)}
+    className={cl(classes.listItem, rest.className)}
   >
     {children}
   </li>

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -1,6 +1,6 @@
 import type { DialogHTMLAttributes } from 'react';
 import React, { createContext, forwardRef, useEffect, useRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import {
   FloatingFocusManager,
   useFloating,
@@ -104,7 +104,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(
         <dialog
           ref={mergedRefs}
           {...props}
-          className={cn(classes.modal, props.className)}
+          className={cl(classes.modal, props.className)}
           onCancel={onCancel}
         >
           {open && (

--- a/packages/react/src/components/Modal/ModalContent/ModaContent.tsx
+++ b/packages/react/src/components/Modal/ModalContent/ModaContent.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import type { HTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './ModalContent.module.css';
 
@@ -12,7 +12,7 @@ export const ModalContent = forwardRef<
     <div
       {...props}
       ref={ref}
-      className={cn(classes.modalContent, props.className)}
+      className={cl(classes.modalContent, props.className)}
     >
       {children}
     </div>

--- a/packages/react/src/components/Modal/ModalFooter/ModalFooter.tsx
+++ b/packages/react/src/components/Modal/ModalFooter/ModalFooter.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './ModalFooter.module.css';
 
@@ -10,7 +10,7 @@ export const ModalFooter = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>(
       <footer
         {...props}
         ref={ref}
-        className={cn(classes.modalFooter, props.className)}
+        className={cl(classes.modalFooter, props.className)}
       >
         {children}
       </footer>

--- a/packages/react/src/components/Modal/ModalHeader/ModalHeader.tsx
+++ b/packages/react/src/components/Modal/ModalHeader/ModalHeader.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef, useContext } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { XMarkIcon } from '@navikt/aksel-icons';
 
 import { Heading, Paragraph } from '../../Typography';
@@ -26,7 +26,7 @@ export const ModalHeader = forwardRef<HTMLDivElement, ModalHeaderProps>(
       <div
         {...rest}
         ref={ref}
-        className={cn(
+        className={cl(
           classes.modalHeader,
           !closeButton && classes.noCloseButton,
           rest.className,

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react';
 import * as React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { ChevronLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons';
 
 import { Button } from '../Button';
@@ -93,7 +93,7 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
         ref={ref}
         {...rest}
       >
-        <ul className={cn(classes.pagination, classes[size])}>
+        <ul className={cl(classes.pagination, classes[size])}>
           <li>
             <Button
               icon={<ChevronLeftIcon aria-hidden />}
@@ -104,14 +104,14 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
               variant='tertiary'
               color={'first'}
               size={size}
-              className={cn({ [classes.hidden]: currentPage === 1 })}
+              className={cl({ [classes.hidden]: currentPage === 1 })}
             >
               {!hideLabels && previousLabel}
             </Button>
           </li>
           {getSteps({ compact, currentPage, totalPages }).map((step, i) => (
             <li
-              className={cn(
+              className={cl(
                 classes.listitem,
                 classes[size],
                 compact && classes.compact,
@@ -120,7 +120,7 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
             >
               {step === 'ellipsis' ? (
                 <Paragraph
-                  className={cn(classes.ellipsis)}
+                  className={cl(classes.ellipsis)}
                   size={size}
                 >
                   …
@@ -152,7 +152,7 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
                 onChange(currentPage + 1);
               }}
               iconPlacement='right'
-              className={cn({
+              className={cl({
                 [classes.hidden]: currentPage === totalPages,
               })}
             >

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -15,7 +15,7 @@ import {
 } from '@floating-ui/react';
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef, useLayoutEffect, useMemo, useRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { Paragraph } from '../Typography';
 
@@ -132,7 +132,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
             ref={floatingEl}
             as={'div'}
             size={size}
-            className={cn(
+            className={cl(
               classes.popover,
               classes[variant],
               classes[size],
@@ -150,7 +150,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
             {children}
             <div
               ref={arrowRef}
-              className={cn(classes.arrow, classes[arrowPlacement])}
+              className={cl(classes.arrow, classes[arrowPlacement])}
               style={{
                 height: ARROW_HEIGHT,
                 width: ARROW_HEIGHT,

--- a/packages/react/src/components/Skeleton/Circle/Circle.tsx
+++ b/packages/react/src/components/Skeleton/Circle/Circle.tsx
@@ -1,5 +1,5 @@
 import React, { type HTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from '../Skeleton.module.css';
 import { useSynchronizedAnimation } from '../../../hooks';
@@ -25,7 +25,7 @@ export const Circle = ({
     <div
       {...rest}
       ref={ref}
-      className={cn(
+      className={cl(
         classes.skeleton,
         classes.circle,
         { [classes.hasChildren]: Boolean(children) },

--- a/packages/react/src/components/Skeleton/Rectangle/Rectangle.tsx
+++ b/packages/react/src/components/Skeleton/Rectangle/Rectangle.tsx
@@ -1,5 +1,5 @@
 import React, { type HTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { useSynchronizedAnimation } from '../../../hooks';
 import classes from '../Skeleton.module.css';
@@ -25,7 +25,7 @@ export const Rectangle = ({
     <div
       {...rest}
       ref={ref}
-      className={cn(
+      className={cl(
         classes.skeleton,
         classes.rectangle,
         {

--- a/packages/react/src/components/Skeleton/Text/Text.tsx
+++ b/packages/react/src/components/Skeleton/Text/Text.tsx
@@ -1,5 +1,5 @@
 import React, { type HTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from '../Skeleton.module.css';
 import { useSynchronizedAnimation } from '../../../hooks';
@@ -25,7 +25,7 @@ export const Text = ({
     <div
       {...rest}
       ref={ref}
-      className={cn(
+      className={cl(
         classes.skeleton,
         classes.text,
         {

--- a/packages/react/src/components/SkipLink/SkipLink.tsx
+++ b/packages/react/src/components/SkipLink/SkipLink.tsx
@@ -1,6 +1,6 @@
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import utilityClasses from './../../utilities/utility.module.css';
 import classes from './SkipLink.module.css';
@@ -22,7 +22,7 @@ export const SkipLink = ({
     <a
       href={href}
       {...rest}
-      className={cn(
+      className={cl(
         utilityClasses.visuallyHidden,
         classes.skiplink,
         rest.className,

--- a/packages/react/src/components/Spinner/Spinner.tsx
+++ b/packages/react/src/components/Spinner/Spinner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { useSynchronizedAnimation } from '../../hooks';
 
@@ -41,7 +41,7 @@ export const Spinner = ({
 
   return (
     <svg
-      className={cn(classes.spinner, className)}
+      className={cl(classes.spinner, className)}
       style={{ width: sizeMap[size], height: sizeMap[size] }}
       viewBox='0 0 50 50'
       {...rest}
@@ -57,7 +57,7 @@ export const Spinner = ({
         strokeWidth='5'
       ></circle>
       <circle
-        className={cn(classes.spinnerCircle, classes[variant])}
+        className={cl(classes.spinnerCircle, classes[variant])}
         cx='25'
         cy='25'
         r='20'

--- a/packages/react/src/components/Table/Table.tsx
+++ b/packages/react/src/components/Table/Table.tsx
@@ -1,6 +1,6 @@
 import type { HTMLProps } from 'react';
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Table.module.css';
 import type { ChangeHandler, TableContextType } from './utils';
@@ -27,7 +27,7 @@ export function Table<T>({
   return (
     <table
       {...tableProps}
-      className={cn(classes.table, className)}
+      className={cl(classes.table, className)}
     >
       <TableContext.Provider value={context}>{children}</TableContext.Provider>
     </table>

--- a/packages/react/src/components/Table/TableBody.tsx
+++ b/packages/react/src/components/Table/TableBody.tsx
@@ -1,6 +1,6 @@
 import type { HTMLProps } from 'react';
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './TableBody.module.css';
 import { TableRowTypeContext } from './utils';
@@ -19,7 +19,7 @@ export const TableBody = ({
     <TableRowTypeContext.Provider value={{ variantStandard }}>
       <tbody
         {...tableBodyProps}
-        className={cn(classes.tableBody, className)}
+        className={cl(classes.tableBody, className)}
       >
         {children}
       </tbody>

--- a/packages/react/src/components/Table/TableCell.tsx
+++ b/packages/react/src/components/Table/TableCell.tsx
@@ -1,6 +1,6 @@
 import type { HTMLProps } from 'react';
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './TableCell.module.css';
 import type { SortHandler, Variant, SortDirection } from './utils';
@@ -54,7 +54,7 @@ export function TableCell({
         <TableHeaderCell
           useTd={!children}
           {...tableCellProps}
-          className={cn(
+          className={cl(
             radiobutton
               ? classes.headerTableCellRadiobutton
               : classes.headerTableCell,
@@ -69,7 +69,7 @@ export function TableCell({
           }
         >
           <div
-            className={cn(
+            className={cl(
               sortDirection != 'notSortable' && classes.containerSortable,
             )}
             onClick={() => handleChange()}
@@ -101,7 +101,7 @@ export function TableCell({
       {isVariant('body') && (
         <td
           {...tableCellProps}
-          className={cn(
+          className={cl(
             radiobutton
               ? classes.bodyTableCellRadiobutton
               : classes.bodyTableCell,

--- a/packages/react/src/components/Table/TableFooter.tsx
+++ b/packages/react/src/components/Table/TableFooter.tsx
@@ -1,6 +1,6 @@
 import type { HTMLProps } from 'react';
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './TableFooter.module.css';
 import { TableRowTypeContext } from './utils';
@@ -19,7 +19,7 @@ export const TableFooter = ({
     <TableRowTypeContext.Provider value={{ variantStandard }}>
       <tfoot
         {...tableFooterProps}
-        className={cn(classes.tableFooter, className)}
+        className={cl(classes.tableFooter, className)}
       >
         {children}
       </tfoot>

--- a/packages/react/src/components/Table/TableHeader.tsx
+++ b/packages/react/src/components/Table/TableHeader.tsx
@@ -1,6 +1,6 @@
 import type { HTMLProps } from 'react';
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './TableHeader.module.css';
 import { TableRowTypeContext } from './utils';
@@ -19,7 +19,7 @@ export const TableHeader = ({
     <TableRowTypeContext.Provider value={{ variantStandard }}>
       <thead
         {...tableHeaderProps}
-        className={cn(classes.tableHeader, className)}
+        className={cl(classes.tableHeader, className)}
       >
         {children}
       </thead>

--- a/packages/react/src/components/Table/TableRow.tsx
+++ b/packages/react/src/components/Table/TableRow.tsx
@@ -1,6 +1,6 @@
 import type { HTMLProps } from 'react';
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './TableRow.module.css';
 import { useTableContext, useTableRowTypeContext } from './utils';
@@ -40,7 +40,7 @@ export function TableRow<T>({
   return (
     <tr
       {...tableRowProps}
-      className={cn(
+      className={cl(
         classes.tableRow,
         {
           [classes.selected]: isSelected,

--- a/packages/react/src/components/Tabs/Tab/Tab.tsx
+++ b/packages/react/src/components/Tabs/Tab/Tab.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { RovingTabindexItem } from '../../../utilities/RovingTabIndex';
 
@@ -23,7 +23,7 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
       {...rest}
       {...useTabRest}
       as={'button'}
-      className={cn(
+      className={cl(
         classes.tabItem,
         classes[size],
         active && classes.isActive,

--- a/packages/react/src/components/Tabs/TabContent/TabContent.tsx
+++ b/packages/react/src/components/Tabs/TabContent/TabContent.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef, useContext } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { TabsContext } from '../Tabs';
 
@@ -22,7 +22,7 @@ export const TabContent = forwardRef<HTMLDivElement, TabContentProps>(
         {active && (
           <div
             {...rest}
-            className={cn(
+            className={cl(
               classes[size],
               classes.tabContent,
               onlyText && classes.onlyText,

--- a/packages/react/src/components/Tabs/TabList/TabList.tsx
+++ b/packages/react/src/components/Tabs/TabList/TabList.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { RovingTabindexRoot } from '../../../utilities/RovingTabIndex';
 
@@ -14,7 +14,7 @@ export const TabList = forwardRef<
     <RovingTabindexRoot
       {...rest}
       role='tablist'
-      className={cn(classes.tabItemList, rest.className)}
+      className={cl(classes.tabItemList, rest.className)}
       ref={ref}
     >
       {children}

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import type { ParagraphProps } from '../Typography';
 import { Paragraph } from '../Typography';
@@ -43,7 +43,7 @@ export const Tag = forwardRef<HTMLSpanElement, TagProps>(
         as='span'
         size={size}
         {...restHTMLProps}
-        className={cn(
+        className={cl(
           classes.tag,
           classes[color],
           classes[size],

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { createContext, forwardRef, useId, useState } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { RovingTabindexRoot } from '../../utilities/RovingTabIndex';
 
@@ -62,7 +62,7 @@ export const ToggleGroup = forwardRef<HTMLDivElement, ToggleGroupProps>(
     return (
       <div
         {...rest}
-        className={cn(classes.toggleGroupContainer, rest.className)}
+        className={cl(classes.toggleGroupContainer, rest.className)}
         ref={ref}
       >
         <ToggleGroupContext.Provider

--- a/packages/react/src/components/ToggleGroup/ToggleGroupItem/ToggleGroupItem.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroupItem/ToggleGroupItem.tsx
@@ -1,6 +1,6 @@
 import type { ButtonHTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { Button } from '../../Button';
 import { RovingTabindexItem } from '../../../utilities/RovingTabIndex';
@@ -27,7 +27,7 @@ export const ToggleGroupItem = forwardRef<
     <RovingTabindexItem
       {...rest}
       {...buttonProps}
-      className={cn(classes.toggleGroupItem, rest.className)}
+      className={cl(classes.toggleGroupItem, rest.className)}
       as={Button}
       value={rest.value}
       icon={icon}

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { cloneElement, forwardRef, useState } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import {
   useFloating,
   autoUpdate,
@@ -134,7 +134,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
                 style={{ ...floatingStyles, ...animationStyles }}
                 {...getFloatingProps({
                   ...restHTMLProps,
-                  className: cn(styles.wrapper, className),
+                  className: cl(styles.wrapper, className),
                   ref: mergedRef,
                 })}
                 role='tooltip'

--- a/packages/react/src/components/Typography/ErrorMessage/ErrorMessage.tsx
+++ b/packages/react/src/components/Typography/ErrorMessage/ErrorMessage.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cl from 'classnames';
+import cl from 'clsx';
 
 import type { OverridableComponent } from '../../../types/OverridableComponent';
 

--- a/packages/react/src/components/Typography/Heading/Heading.tsx
+++ b/packages/react/src/components/Typography/Heading/Heading.tsx
@@ -1,6 +1,6 @@
 import type { ElementType, HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cl from 'classnames';
+import cl from 'clsx';
 
 import type { OverridableComponent } from '../../../types/OverridableComponent';
 

--- a/packages/react/src/components/Typography/Ingress/Ingress.tsx
+++ b/packages/react/src/components/Typography/Ingress/Ingress.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cl from 'classnames';
+import cl from 'clsx';
 
 import type { OverridableComponent } from '../../../types/OverridableComponent';
 

--- a/packages/react/src/components/Typography/Label/Label.tsx
+++ b/packages/react/src/components/Typography/Label/Label.tsx
@@ -1,6 +1,6 @@
 import type { LabelHTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cl from 'classnames';
+import cl from 'clsx';
 
 import type { OverridableComponent } from '../../../types/OverridableComponent';
 

--- a/packages/react/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/react/src/components/Typography/Paragraph/Paragraph.tsx
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cl from 'classnames';
+import cl from 'clsx';
 
 import type { OverridableComponent } from '../../../types/OverridableComponent';
 

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
 import type { InputHTMLAttributes, ReactNode, SVGAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { omit } from '../../../utilities';
 import { Label, Paragraph } from '../../Typography';
@@ -63,7 +63,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       <Paragraph
         as='div'
         size={size}
-        className={cn(
+        className={cl(
           classes.container,
           classes[size],
           children && classes.spacing,
@@ -73,7 +73,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           rest.className,
         )}
       >
-        <span className={cn(classes.control, classes.checkbox)}>
+        <span className={cl(classes.control, classes.checkbox)}>
           <input
             {...omit(['size', 'error'], rest)}
             {...inputProps}

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import React, { useState, forwardRef, createContext } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import type { FieldsetProps } from '../../Fieldset';
 import { Fieldset } from '../../Fieldset';
@@ -75,7 +75,7 @@ export const CheckboxGroup = forwardRef<
             toggleValue,
           }}
         >
-          <div className={cn(!rest.hideLegend && classes.alignToLegend)}>
+          <div className={cl(!rest.hideLegend && classes.alignToLegend)}>
             {children}
           </div>
         </CheckboxGroupContext.Provider>

--- a/packages/react/src/components/form/Combobox/Combobox.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.tsx
@@ -18,7 +18,7 @@ import {
   useRole,
   FloatingPortal,
 } from '@floating-ui/react';
-import cn from 'classnames';
+import cl from 'clsx';
 import type {
   UseFloatingReturn,
   UseListNavigationProps,
@@ -389,7 +389,7 @@ export const Combobox = ({
       }}
     >
       <Box
-        className={cn(
+        className={cl(
           classes.combobox,
           disabled && classes.disabled,
           rest.className,
@@ -446,7 +446,7 @@ export const Combobox = ({
                   ...floatingStyles,
                 },
               })}
-              className={cn(classes.optionsWrapper, classes[size])}
+              className={cl(classes.optionsWrapper, classes[size])}
             >
               {/* Map our children, and add props if it is a ComboboxOption */}
               {optionsChildren}

--- a/packages/react/src/components/form/Combobox/Empty/Empty.tsx
+++ b/packages/react/src/components/form/Combobox/Empty/Empty.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { ComboboxContext } from '../Combobox';
 
@@ -21,7 +21,7 @@ export const ComboboxEmpty = forwardRef<HTMLDivElement, ComboboxEmptyProps>(
         <div
           {...rest}
           ref={ref}
-          className={cn(classes.empty, classes[size], rest.className)}
+          className={cl(classes.empty, classes[size], rest.className)}
         >
           {children}
         </div>

--- a/packages/react/src/components/form/Combobox/Option/Description/Description.tsx
+++ b/packages/react/src/components/form/Combobox/Option/Description/Description.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Description.module.css';
 
@@ -12,7 +12,7 @@ export const ComboboxOptionDescription = forwardRef<
   return (
     <span
       {...rest}
-      className={cn(classes.description, rest.className)}
+      className={cl(classes.description, rest.className)}
       ref={ref}
     >
       {children}

--- a/packages/react/src/components/form/Combobox/Option/Icon/SelectedIcon.tsx
+++ b/packages/react/src/components/form/Combobox/Option/Icon/SelectedIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { CheckmarkIcon } from '@navikt/aksel-icons';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from '../Option.module.css';
 
@@ -12,7 +12,7 @@ type SelectedIconProps = {
 export const SelectedIcon = ({ multiple, selected }: SelectedIconProps) => {
   return (
     <div
-      className={cn(
+      className={cl(
         multiple && classes.selectIconWrapper,
         selected && classes.selected,
       )}

--- a/packages/react/src/components/form/Combobox/Option/Option.tsx
+++ b/packages/react/src/components/form/Combobox/Option/Option.tsx
@@ -5,7 +5,7 @@ import React, {
   useId,
   useMemo,
 } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { useMergeRefs } from '@floating-ui/react';
 
 import { ComboboxContext } from '../Combobox';
@@ -98,7 +98,7 @@ export const ComboboxOption = forwardRef<
         setActiveOption(index, labelId);
         rest.onFocus?.(e);
       }} // Set active index on focus
-      className={cn(
+      className={cl(
         classes.option,
         classes[size],
         activeIndex === index && classes.active,

--- a/packages/react/src/components/form/Combobox/internal/ComboboxClearButton.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxClearButton.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { XMarkIcon } from '@navikt/aksel-icons';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { ComboboxContext } from '../Combobox';
 import classes from '../Combobox.module.css';
@@ -25,7 +25,7 @@ export const ComboboxClearButton = () => {
   return (
     <button
       disabled={disabled}
-      className={cn(
+      className={cl(
         classes.clearButton,
         classes[size],
         utilityClasses.focusable,

--- a/packages/react/src/components/form/Combobox/internal/ComboboxInput.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxInput.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { ChevronUpIcon, ChevronDownIcon } from '@navikt/aksel-icons';
 
 import { ComboboxContext } from '../Combobox';
@@ -125,7 +125,7 @@ export const ComboboxInput = ({
         },
       })}
       aria-disabled={disabled}
-      className={cn(
+      className={cl(
         textFieldClasses.input,
         classes.inputWrapper,
         classes[size],

--- a/packages/react/src/components/form/Combobox/internal/ComboboxLabel.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxLabel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 
 import { Label, Paragraph } from '../../../Typography';
@@ -31,7 +31,7 @@ export const ComboboxLabel = ({
         <Label
           size={size}
           htmlFor={formFieldProps.inputProps.id}
-          className={cn(
+          className={cl(
             classes.label,
             hideLabel && utilityClasses.visuallyHidden,
           )}
@@ -50,7 +50,7 @@ export const ComboboxLabel = ({
           as='div'
           size={size}
           id={formFieldProps.descriptionId}
-          className={cn(
+          className={cl(
             classes.description,
             hideLabel && utilityClasses.visuallyHidden,
           )}

--- a/packages/react/src/components/form/Fieldset/Fieldset.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.tsx
@@ -1,6 +1,6 @@
 import type { FieldsetHTMLAttributes, ReactNode } from 'react';
 import React, { useContext, forwardRef, createContext } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 
 import { Label, Paragraph, ErrorMessage } from '../../Typography';
@@ -56,7 +56,7 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
         <fieldset
           {...rest}
           {...fieldsetProps}
-          className={cn(
+          className={cl(
             classes.fieldset,
             !hideLegend && classes.spacing,
             readOnly && classes.readonly,
@@ -68,7 +68,7 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
           <Label
             as='legend'
             size={size}
-            className={cn(
+            className={cl(
               classes.legend,
               hideLegend && utilityclasses.visuallyHidden,
             )}
@@ -84,7 +84,7 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
           {description && (
             <Paragraph
               id={descriptionId}
-              className={cn(
+              className={cl(
                 classes.description,
                 hideLegend && utilityclasses.visuallyHidden,
               )}

--- a/packages/react/src/components/form/NativeSelect/NativeSelect.tsx
+++ b/packages/react/src/components/form/NativeSelect/NativeSelect.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import type { ForwardedRef, ReactNode, SelectHTMLAttributes } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 
 import { omit } from '../../../utilities';
@@ -62,7 +62,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
       <Paragraph
         as='div'
         size={size}
-        className={cn(
+        className={cl(
           classes.formField,
           disabled && classes.disabled,
           readOnly && classes.readOnly,
@@ -74,7 +74,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
             weight='medium'
             size={size}
             htmlFor={selectProps.id}
-            className={cn(
+            className={cl(
               classes.label,
               hideLabel && utilityClasses.visuallyHidden,
             )}
@@ -95,7 +95,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
           disabled={disabled || readOnly}
           ref={ref}
           size={htmlSize}
-          className={cn(
+          className={cl(
             classes.select,
             classes[size],
             utilityClasses.focusable,

--- a/packages/react/src/components/form/Radio/Group/Group.tsx
+++ b/packages/react/src/components/form/Radio/Group/Group.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import React, { forwardRef, createContext, useId } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import type { FieldsetProps } from '../../Fieldset';
 import { Fieldset } from '../../Fieldset';
@@ -59,7 +59,7 @@ export const RadioGroup = forwardRef<HTMLFieldSetElement, RadioGroupProps>(
         {...rest}
         readOnly={readOnly}
         size={size}
-        className={cn(rest.className)}
+        className={cl(rest.className)}
         ref={ref}
       >
         <RadioGroupContext.Provider
@@ -72,7 +72,7 @@ export const RadioGroup = forwardRef<HTMLFieldSetElement, RadioGroupProps>(
           }}
         >
           <div
-            className={cn(
+            className={cl(
               !rest.hideLegend && classes.alignToLegend,
               inline && classes.inline,
             )}

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -1,6 +1,6 @@
 import type { InputHTMLAttributes, ReactNode, SVGAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { omit } from '../../../utilities';
 import { Label, Paragraph } from '../../Typography';
@@ -62,7 +62,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
     <Paragraph
       as='div'
       size={size}
-      className={cn(
+      className={cl(
         classes.container,
         classes[size],
         children && classes.spacing,
@@ -72,7 +72,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
         rest.className,
       )}
     >
-      <span className={cn(classes.control, classes.radio)}>
+      <span className={cl(classes.control, classes.radio)}>
         <input
           {...omit(['size', 'error'], rest)}
           {...inputProps}

--- a/packages/react/src/components/form/Search/Search.tsx
+++ b/packages/react/src/components/form/Search/Search.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode, InputHTMLAttributes, ChangeEvent } from 'react';
 import React, { forwardRef, useCallback, useRef, useState } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { MagnifyingGlassIcon, XMarkIcon } from '@navikt/aksel-icons';
 import { useMergeRefs } from '@floating-ui/react';
 
@@ -107,7 +107,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
         as='div'
         size={size}
         style={style}
-        className={cn(
+        className={cl(
           classes.formField,
           inputProps.disabled && classes.disabled,
           classes[size],
@@ -119,7 +119,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
             size={size}
             weight='medium'
             htmlFor={inputProps.id}
-            className={cn(
+            className={cl(
               classes.label,
               hideLabel && utilityClasses.visuallyHidden,
             )}
@@ -144,7 +144,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
               value={value ?? internalValue}
               onChange={handleChange}
               disabled={disabled}
-              className={cn(
+              className={cl(
                 classes.input,
                 utilityClasses.focusable,
                 classes[size],
@@ -154,7 +154,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
             />
             {showClearButton && (
               <button
-                className={cn(classes.clearButton, utilityClasses.focusable)}
+                className={cl(classes.clearButton, utilityClasses.focusable)}
                 type='button'
                 onClick={handleClear}
                 disabled={disabled}

--- a/packages/react/src/components/form/Switch/Switch.tsx
+++ b/packages/react/src/components/form/Switch/Switch.tsx
@@ -1,6 +1,6 @@
 import type { InputHTMLAttributes, ReactNode, SVGAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 
 import { omit } from '../../../utilities';
@@ -77,7 +77,7 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
       <Paragraph
         as='div'
         size={size}
-        className={cn(
+        className={cl(
           classes.switch,
           classes[size],
           inputProps.disabled && classes.disabled,

--- a/packages/react/src/components/form/Textarea/Textarea.tsx
+++ b/packages/react/src/components/form/Textarea/Textarea.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode, TextareaHTMLAttributes } from 'react';
 import React, { useState, forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 
 import { omit } from '../../../utilities';
@@ -61,7 +61,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     const hasCharacterLimit = characterLimit != null;
 
     const describedBy =
-      cn(
+      cl(
         textareaProps['aria-describedby'],
         hasCharacterLimit && characterLimitId,
       ) || undefined;
@@ -71,7 +71,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         as='div'
         size={size}
         style={style}
-        className={cn(
+        className={cl(
           classes.formField,
           textareaProps.disabled && classes.disabled,
           readOnly && classes.readonly,
@@ -83,7 +83,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             size={size}
             weight='medium'
             htmlFor={textareaProps.id}
-            className={cn(
+            className={cl(
               classes.label,
               hideLabel && utilityClasses.visuallyHidden,
             )}
@@ -102,7 +102,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             id={descriptionId}
             as='div'
             size={size}
-            className={cn(
+            className={cl(
               classes.description,
               hideLabel && utilityClasses.visuallyHidden,
             )}
@@ -113,7 +113,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         <textarea
           {...omit(['size', 'error', 'errorId'], rest)}
           {...textareaProps}
-          className={cn(
+          className={cl(
             classes.textarea,
             utilityClasses.focusable,
             classes[size],

--- a/packages/react/src/components/form/Textfield/Textfield.tsx
+++ b/packages/react/src/components/form/Textfield/Textfield.tsx
@@ -1,6 +1,6 @@
 import type { InputHTMLAttributes, ReactNode } from 'react';
 import React, { useState, useId, forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 
 import { omit } from '../../../utilities';
@@ -92,7 +92,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
     const hasCharacterLimit = characterLimit != null;
 
     const describedBy =
-      cn(
+      cl(
         inputProps['aria-describedby'],
         hasCharacterLimit && characterLimitId,
       ) || undefined;
@@ -102,7 +102,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
         as='div'
         size={size}
         style={style}
-        className={cn(
+        className={cl(
           classes.formField,
           classes[size],
           inputProps.disabled && classes.disabled,
@@ -115,7 +115,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
             size={size}
             weight='medium'
             htmlFor={inputProps.id}
-            className={cn(
+            className={cl(
               classes.label,
               hideLabel && utilityClasses.visuallyHidden,
             )}
@@ -134,7 +134,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
             id={descriptionId}
             as='div'
             size={size}
-            className={cn(
+            className={cl(
               classes.description,
               hideLabel && utilityClasses.visuallyHidden,
             )}
@@ -142,12 +142,12 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
             {description}
           </Paragraph>
         )}
-        <div className={cn(classes.field, hasError && classes.error)}>
+        <div className={cl(classes.field, hasError && classes.error)}>
           {prefix && (
             <Paragraph
               as='div'
               size={size}
-              className={cn(classes.adornment, classes.prefix)}
+              className={cl(classes.adornment, classes.prefix)}
               aria-hidden='true'
               short
             >
@@ -157,7 +157,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
           <input
             {...omit(['size', 'error', 'errorId'], rest)}
             {...inputProps}
-            className={cn(
+            className={cl(
               classes.input,
               classes[size],
               utilityClasses.focusable,
@@ -177,7 +177,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
             <Paragraph
               as='div'
               size={size}
-              className={cn(classes.adornment, classes.suffix)}
+              className={cl(classes.adornment, classes.suffix)}
               aria-hidden='true'
               short
             >

--- a/packages/react/src/components/form/useFormField.ts
+++ b/packages/react/src/components/form/useFormField.ts
@@ -1,6 +1,6 @@
 import { useContext, useId } from 'react';
 import type { HTMLAttributes, InputHTMLAttributes, ReactNode } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { FieldsetContext } from './Fieldset';
 
@@ -67,7 +67,7 @@ export const useFormField = (
       disabled,
       'aria-invalid': hasError ? true : undefined,
       'aria-describedby':
-        cn(props['aria-describedby'], {
+        cl(props['aria-describedby'], {
           [descriptionId]:
             !!props?.description && typeof props?.description === 'string',
           [errorId]: hasError && !fieldset?.error,

--- a/packages/react/src/components/legacy/LegacyCheckbox/Checkbox.tsx
+++ b/packages/react/src/components/legacy/LegacyCheckbox/Checkbox.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEventHandler, ReactNode } from 'react';
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { CheckboxRadioTemplate } from '../_CheckboxRadioTemplate';
 
@@ -79,7 +79,7 @@ const LegacyCheckbox = ({
 }: LegacyCheckboxProps) => (
   <CheckboxRadioTemplate
     checked={checked}
-    className={cn(
+    className={cl(
       classes.checkbox,
       checked && classes.checked,
       error && classes.error,

--- a/packages/react/src/components/legacy/LegacyCheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/components/legacy/LegacyCheckboxGroup/CheckboxGroup.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import React, { useReducer } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { LegacyCheckbox } from '../LegacyCheckbox';
 import type { LegacyFieldSetProps } from '../LegacyFieldSet';
@@ -99,7 +99,7 @@ const LegacyCheckboxGroup = ({
 
   return (
     <LegacyFieldSet
-      contentClassName={cn(
+      contentClassName={cl(
         classes.checkboxGroup,
         classes[variant],
         compact && classes.compact,

--- a/packages/react/src/components/legacy/LegacyFieldSet/FieldSet.tsx
+++ b/packages/react/src/components/legacy/LegacyFieldSet/FieldSet.tsx
@@ -1,6 +1,6 @@
 import type { FieldsetHTMLAttributes, ForwardedRef, ReactNode } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { ErrorMessage, HelpText } from '../..';
 import type { HelpTextProps } from '../../HelpText/HelpText';
@@ -69,7 +69,7 @@ const LegacyFieldSet = forwardRef<HTMLFieldSetElement, LegacyFieldSetProps>(
       ref={ref}
       disabled={disabled}
       {...rest}
-      className={cn(classes.fieldSet, classes[size], className)}
+      className={cl(classes.fieldSet, classes[size], className)}
     >
       {legend && (
         <legend className={classes.legend}>
@@ -87,7 +87,7 @@ const LegacyFieldSet = forwardRef<HTMLFieldSetElement, LegacyFieldSetProps>(
         </legend>
       )}
       {description && <p className={classes.description}>{description}</p>}
-      <div className={cn(classes.content, contentClassName)}>{children}</div>
+      <div className={cl(classes.content, contentClassName)}>{children}</div>
       {error && (
         <div className={classes.errorMessage}>
           <ErrorMessage role='alert'>{error}</ErrorMessage>

--- a/packages/react/src/components/legacy/LegacyPopover/Popover.tsx
+++ b/packages/react/src/components/legacy/LegacyPopover/Popover.tsx
@@ -23,7 +23,7 @@ import {
   useInteractions,
   useMergeRefs,
 } from '@floating-ui/react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './Popover.module.css';
 
@@ -208,7 +208,7 @@ const PopoverContent = forwardRef<
         left: context.x ?? 0,
       }}
       data-placement={context.placement}
-      className={cn(
+      className={cl(
         classes.popover,
         classes[context.variant],
         context.className,

--- a/packages/react/src/components/legacy/LegacyRadioButton/RadioButton.tsx
+++ b/packages/react/src/components/legacy/LegacyRadioButton/RadioButton.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEventHandler, ReactNode } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { CheckboxRadioTemplate } from '../_CheckboxRadioTemplate';
 
@@ -49,7 +49,7 @@ const LegacyRadioButton = forwardRef<HTMLInputElement, LegacyRadioButtonProps>(
   ) => (
     <CheckboxRadioTemplate
       checked={checked}
-      className={cn(
+      className={cl(
         classes.radio,
         classes[size],
         checked && classes.checked,

--- a/packages/react/src/components/legacy/LegacySelect/OptionList/Option.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/OptionList/Option.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import type {
   LegacyMultiSelectOption,
@@ -33,7 +33,7 @@ const Option = ({
   <button
     aria-label={option.label}
     aria-selected={selected}
-    className={cn(
+    className={cl(
       classes.option,
       selected && classes.selected,
       multiple && active && classes.focused,

--- a/packages/react/src/components/legacy/LegacySelect/OptionList/OptionList.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/OptionList/OptionList.tsx
@@ -1,6 +1,6 @@
 import React, { useId, useRef, useState } from 'react';
 import { FloatingPortal } from '@floating-ui/react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { useEventListener } from '../../../../hooks';
 import type {
@@ -63,7 +63,7 @@ const OptionList = ({
         root={portal ? null : portalRef}
       >
         <span
-          className={cn(
+          className={cl(
             classes.wrapper,
             expanded && classes.expanded,
             usingKeyboard && classes.usingKeyboard,

--- a/packages/react/src/components/legacy/LegacySelect/Select.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/Select.tsx
@@ -1,6 +1,6 @@
 import type { ChangeEvent } from 'react';
 import React, { useCallback, useEffect, useId, useState } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import { autoUpdate, useFloating } from '@floating-ui/react';
 import { flip, size } from '@floating-ui/dom';
 
@@ -320,7 +320,7 @@ const LegacySelect = (props: LegacySelectProps) => {
 
   return (
     <span
-      className={cn(
+      className={cl(
         classes.select,
         classes[multiple ? 'multiple' : 'single'],
         expanded && classes.expanded,
@@ -333,7 +333,7 @@ const LegacySelect = (props: LegacySelectProps) => {
         inputId={givenOrRandomInputId}
         inputRenderer={({ className, inputId: id, hasIcon }) => (
           <span
-            className={cn(className, classes.field, hasIcon && classes.hasIcon)}
+            className={cl(className, classes.field, hasIcon && classes.hasIcon)}
             ref={refs.setReference}
           >
             <span className={classes.inputArea}>

--- a/packages/react/src/components/legacy/LegacyTabs/Tabs.tsx
+++ b/packages/react/src/components/legacy/LegacyTabs/Tabs.tsx
@@ -1,6 +1,6 @@
 import type { KeyboardEventHandler } from 'react';
 import React, { useEffect, useId, useRef, useState } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { useUpdate } from '../../../hooks';
 import { areItemsUnique } from '../../../utilities/arrayUtils';
@@ -106,7 +106,7 @@ const LegacyTabs = ({ activeTab, items, onChange }: LegacyTabsProps) => {
             <button
               aria-controls={tab.panelId}
               aria-selected={isSelected}
-              className={cn(classes.tab, isSelected && classes.selected)}
+              className={cl(classes.tab, isSelected && classes.selected)}
               id={tab.tabId}
               key={tab.value}
               onClick={() => selectTab(tab.value)}

--- a/packages/react/src/components/legacy/LegacyTextField/TextField.tsx
+++ b/packages/react/src/components/legacy/LegacyTextField/TextField.tsx
@@ -1,6 +1,6 @@
 import type { ForwardedRef, ChangeEvent } from 'react';
 import React, { forwardRef, useState } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 import type {
   NumericFormatProps,
   PatternFormatProps,
@@ -166,7 +166,7 @@ export const LegacyTextField = forwardRef<
             readOnly: Boolean(readOnly),
             disabled,
             required,
-            className: cn(className, rest.className),
+            className: cl(className, rest.className),
             style: {
               textAlign: formatting?.align,
               ...rest.style,

--- a/packages/react/src/components/legacy/LegacyToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react/src/components/legacy/LegacyToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import React, { useEffect, useState } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { areItemsUnique } from '../../../utilities';
 
@@ -74,7 +74,7 @@ export const LegacyToggleButtonGroup = ({
       {items.map((item) => (
         <button
           aria-pressed={item.value === selected}
-          className={cn(
+          className={cl(
             classes.toggleButton,
             item.value === selected && classes.pressed,
           )}

--- a/packages/react/src/components/legacy/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/legacy/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -5,7 +5,7 @@
 
 import type { ChangeEventHandler, ReactNode } from 'react';
 import React, { forwardRef, useId } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { HelpText } from '../../HelpText';
 import utilityClasses from '../../../utilities/utility.module.css';
@@ -78,7 +78,7 @@ export const CheckboxRadioTemplate = forwardRef<
 
     return (
       <Wrapper
-        className={cn(
+        className={cl(
           classes.template,
           classes[size],
           !showLabel && classes.hiddenLabel,

--- a/packages/react/src/utilities/AnimateHeight/AnimateHeight.tsx
+++ b/packages/react/src/utilities/AnimateHeight/AnimateHeight.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import { useMediaQuery, usePrevious } from '../../hooks';
 
@@ -58,7 +58,7 @@ export const AnimateHeight = ({
   return (
     <div
       {...rest}
-      className={cn(classes.root, classes[state], className)}
+      className={cl(classes.root, classes[state], className)}
       style={{ height, transition, ...style }}
     >
       <div

--- a/packages/react/src/utilities/InputWrapper/Icon.tsx
+++ b/packages/react/src/utilities/InputWrapper/Icon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import type { IconVariant_ } from './utils';
 import { ErrorIcon } from './ErrorIcon';
@@ -25,7 +25,7 @@ export const Icon = ({ variant, disabled = false }: IconProps) => {
     case 'search':
       return (
         <span
-          className={cn(classes.icon, disabled && classes.disabled)}
+          className={cl(classes.icon, disabled && classes.disabled)}
           data-testid='input-icon-search'
         >
           <SearchIcon />

--- a/packages/react/src/utilities/InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/utilities/InputWrapper/InputWrapper.tsx
@@ -1,6 +1,6 @@
 import React, { useId } from 'react';
 import type { ReactNode } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import utilityClasses from '../../utilities/utility.module.css';
 import { ErrorMessage, Paragraph } from '../../components/Typography';
@@ -132,7 +132,7 @@ export const InputWrapper = ({
         flexDirection: 'column',
       }}
     >
-      <span className={cn(classes.inputAndLabel, hasIcon && classes.withIcon)}>
+      <span className={cl(classes.inputAndLabel, hasIcon && classes.withIcon)}>
         {label && (
           <label
             className={classes.label}
@@ -143,7 +143,7 @@ export const InputWrapper = ({
         )}
         <span
           data-testid='InputWrapper'
-          className={cn(classes.inputWrapper, classes[variant], {
+          className={cl(classes.inputWrapper, classes[variant], {
             [classes.search]: isSearch,
             [classes.withPadding]: !noPadding,
           })}
@@ -153,7 +153,7 @@ export const InputWrapper = ({
             disabled={disabled}
           />
           {inputRenderer({
-            className: cn(
+            className: cl(
               classes.field,
               !noFocusEffect && utilityClasses.focusable,
             ),

--- a/scripts/generate-component/fileTemplates.ts
+++ b/scripts/generate-component/fileTemplates.ts
@@ -10,7 +10,7 @@ const mainContent = (
   componentName: string,
 ) => `import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
-import cn from 'classnames';
+import cl from 'clsx';
 
 import classes from './${componentName}.module.css';
 
@@ -24,7 +24,7 @@ export const ${componentName} = forwardRef<HTMLDivElement, ${componentName}Props
     return (
       <div
         {...rest}
-        className={cn(myProp && classes.myClass, rest.className)}
+        className={cl(myProp && classes.myClass, rest.className)}
         ref={ref}
       >
         {children}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7945,13 +7945,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "classnames@npm:2.3.2"
-  checksum: ba3151c12e8b6a84c64b340ab4259ad0408947652009314462d828e94631505989c6a7d7e796bec1d309be9295d3111b498ad18a9d533fe3e6f859e51e574cbb
-  languageName: node
-  linkType: hard
-
 "clean-css@npm:^5.2.2":
   version: 5.3.1
   resolution: "clean-css@npm:5.3.1"
@@ -8062,6 +8055,13 @@ __metadata:
   version: 1.2.1
   resolution: "clsx@npm:1.2.1"
   checksum: 5ded6f61f15f1fa0350e691ccec43a28b12fb8e64c8e94715f2a937bc3722d4c3ed41d6e945c971fc4dcc2a7213a43323beaf2e1c28654af63ba70c9968a8643
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "clsx@npm:2.0.0"
+  checksum: 943766d1b02fee3538c871e56638d87f973fbc2d6291ce221215ea436fdecb9be97ad323f411839c2d52c45640c449b1a53fbfe7e8b3d529b4e263308b630c9a
   languageName: node
   linkType: hard
 
@@ -18829,7 +18829,7 @@ __metadata:
     "@types/rimraf": "npm:^4.0.5"
     "@typescript-eslint/eslint-plugin": "npm:6.15.0"
     "@typescript-eslint/parser": "npm:6.15.0"
-    classnames: "npm:^2.3.2"
+    clsx: "npm:^2.0.0"
     copyfiles: "npm:^2.4.1"
     eslint: "npm:8.56.0"
     eslint-config-prettier: "npm:9.0.0"


### PR DESCRIPTION
> A tiny (234B) utility for constructing `className` strings conditionally.<Br>Also serves as a [faster](bench) & smaller drop-in replacement for the `classnames` module.

[clsx](https://github.com/lukeed/clsx) has for a long time been a replacement for [classnames](https://github.com/JedWatson/classnames) being faster and smaller. 