### PR TITLE
fix(www): add missing siteimprove script

### DIFF
--- a/apps/www/app/root.tsx
+++ b/apps/www/app/root.tsx
@@ -143,7 +143,10 @@ function Document({ children }: DocumentProps) {
         <ScrollRestoration />
         <Scripts />
         {process.env.NODE_ENV === 'production' && (
-          <script src='https://siteimproveanalytics.com/js/siteanalyze_6255470.js' />
+          <script
+            src='https://siteimproveanalytics.com/js/siteanalyze_6255470.js'
+            crossOrigin='anonymous'
+          />
         )}
       </body>
     </html>


### PR DESCRIPTION
I copied the siteimprove link from a 4 month old branch that still has the next project.
It didnt look like themebuilder had a siteimprove script?

resolves #4020 