### PR TITLE
style(button): use correct semantic variables

### DIFF
--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -20,7 +20,7 @@
     --dsc-button-color--hover: var(--ds-color-accent-text-default);
   }
   &[data-variant='secondary'] {
-    --dsc-button-border-color: var(--ds-color-accent-border-default);
+    --dsc-button-border-color: var(--ds-color-accent-border-strong);
   }
 
   &[data-color] {


### PR DESCRIPTION
resolves [#2804](https://github.com/digdir/designsystemet/issues/2804)

In Figma secondary and tertiary buttons change text color on hover, so I had to add a new var for this,