### PR TITLE
fix(www): prevent u-rich-text overflow

### DIFF
--- a/apps/www/app/app.css
+++ b/apps/www/app/app.css
@@ -111,7 +111,6 @@ body {
 
 @layer rich-text {
   .u-rich-text {
-    overflow: hidden;
     & > *:first-child {
       margin-top: 0;
     }

--- a/internal/components/src/code-block/code-block.module.css
+++ b/internal/components/src/code-block/code-block.module.css
@@ -20,6 +20,8 @@
 .codeBlockWrapper {
   position: relative;
   max-width: 100%;
+  /* so it shrinks without needing overflow: hidden on its parent */
+  contain: inline-size;
 }
 
 .copyButton {


### PR DESCRIPTION
Due to the changes to CodeBlock, ~~it seems we need to add overflow hidden to its parent~~

adding `contain: inline-size;` on `.codeblockWrapper` seems to have done the trick

Seems fine in storybook, themebuilder and www
