### PR TITLE
fix(themeBuilder): missing translation header

### DIFF
--- a/apps/themebuilder/app/locales/en.ts
+++ b/apps/themebuilder/app/locales/en.ts
@@ -5,6 +5,7 @@ import type no from './no';
 export default {
   ...en,
   navigation: {
+    intro: 'Intro',
     fundamentals: 'Get Started',
     'best-practices': 'Best Practices',
     patterns: 'Patterns',

--- a/apps/themebuilder/app/locales/no.ts
+++ b/apps/themebuilder/app/locales/no.ts
@@ -4,6 +4,7 @@ import themeModal from './no/theme-modal';
 export default {
   ...no,
   navigation: {
+    intro: 'Intro',
     fundamentals: 'Kom i gang',
     'best-practices': 'God praksis',
     patterns: 'Mønstre',


### PR DESCRIPTION
it says `navigation.intro ` in the header if you go to the published themebuilder