### PR TITLE
fix(Dialog): removed autofocus from closeButton

### DIFF
--- a/.changeset/violet-loops-lead.md
+++ b/.changeset/violet-loops-lead.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Dialog**: Removed the autofocus attribute from built in closeButton, which prevented setting autofocus on other elements in Dialog.

--- a/packages/react/src/components/dialog/dialog.tsx
+++ b/packages/react/src/components/dialog/dialog.tsx
@@ -156,7 +156,6 @@ export const Dialog = forwardRef<HTMLDialogElement, DialogProps>(
         {closeButton !== false && (
           <Button
             aria-label={closeButton}
-            autoFocus
             data-color='neutral'
             icon
             variant='tertiary'


### PR DESCRIPTION
resolves #4158 

Sidenote: looks like just `autoFocus` and not `autoFocus={true}` causes the attribute to be stripped away in storybook, but not downstream such as in www
