### PR TITLE
fix(www): align header to top on component pages

### DIFF
--- a/apps/www/app/routes/components/component.module.css
+++ b/apps/www/app/routes/components/component.module.css
@@ -69,6 +69,7 @@
 
 .headerText {
   max-width: var(--short-content-width);
+  place-self: start;
   [data-size='xs'] {
     margin-bottom: var(--ds-size-3);
     color: var(--ds-color-neutral-text-subtle);


### PR DESCRIPTION
resolves #4510

makes sure header text  grows from top down in the component pages