### PR TITLE
feat(www): add rss and atom feeds

### DIFF
--- a/apps/www/app/_utils/config/generate-feeds.ts
+++ b/apps/www/app/_utils/config/generate-feeds.ts
@@ -1,0 +1,138 @@
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { cwd } from 'node:process';
+import { buildMetadata, logoPath } from '../metadata';
+import { getBlogPosts } from './get-blog-posts';
+import { buildRFC822Date } from './rfc-822';
+import { rfc3339 } from './rfc-3339';
+
+const baseUrl = 'https://designsystemet.no';
+const ttl = 60 * 24 * 7; // 1 week
+
+// Source - https://stackoverflow.com/a/27979933
+// Posted by hgoebl, modified by community. See post 'Timeline' for change history
+// Retrieved 2026-02-11, License - CC BY-SA 4.0
+function escapeXml(unsafe: string): string {
+  return unsafe.replace(/[<>&'"]/g, (c) => {
+    switch (c) {
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '&':
+        return '&amp;';
+      case "'":
+        return '&apos;';
+      case '"':
+        return '&quot;';
+    }
+    return c;
+  });
+}
+
+export async function generateFeeds(lang: string): Promise<void> {
+  const dirname = cwd();
+  const now = new Date();
+
+  try {
+    const rssPath = `/${lang}/blog/feed.rss`;
+    const rssSource = `${baseUrl}${rssPath}`;
+    const atomPath = `/${lang}/blog/feed.atom`;
+    const atomSource = `${baseUrl}${atomPath}`;
+
+    const blogPosts = await getBlogPosts(lang);
+    const { title, description, siteUrl, image } = buildMetadata(
+      blogPosts.metadata,
+    );
+
+    const rssOutput = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+<channel>
+  <title>${escapeXml(title)} - Designsystemet</title>
+  <description>${escapeXml(description)}</description>
+  <link>${escapeXml(siteUrl)}</link>
+  <language>${lang}</language>
+  <image>
+    <title>${escapeXml(title)}</title>
+    <link>${escapeXml(siteUrl)}</link>
+    <url>${escapeXml(`${baseUrl}/${image}`)}</url>
+  </image>
+  <ttl>${ttl}</ttl>
+  <pubDate>${buildRFC822Date(now)}</pubDate>
+  <lastBuildDate>${buildRFC822Date(now)}</lastBuildDate>
+  <atom:link href="${escapeXml(rssSource)}" rel="self" type="application/rss+xml" />
+${blogPosts.posts
+  .map(
+    ({ url, description, title, date, searchTerms, image }) => `  <item>
+      <title>${escapeXml(title)}</title>
+      <link>${escapeXml(`${baseUrl}/${lang}/blog/${url}`)}</link>
+      <guid isPermaLink="true">${escapeXml(`${baseUrl}/${lang}/blog/${url}`)}</guid>
+      <pubDate>${buildRFC822Date(date)}</pubDate>
+      <description>${escapeXml(description)}</description>
+      <source url="${escapeXml(rssSource)}">${escapeXml(title)}</source>
+      <media:content url="${escapeXml(`${baseUrl}${image.src}`)}" lang="${lang}" />
+${searchTerms.map((term) => `      <category>${escapeXml(term.trim())}</category>`).join('\n')}
+  </item>`,
+  )
+  .join('\n')}
+  </channel>
+</rss>`;
+
+    const atomOutput = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>${escapeXml(title)} - Designsystemet</title>
+  <subtitle>${escapeXml(description)}</subtitle>
+  <link href="${escapeXml(siteUrl)}" />
+  <link rel="self" href="${escapeXml(atomPath)}" />
+  <icon>${escapeXml(logoPath)}</icon>
+  <logo>${escapeXml(image)}</logo>
+  <id>${escapeXml(atomSource)}</id>
+  <updated>${escapeXml(rfc3339(now))}</updated>
+
+${blogPosts.posts
+  .map(
+    ({ url, description, title, date, author, searchTerms }) => `  <entry>
+      <title>${escapeXml(title)}</title>
+      <link rel="alternate" href="${escapeXml(`${baseUrl}/${lang}/blog/${url}`)}" />
+      <link rel="self" href="${escapeXml(atomSource)}" />
+      <id>${escapeXml(`${baseUrl}/${lang}/blog/${url}`)}</id>
+      <updated>${escapeXml(rfc3339(new Date(date)))}</updated>
+      <summary>${escapeXml(description)}</summary>
+      <author>
+        <name>${escapeXml(author)}</name>
+      </author>
+${searchTerms.map((term) => `      <category term="${escapeXml(term.trim())}" />`).join('\n')}
+  </entry>`,
+  )
+  .join('\n')}
+</feed>`;
+
+    const rssClientPath = join(
+      dirname,
+      'dist',
+      'client',
+      lang,
+      'blog',
+      'feed.rss',
+    );
+    console.log(
+      `Writing feed.rss to ${rssClientPath} with ${blogPosts.posts.length} URLs`,
+    );
+    writeFileSync(rssClientPath, rssOutput);
+
+    const atomClientPath = join(
+      dirname,
+      'dist',
+      'client',
+      lang,
+      'blog',
+      'feed.atom',
+    );
+    console.log(
+      `Writing feed.atom to ${atomClientPath} with ${blogPosts.posts.length} URLs`,
+    );
+    writeFileSync(atomClientPath, atomOutput);
+  } catch (error) {
+    console.error(`Error generating feeds: ${error}`);
+  }
+}

--- a/apps/www/app/_utils/config/get-blog-posts.ts
+++ b/apps/www/app/_utils/config/get-blog-posts.ts
@@ -1,0 +1,81 @@
+import { join } from 'node:path';
+import { bundleMDX } from 'mdx-bundler';
+import i18n from '../../i18next.server';
+import { getFileFromContentDir, getFilesFromContentDir } from '../files.server';
+import { defaultCoverImagePath, type PageMetadata } from '../metadata';
+
+export interface BlogPosts {
+  lang: string;
+  posts: {
+    title: string;
+    author: string;
+    description: string;
+    url: string;
+    date: string;
+    image: {
+      src: string;
+      alt: string;
+    };
+    searchTerms: string[];
+  }[];
+  metadata: PageMetadata;
+}
+
+export async function getBlogPosts(lang: string): Promise<BlogPosts> {
+  /* Get all files in /content/blog for the lang we have selected */
+  const files = getFilesFromContentDir(join('blog', lang));
+
+  /* Filter out files that are not .mdx */
+  const mdxFiles = files.filter((file) => file.relativePath.endsWith('.mdx'));
+
+  /* Get titles and URLs for all files */
+  const posts: BlogPosts['posts'] = [];
+
+  const t = await i18n.getFixedT(lang);
+
+  /* Map over files with mdx parser to get title */
+  for (const file of mdxFiles) {
+    const fileContent = getFileFromContentDir(
+      join('blog', lang, file.relativePath),
+    );
+    const result = await bundleMDX({
+      source: fileContent,
+    });
+
+    const title =
+      result.frontmatter.title || file.relativePath.replace('.mdx', '');
+    const url = file.relativePath.replace('.mdx', '');
+    const searchTerms: string[] = [];
+    if (typeof result.frontmatter.search_terms === 'string')
+      result.frontmatter.search_terms
+        .split(',')
+        .map((term) => searchTerms.push(term));
+
+    posts.push({
+      title,
+      author: result.frontmatter.author || 'Unknown Author',
+      description: result.frontmatter.description || 'No description available',
+      url,
+      date: result.frontmatter.date || '2000-01-01',
+      image: {
+        src: result.frontmatter.imageSrc || defaultCoverImagePath,
+        alt: result.frontmatter.imageAlt || t('meta.meta-cover'),
+      },
+      searchTerms,
+    });
+  }
+
+  /* Sort posts by date */
+  posts.sort((a, b) => {
+    return new Date(b.date).getTime() - new Date(a.date).getTime();
+  });
+
+  return {
+    lang,
+    posts,
+    metadata: {
+      title: t('blog.title'),
+      description: t('blog.description'),
+    },
+  };
+}

--- a/apps/www/app/_utils/config/rfc-3339.ts
+++ b/apps/www/app/_utils/config/rfc-3339.ts
@@ -1,0 +1,32 @@
+// Authored by @pjdietz on GitHub
+// https://gist.github.com/pjdietz/e0545332e2fc67a9a460
+
+export function rfc3339(d: Date): string {
+  function pad(n: number): string | number {
+    return n < 10 ? '0' + n : n;
+  }
+
+  function timezoneOffset(offset: number): string {
+    if (offset === 0) {
+      return 'Z';
+    }
+    const sign = offset > 0 ? '-' : '+';
+    offset = Math.abs(offset);
+    return sign + pad(Math.floor(offset / 60)) + ':' + pad(offset % 60);
+  }
+
+  return (
+    d.getFullYear() +
+    '-' +
+    pad(d.getMonth() + 1) +
+    '-' +
+    pad(d.getDate()) +
+    'T' +
+    pad(d.getHours()) +
+    ':' +
+    pad(d.getMinutes()) +
+    ':' +
+    pad(d.getSeconds()) +
+    timezoneOffset(d.getTimezoneOffset())
+  );
+}

--- a/apps/www/app/_utils/config/rfc-822.ts
+++ b/apps/www/app/_utils/config/rfc-822.ts
@@ -1,0 +1,31 @@
+/**
+ * MIT License Copyright (c) 2022 Salma Alam-Naylor
+ * https://github.com/whitep4nth3r/rfc-822/blob/781aee2019a6a05d2fe91631bce00b41fc17a80e/index.js
+ */
+
+const weekdayFormat = new Intl.DateTimeFormat('en-US', { weekday: 'short' })
+  .format;
+const monthFormat = new Intl.DateTimeFormat('en-US', { month: 'short' }).format;
+
+// add a leading 0 to a number if it is only one digit
+function addLeadingZero(num: string | number): string {
+  num = num.toString();
+  while (num.length < 2) num = '0' + num;
+  return num;
+}
+
+export function buildRFC822Date(dateString: string | Date) {
+  const date =
+    dateString instanceof Date ? dateString : new Date(Date.parse(dateString));
+  // Convert to GMT
+  date.setTime(date.getTime() + date.getTimezoneOffset() * 60_000);
+
+  const day = weekdayFormat(date);
+  const dayNumber = addLeadingZero(date.getDate());
+  const month = monthFormat(date);
+  const year = date.getFullYear();
+  const time = `${addLeadingZero(date.getHours())}:${addLeadingZero(date.getMinutes())}:00`;
+
+  //Wed, 02 Oct 2002 13:00:00 GMT
+  return `${day}, ${dayNumber} ${month} ${year} ${time} GMT`;
+}

--- a/apps/www/app/_utils/metadata.ts
+++ b/apps/www/app/_utils/metadata.ts
@@ -1,15 +1,26 @@
-export const generateMetadata = ({
-  title,
-  description,
-  image = '/img/designsystemet-meta.png',
-}: {
+export interface PageMetadata {
   title: string;
   description: string;
   image?: string;
-}) => {
+}
+
+export interface BuiltMetadata {
+  pageTitle: string;
+  title: string;
+  description: string;
+  image: string;
+  siteUrl: string;
+}
+
+export const defaultCoverImagePath = '/img/designsystemet-meta.png';
+export const logoPath = '/img/Logotest.svg';
+
+export const generateMetadata = (metadata: PageMetadata) => {
+  const { title, description, siteUrl, pageTitle, image } =
+    buildMetadata(metadata);
   return [
     {
-      title: `${title} - Designsystemet`,
+      title: pageTitle,
     },
     {
       name: 'description',
@@ -29,7 +40,7 @@ export const generateMetadata = ({
     },
     {
       property: 'og:url',
-      content: 'https://designsystemet.no',
+      content: siteUrl,
     },
     {
       property: 'twitter:title',
@@ -49,3 +60,15 @@ export const generateMetadata = ({
     },
   ];
 };
+
+export const buildMetadata = ({
+  title,
+  description,
+  image = defaultCoverImagePath,
+}: PageMetadata): BuiltMetadata => ({
+  pageTitle: `${title} - Designsystemet`,
+  title,
+  description,
+  image,
+  siteUrl: 'https://designsystemet.no',
+});

--- a/apps/www/app/i18next.server.ts
+++ b/apps/www/app/i18next.server.ts
@@ -1,7 +1,7 @@
 import { RemixI18Next } from 'remix-i18next/server';
-import i18n from '~/i18n';
-import en from '~/locales/en';
-import no from '~/locales/no';
+import i18n from './i18n';
+import en from './locales/en';
+import no from './locales/no';
 
 const i18next = new RemixI18Next({
   detection: {

--- a/apps/www/app/routes/blog/blog.tsx
+++ b/apps/www/app/routes/blog/blog.tsx
@@ -1,13 +1,7 @@
-import { join } from 'node:path';
-import { bundleMDX } from 'mdx-bundler';
 import { BlogCard } from '~/_components/blog-card/blog-card';
-import {
-  getFileFromContentDir,
-  getFilesFromContentDir,
-} from '~/_utils/files.server';
+import { getBlogPosts } from '~/_utils/config/get-blog-posts';
 import { generateMetadata } from '~/_utils/metadata';
 import i18nConf from '~/i18n';
-import i18n from '~/i18next.server';
 import type { Route } from './+types/blog';
 
 export const loader = async ({ params: { lang } }: Route.LoaderArgs) => {
@@ -25,71 +19,32 @@ export const loader = async ({ params: { lang } }: Route.LoaderArgs) => {
     });
   }
 
-  /* Get all files in /content/blog for the lang we have selected */
-  const files = getFilesFromContentDir(join('blog', lang));
-
-  /* Filter out files that are not .mdx */
-  const mdxFiles = files.filter((file) => file.relativePath.endsWith('.mdx'));
-
-  /* Get titles and URLs for all files */
-  const posts: {
-    title: string;
-    author: string;
-    description: string;
-    url: string;
-    date: string;
-    image: {
-      src: string;
-      alt: string;
-    };
-  }[] = [];
-
-  /* Map over files with mdx parser to get title */
-  for (const file of mdxFiles) {
-    const fileContent = getFileFromContentDir(
-      join('blog', lang, file.relativePath),
-    );
-    const result = await bundleMDX({
-      source: fileContent,
-    });
-
-    const title =
-      result.frontmatter.title || file.relativePath.replace('.mdx', '');
-    const url = file.relativePath.replace('.mdx', '');
-    posts.push({
-      title,
-      author: result.frontmatter.author || 'Unknown Author',
-      description: result.frontmatter.description || 'No description available',
-      url,
-      date: result.frontmatter.date || '2000-01-01',
-      image: {
-        src: result.frontmatter.imageSrc || '',
-        alt: result.frontmatter.imageAlt || '',
-      },
-    });
-  }
-
-  /* Sort posts by date */
-  posts.sort((a, b) => {
-    return new Date(b.date).getTime() - new Date(a.date).getTime();
-  });
-
-  const t = await i18n.getFixedT(lang);
-
-  return {
-    lang,
-    posts,
-    metadata: generateMetadata({
-      title: t('blog.title'),
-      description: t('blog.description'),
-    }),
-  };
+  return getBlogPosts(lang);
 };
 
-export const meta = ({ data }: Route.MetaArgs) => {
-  if (!data) return [{ title: 'Designsystemet' }];
-  return data.metadata;
+export const meta: Route.MetaFunction = ({ loaderData }) => {
+  if (!loaderData) return [{ title: 'Designsystemet' }];
+  return generateMetadata(loaderData.metadata);
 };
+
+export const links: Route.LinksFunction = () => [
+  ...i18nConf.supportedLngs.flatMap((lang) => [
+    {
+      rel: 'alternate',
+      type: 'application/rss+xml',
+      title: `RSS - ${lang}`,
+      href: `/${lang}/blog/feed.rss`,
+      hrefLang: lang,
+    },
+    {
+      rel: 'alternate',
+      type: 'application/atom+xml',
+      title: `Atom - ${lang}`,
+      href: `/${lang}/blog/feed.atom`,
+      hrefLang: lang,
+    },
+  ]),
+];
 
 export default function Blog({ loaderData: { posts } }: Route.ComponentProps) {
   return (

--- a/apps/www/app/routes/home/home.tsx
+++ b/apps/www/app/routes/home/home.tsx
@@ -24,7 +24,7 @@ import {
   getFileFromContentDir,
   getFilesFromContentDir,
 } from '~/_utils/files.server';
-import { generateMetadata } from '~/_utils/metadata';
+import { generateMetadata, logoPath } from '~/_utils/metadata';
 import i18nConf from '~/i18n';
 import i18n from '~/i18next.server';
 import type { Route } from './+types/home';
@@ -285,7 +285,7 @@ export default function Home({ loaderData: { posts } }: Route.ComponentProps) {
           </div>
         </div>
         <div className={classes.joinCard}>
-          <img src='/img/Logotest.svg' alt='' />
+          <img src={logoPath} alt='' />
           <div>
             <Heading level={2} data-size='md'>
               {t('frontpage.join-section.title')}

--- a/apps/www/react-router.config.ts
+++ b/apps/www/react-router.config.ts
@@ -1,8 +1,10 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Config } from '@react-router/dev/config';
+import { generateFeeds } from './app/_utils/config/generate-feeds';
 import { generatePrerenderPaths } from './app/_utils/config/generate-prerender-paths';
 import { generateSitemap } from './app/_utils/config/generate-sitemap';
+import i18n from './app/i18n';
 
 const config: Config = {
   ssr: true,
@@ -36,6 +38,7 @@ const config: Config = {
       throw new Error(`Failed to write robots.txt file: ${error}`);
     }
     await generateSitemap(allPages);
+    await Promise.all(i18n.supportedLngs.map((lang) => generateFeeds(lang)));
   },
 };
 

--- a/internal/components/src/_locales/en.ts
+++ b/internal/components/src/_locales/en.ts
@@ -25,6 +25,9 @@ export default {
     'back-to-home': 'Go back to the home page',
     search: 'Search',
   },
+  meta: {
+    'meta-cover': "Designsystemet's logo",
+  },
   'clipboard-button': {
     copy: 'Copy',
     copied: 'Copied',

--- a/internal/components/src/_locales/no.ts
+++ b/internal/components/src/_locales/no.ts
@@ -23,6 +23,9 @@ export default {
     'back-to-home': 'Gå tilbake til forsiden',
     search: 'Søk',
   },
+  meta: {
+    'meta-cover': 'Designsystemet logo',
+  },
   'clipboard-button': {
     copy: 'Kopier',
     copied: 'Kopiert',


### PR DESCRIPTION
resolves #4492

## Summary

Generate RSS and Atom feeds at build time for the blog on the main designsystemet.no website for all available languages. Strongly inspired by how sitemap.xml is generated, as well as many helper functions copied all over github and stackoverflow

In addition these feeds have been checked with https://validator.w3.org/feed/ and should be valid

Lastly, I couldn't get react router to build when using path aliases, so some stuff had to be changed to be relative links unfortunately

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
