### PR TITLE
fix(cli): support secondary fontFamily in schema and in tokens

### DIFF
--- a/.changeset/nasty-crabs-care.md
+++ b/.changeset/nasty-crabs-care.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": patch
+---
+
+support secondary fontFamily in schema and in tokens

--- a/packages/cli/bin/designsystemet.ts
+++ b/packages/cli/bin/designsystemet.ts
@@ -85,6 +85,7 @@ function makeTokenCommands() {
     .option(`--${cliOptions.clean} [boolean]`, 'Clean output directory before creating tokens', parseBoolean, false)
     .option('--dry [boolean]', `Dry run for created ${pc.blue('design-tokens')}`, parseBoolean, false)
     .option(`-f, --${cliOptions.theme.typography.fontFamily} <string>`, `Font family (experimental)`, DEFAULT_FONT)
+    .option(`--${cliOptions.theme.typography.secondaryFontFamily} <string>`, `Secondary font family (experimental)`)
     .option(
       `-b, --${cliOptions.theme.borderRadius} <number>`,
       `Unitless base border-radius in px`,

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -183,6 +183,7 @@ const themeSchema = z
     typography: z
       .object({
         fontFamily: z.string().meta({ description: 'Sets the font-family for this theme' }),
+        secondaryFontFamily: z.string().meta({ description: 'Sets the font-family for secondary typography' }).optional(),
       })
       .describe('Defines the typography for a given theme')
       .optional(),

--- a/packages/cli/src/tokens/create.ts
+++ b/packages/cli/src/tokens/create.ts
@@ -19,6 +19,7 @@ export const cliOptions = {
     },
     typography: {
       fontFamily: 'font-family',
+      secondaryFontFamily: 'secondary-font-family',
     },
     borderRadius: 'border-radius',
   },
@@ -42,7 +43,7 @@ export const createTokens = async (opts: Theme) => {
       'primitives/modes/typography/size/large',
     ]),
     [`primitives/modes/typography/primary/${name}`, generateTypography(name, typography)],
-    [`primitives/modes/typography/secondary/${name}`, generateTypography(name, typography)],
+    [`primitives/modes/typography/secondary/${name}`, generateTypography(name, { fontFamily: typography.secondaryFontFamily || typography.fontFamily })],
     ...colorSchemes.flatMap((scheme): [string, TokenSet][] => [
       [`primitives/modes/color-scheme/${scheme}/${name}`, generateColorScheme(name, scheme, colors, overrides)],
     ]),


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

This PR adds support for configuring a secondary font family in the CLI. Users can now specify a different font family for secondary typography using the `--secondary-font-family` option when generating tokens. If not specified, it falls back to the primary font family. This enables more flexible typography configuration for themes that require different font families for primary and secondary text.

## Checks

- [X] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [X] I have added a changeset (run `pnpm changeset` if relevant)
