### PR TITLE
fix(www): double underline in safari

### DIFF
--- a/apps/www/app/_components/blog-card/blog-card.module.css
+++ b/apps/www/app/_components/blog-card/blog-card.module.css
@@ -21,10 +21,6 @@
     transition: none;
   }
 }
-.heading a {
-  text-decoration-thickness: 1px;
-  text-underline-offset: 4px;
-}
 
 @media screen and (min-width: 1024px) {
   .card[data-featured='true'] {

--- a/apps/www/app/_components/navigation-card/navigation-card.module.css
+++ b/apps/www/app/_components/navigation-card/navigation-card.module.css
@@ -84,10 +84,6 @@
   margin-bottom: var(--ds-size-5);
   text-align: center;
   line-height: 1.4em;
-  a {
-    text-decoration-thickness: 1px;
-    text-underline-offset: 4px;
-  }
 }
 
 .desc {


### PR DESCRIPTION
Due to changes in `.ds-card`, our overrides of the cards in hero-section and blog cards ended up with double underlines in the heading on safari. It was decided to remove the overrides. The new default style is thinner than the old so the difference is small regardless

<img width="443" height="301" alt="bilde" src="https://github.com/user-attachments/assets/2b7256e9-9a19-4958-92ee-8b7b9c4dc625" />
  