### PR TITLE
docs: add missing tsconfig in react get started

### DIFF
--- a/apps/www/app/content/fundamentals/en/code/react.mdx
+++ b/apps/www/app/content/fundamentals/en/code/react.mdx
@@ -25,7 +25,7 @@ You can easily create your own theme later.
 If you are using Typescript, make sure you have typescript >= 3.8.
 
 #### Types for data attributes in React
-The design system provides type safety for `data-color` and `data-size` on React JSX elements.
+Designsystemet provides type safety for `data-color` and `data-size` on React JSX elements.
 We need to mutate React's built-in types to add these, and is why this is optional.
 To enable this, add the following to your `tsconfig.json`:
 

--- a/apps/www/app/content/fundamentals/no/code/react.mdx
+++ b/apps/www/app/content/fundamentals/no/code/react.mdx
@@ -28,7 +28,7 @@ Dersom du bruker Typescript, sørg for at du har typescript >= 3.8.
 
 #### Typer for data-attributer i React
 
-Designsystemet tilbyder typesikkerhet for `data-color` og `data-size` på React JSX elementer. 
+Designsystemet tilbyr typesikkerhet for `data-color` og `data-size` på React JSX elementer. 
 Vi må endre på Reacts innebygde typer for å legge til disse, og det er derfor valgfritt.
 For å aktivere dette, legg til følgende i din `tsconfig.json`:
 


### PR DESCRIPTION
Discovered we missed porting this information when new docs were made.