### PR TITLE
fix(ToggleGroupItem): add missing backwards compatible props

### DIFF
--- a/.changeset/cyan-phones-heal.md
+++ b/.changeset/cyan-phones-heal.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet-react": patch
 ---
 
-**ToggleGroupItem**: add backwards compatible props
+**ToggleGroupItem**: Add missing props for backward compatibility. An internal rewrite from `button` to `label+input` in version v1.12.0 led to a lack of some props on `ToggleGroupItem` related to `button`.

--- a/apps/www/app/content/components/toggle-group/en/code.mdx
+++ b/apps/www/app/content/components/toggle-group/en/code.mdx
@@ -86,11 +86,6 @@ The remaining buttons should have `data-variant="tertiary"`.
 ```
 
 ## CSS variables and data attributes
-<Alert color="info">
-An internal rewrite from `button` to `label+input` in version v1.12.0 led to a lack of some props on `ToggleGroupItem` related to `button`. 
-<br/>
-Missing props were added again in version v1.12.2 for backward compatibility to the next major version.
-</Alert>
 <CssVariables />
 
 <CssAttributes />

--- a/apps/www/app/content/components/toggle-group/no/code.mdx
+++ b/apps/www/app/content/components/toggle-group/no/code.mdx
@@ -86,11 +86,6 @@ Resterande knappar skal ha `data-variant="tertiary"`.
 ```
 
 ## CSS variablar og data-attributter
-<Alert color="info">
-En intern omskriving fra `button` til `label+input` i versjon v1.12.0 førte til at det manglet en del props på `ToggleGroupItem` relatert til `button`. 
-<br/>
-Manglende props ble lagt til igjen versjon v1.12.2 for bakoverkompatibilitet til neste major versjon.
-</Alert>
 <CssVariables />
 
 <CssAttributes />


### PR DESCRIPTION
Resolves #4570
- Added missing `button` attributes previously available, except for `button[type]`, `disabled` and `readonly`.
- Will be looked at in separate issues. 
 - #4581
 - #4594 
- Added not about missing props in which versions above props table in docs.
