### PR TITLE
fix(www): broken redirects

### DIFF
--- a/apps/www/server.js
+++ b/apps/www/server.js
@@ -42,7 +42,7 @@ if (DEVELOPMENT) {
     '/.well-known',
     express.static('dist/client/.well-known', { maxAge: '1y' }),
   );
-  app.use(express.static('dist/client'));
+  app.use(express.static('dist/client', { redirect: false }));
   app.use(express.static('dist/client/img', { maxAge: '30d' }));
   app.use(express.static('dist/client/animations', { maxAge: '30d' }));
   app.use(await import(BUILD_PATH).then((mod) => mod.app));


### PR DESCRIPTION
## Summary

When Express serves prerendered React Router pages, URLs pointing to directories without an index, like `/no/components/docs/alert` cause an infinite redirect loop between the React Router loader and express instead of redirecting to `/no/components/docs/alert/overview`. Disabling directory redirects in express fixes this by letting React Router handle all the redirect logic

<!-- Explain in short what this PR does -->

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
