### PR TITLE
docs: added short note in start guide

### DIFF
--- a/apps/www/app/content/fundamentals/en/start-here/own-theme.mdx
+++ b/apps/www/app/content/fundamentals/en/start-here/own-theme.mdx
@@ -107,7 +107,7 @@ Select `Themes`, `Select All`, and `Export to Figma`:
   boxShadow={false}
 />
 
-You should now see all components using your brand colours in Figma. Note: If you changed the names of the colours in the Theme Builder, you must go into Figma Variables and manually delete the old colours.
+You should now see all components using your brand colours in Figma.
 
 **Note:** Token Studio does not delete existing modes during export. After export, check Theme, Main color, and Support color, and remove any default themes that may still remain from the community file.
 

--- a/apps/www/app/content/fundamentals/no/start-here/own-theme.mdx
+++ b/apps/www/app/content/fundamentals/no/start-here/own-theme.mdx
@@ -109,7 +109,7 @@ Velg `Themes`, `Select All` og `Export to Figma`:
   boxShadow={false}
 />
 
-Nå skal du se alle komponentene med dine egne profilfarger i Figma. NB: Dersom du endret navn på fargene i Temabyggeren, må du inn i Figma Variabler og slette de gamle fargene manuelt. 
+Nå skal du se alle komponentene med dine egne profilfarger i Figma. 
 
 **Obs:** Token Studio sletter ikke eksisterende modes ved eksport. Etter eksport: kontroller Theme, Main color og Support color, og fjern eventuelle standardtemaer som fortsatt ligger igjen fra community filen.
 


### PR DESCRIPTION
resolves: #4524 

## Summary

Just a small adjustment to our guide. Telling the users that they should check their variables for "old" themes that my be their from the original community file

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
