### PR TITLE
fix(Chips): :bug: Correct sizings

### DIFF
--- a/packages/react/src/components/Chip/Chip.module.css
+++ b/packages/react/src/components/Chip/Chip.module.css
@@ -18,6 +18,8 @@
   color: var(--fdsc-chip-text-color);
   text-decoration: none;
   font-family: inherit;
+  display: inline-flex;
+  align-items: center;
 }
 
 .chipButton:disabled,
@@ -40,22 +42,6 @@
   align-items: center;
   flex-direction: row;
   gap: var(--fds-spacing-2);
-  padding: var(--fds-spacing-1) 0;
-}
-
-.small {
-  --fdsc-chip-height: var(--fds-sizing-6);
-  --fdsc-chip-padding: var(--fds-spacing-2);
-}
-
-.medium {
-  --fdsc-chip-height: var(--fds-sizing-7);
-  --fdsc-chip-padding: var(--fds-spacing-3);
-}
-
-.large {
-  --fdsc-chip-height: var(--fds-sizing-8);
-  --fdsc-chip-padding: var(--fds-spacing-3);
 }
 
 .removable {
@@ -64,7 +50,7 @@
   --fdsc-removable-chip-size: var(--fds-sizing-7);
   --fdsc-removable-chip-xmark-color: var(--fds-semantic-text-neutral-on_inverted);
   --fdsc-removable-chip-xmark-padding_right: var(--fds-spacing-1);
-  --fdsc-removable-chip-xmark-size: var(--fds-sizing-5);
+  --fdsc-removable-chip-xmark-size: var(--fds-sizing-6);
   --fdsc-removable-chip-xmark-wrapper-width: calc(var(--fdsc-removable-chip-xmark-size) + var(--fdsc-removable-chip-xmark-padding_right));
 
   color: var(--fdsc-removable-text-color);
@@ -76,7 +62,8 @@
 
 .xMark {
   color: var(--fdsc-removable-chip-xmark-color);
-  display: inline-flex;
+  height: var(--fdsc-removable-chip-xmark-size);
+  width: var(--fdsc-removable-chip-xmark-size);
   padding-right: var(--fdsc-removable-chip-xmark-padding_right);
 }
 
@@ -162,4 +149,22 @@
     );
     --fdsc-removable-chip-xmark-color: var(--fds-semantic-text-neutral-on_inverted);
   }
+}
+
+.small {
+  --fdsc-chip-height: var(--fds-sizing-6);
+  --fdsc-chip-padding: var(--fds-spacing-2);
+  --fdsc-removable-chip-xmark-size: var(--fds-sizing-5);
+}
+
+.medium {
+  --fdsc-chip-height: var(--fds-sizing-7);
+  --fdsc-chip-padding: var(--fds-spacing-3);
+  --fdsc-removable-chip-xmark-size: var(--fds-sizing-6);
+}
+
+.large {
+  --fdsc-chip-height: var(--fds-sizing-8);
+  --fdsc-chip-padding: var(--fds-spacing-3);
+  --fdsc-removable-chip-xmark-size: var(--fds-sizing-7);
 }

--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -12,7 +12,7 @@ export default {
 export const Preview: Story = {
   args: {
     children: 'Nynorsk',
-    size: 'small',
+    size: 'medium',
     selected: false,
     checkmark: false,
   },

--- a/packages/react/src/components/Chip/Removable/Removable.stories.tsx
+++ b/packages/react/src/components/Chip/Removable/Removable.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof RemovableChip>;
 export const Preview: Story = {
   args: {
     children: 'Nynorsk',
-    size: 'small',
+    size: 'medium',
     'aria-label': 'Slett nynorsk',
     disabled: false,
   },

--- a/packages/react/src/components/Chip/Removable/Removable.tsx
+++ b/packages/react/src/components/Chip/Removable/Removable.tsx
@@ -39,7 +39,7 @@ export const RemovableChip = forwardRef<HTMLButtonElement, RemovableChipProps>(
           className={classes.label}
           short
         >
-          {children}
+          <span>{children}</span>
           <span
             className={classes.xMark}
             aria-hidden

--- a/packages/react/src/components/Chip/Toggle/Toggle.stories.tsx
+++ b/packages/react/src/components/Chip/Toggle/Toggle.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof ToggleChip>;
 export const Preview: Story = {
   args: {
     children: 'Nynorsk',
-    size: 'small',
+    size: 'medium',
     selected: false,
     checkmark: false,
     disabled: false,


### PR DESCRIPTION
fixes #1291

- Added correct heights on x-mark icon
- Updated to use correct `size` in stories
- Conformed markup