### PR TITLE
fix(select): missing chevron when readonly

### DIFF
--- a/.changeset/eighty-shoes-swim.md
+++ b/.changeset/eighty-shoes-swim.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**select**: fixed missing chevron icon when `readonly`

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -176,7 +176,7 @@
   /* Using attribute [readonly] since pseudo selector :read-only is always true for checkbox, radio and select */
   &[aria-readonly='true'],
   &[readonly] {
-    background: var(--dsc-input-background--readonly);
+    background-color: var(--dsc-input-background--readonly);
     border-color: var(--dsc-input-border-color--readonly);
     color: var(--dsc-input-color--readonly);
 


### PR DESCRIPTION
resolves #4583 