### PR TITLE
fix(robots.txt): include sitemap entry

### DIFF
--- a/apps/www/public/robots.txt
+++ b/apps/www/public/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Disallow: /
+Sitemap: https://designsystemet.no/sitemap.xml

--- a/apps/www/react-router.config.ts
+++ b/apps/www/react-router.config.ts
@@ -23,8 +23,8 @@ const config: Config = {
     const robotsPath = join(dirname, 'public', 'robots.txt');
     const robotsContent =
       process.env.APP_ENV === 'production'
-        ? `User-agent: *\nAllow: /`
-        : `User-agent: *\nDisallow: /`;
+        ? `User-agent: *\nAllow: /\nSitemap: https://designsystemet.no/sitemap.xml`
+        : `User-agent: *\nDisallow: /\nSitemap: https://designsystemet.no/sitemap.xml`;
 
     console.log(`Writing robots.txt to ${robotsPath}`);
     try {


### PR DESCRIPTION

<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

To make it easier for automated user-agents (such as search engines) to find the sitemap it should be included in the robots.txt file [1].

[1]: https://en.wikipedia.org/wiki/Sitemaps


## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
