### PR TITLE
fix(css): link: Style background, border, and padding regardless of default browser styles #4231

### DIFF
--- a/.changeset/purple-lands-brush.md
+++ b/.changeset/purple-lands-brush.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**link**: Style background, border, and padding regardless of default browser styles ([#4231](https://github.com/digdir/designsystemet/issues/4231))

--- a/packages/css/src/link.css
+++ b/packages/css/src/link.css
@@ -16,6 +16,17 @@
   text-underline-offset: 0.27em; /* 5px ish */
   border-radius: var(--dsc-link-border-radius);
 
+  /* Revert <button> styling */
+  &:is(button) {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+    margin: 0;
+    padding: 0;
+    text-align: inherit;
+  }
+
   & :is(img, svg) {
     vertical-align: middle; /* Align img or svg icon with text */
   }

--- a/packages/react/src/components/link/link.stories.tsx
+++ b/packages/react/src/components/link/link.stories.tsx
@@ -90,3 +90,11 @@ export const Neutral: Story = {
     'data-color': 'neutral',
   },
 };
+
+export const AsButton: Story = {
+  args: {
+    children: <button type='button'>Gå til designsystemet</button>,
+    href: designsystemetLink,
+    asChild: true,
+  },
+};


### PR DESCRIPTION
## Summary

Fixes #4231 by setting background, border, and padding to a "default" value, which matches the `<a>` tag and more importantly overwrites the default `<button>` styles

Also added a story for it. Maybe not needed idk

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
