### PR TITLE
fix(www): live component scheme toggle when light

### DIFF
--- a/apps/www/app/_components/live-component/live-components.tsx
+++ b/apps/www/app/_components/live-component/live-components.tsx
@@ -267,10 +267,15 @@ export const LiveComponent = ({
   const editorId = useId();
 
   useEffect(() => {
-    // Set initial color scheme
-    setColorScheme(
-      document?.documentElement?.getAttribute('data-color-scheme'),
-    );
+    // Set initial color scheme and inverted color scheme
+    const initialColorScheme =
+      document?.documentElement?.getAttribute('data-color-scheme');
+    setColorScheme(initialColorScheme);
+    if (initialColorScheme === 'dark') {
+      setInvertedColorScheme('light');
+    } else {
+      setInvertedColorScheme('dark');
+    }
 
     const observer = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {


### PR DESCRIPTION

The button to toggle color scheme within a live component did not work when in light mode
<img width="711" height="206" alt="bilde" src="https://github.com/user-attachments/assets/677da17b-cc31-43c1-8b45-f7a501b865a9" />
