### PR TITLE
feat(toggle-group): add disabled & readonly support

### DIFF
--- a/.changeset/fluffy-comics-burn.md
+++ b/.changeset/fluffy-comics-burn.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-react": minor
+"@digdir/designsystemet-css": minor
+---
+
+feat(toggle-group): add disabled & readonly support

--- a/apps/www/app/content/components/toggle-group/en/code.mdx
+++ b/apps/www/app/content/components/toggle-group/en/code.mdx
@@ -28,11 +28,19 @@ Use [`Tooltip`](/en/components/docs/tooltip/code) to explain the actions when us
 
 <Story story="SecondaryEn" />
 
+### Disabled
+
+<Story story="DisabledEn" />
+
+### Readonly
+
+<Story story="ReadonlyEn" />
+
 ## HTML
 If you are using `@digdir/designsystemet-web`, you can implement `ToggleGroup` by using the `data-toggle-group` attribute.
 
 ```html
-<fieldset class="ds-toggle-group" data-toggle-group="Text alignment" data-variant="secondary">
+<fieldset class="ds-toggle-group" data-toggle-group="Text alignment" data-variant="secondary" data-readonly>
   <label>
     <input type="radio" name="alignment-two" value="left" checked />
     Leftadjusted

--- a/apps/www/app/content/components/toggle-group/no/code.mdx
+++ b/apps/www/app/content/components/toggle-group/no/code.mdx
@@ -27,6 +27,14 @@ Bruk [`Tooltip`](/no/components/docs/tooltip/code) for å forklare handlingane n
 
 <Story story="Secondary" />
 
+### Disabled
+
+<Story story="Disabled" />
+
+### Readonly
+
+<Story story="Readonly" />
+
 ## HTML
 Bruker du `@digdir/designsystemet-web` kan du implementere `ToggleGroup` ved å bruke `data-toggle-group`-attributtet.
 

--- a/apps/www/app/content/components/toggle-group/toggle-group.stories.tsx
+++ b/apps/www/app/content/components/toggle-group/toggle-group.stories.tsx
@@ -173,3 +173,52 @@ export const SecondaryEn = () => {
     </ToggleGroup>
   );
 };
+
+export const Disabled = () => {
+  return (
+    <ToggleGroup
+      data-toggle-group='Filter'
+      defaultValue='innboks'
+      variant='secondary'
+      disabled
+    >
+      <ToggleGroup.Item value='innboks'>Innboks</ToggleGroup.Item>
+      <ToggleGroup.Item value='utkast'>Utkast</ToggleGroup.Item>
+      <ToggleGroup.Item value='arkiv'>Arkiv</ToggleGroup.Item>
+      <ToggleGroup.Item value='sendt'>Sendt</ToggleGroup.Item>
+    </ToggleGroup>
+  );
+};
+
+export const DisabledEn = () => {
+  return (
+    <ToggleGroup data-toggle-group='Filter' defaultValue='inbox' disabled>
+      <ToggleGroup.Item value='inbox'>Inbox</ToggleGroup.Item>
+      <ToggleGroup.Item value='drafts'>Drafts</ToggleGroup.Item>
+      <ToggleGroup.Item value='archive'>Archive</ToggleGroup.Item>
+      <ToggleGroup.Item value='sent'>Sent</ToggleGroup.Item>
+    </ToggleGroup>
+  );
+};
+
+export const Readonly = () => {
+  return (
+    <ToggleGroup data-toggle-group='Filter' defaultValue='innboks' readOnly>
+      <ToggleGroup.Item value='innboks'>Innboks</ToggleGroup.Item>
+      <ToggleGroup.Item value='utkast'>Utkast</ToggleGroup.Item>
+      <ToggleGroup.Item value='arkiv'>Arkiv</ToggleGroup.Item>
+      <ToggleGroup.Item value='sendt'>Sendt</ToggleGroup.Item>
+    </ToggleGroup>
+  );
+};
+
+export const ReadonlyEn = () => {
+  return (
+    <ToggleGroup data-toggle-group='Filter' defaultValue='inbox' readOnly>
+      <ToggleGroup.Item value='inbox'>Inbox</ToggleGroup.Item>
+      <ToggleGroup.Item value='drafts'>Drafts</ToggleGroup.Item>
+      <ToggleGroup.Item value='archive'>Archive</ToggleGroup.Item>
+      <ToggleGroup.Item value='sent'>Sent</ToggleGroup.Item>
+    </ToggleGroup>
+  );
+};

--- a/packages/css/src/toggle-group.css
+++ b/packages/css/src/toggle-group.css
@@ -68,6 +68,10 @@
     pointer-events: none;
   }
 
+  &[data-readonly] label {
+    cursor: default;
+  }
+
   /* Style active if ds-button */
   & label:has(input:checked) {
     --dsc-button-background--active: var(--ds-color-base-active);

--- a/packages/react/src/components/toggle-group/toggle-group-item.tsx
+++ b/packages/react/src/components/toggle-group/toggle-group-item.tsx
@@ -30,6 +30,8 @@ export type ToggleGroupItemProps = {
     | 'required'
     | 'formNoValidate'
     | 'value'
+    | 'disabled'
+    | 'readOnly'
   >;
 
 /**
@@ -41,7 +43,7 @@ export const ToggleGroupItem = forwardRef<
   HTMLLabelElement,
   ToggleGroupItemProps
 >(function ToggleGroupItem(
-  { className, children, icon, value: rawValue, ...rest },
+  { className, children, icon, value: rawValue, readOnly, disabled, ...rest },
   ref,
 ) {
   const genValue = useId();
@@ -69,11 +71,14 @@ export const ToggleGroupItem = forwardRef<
     formNoValidate,
     formTarget,
     required,
+    disabled,
+    readOnly,
   };
 
   return (
     <label
       ref={ref}
+      aria-disabled={disabled ?? toggleGroup.disabled}
       {...labelProps}
       className={cl('ds-button', className)}
       data-variant='tertiary'
@@ -82,7 +87,9 @@ export const ToggleGroupItem = forwardRef<
         {...inputProps}
         checked={active}
         name={toggleGroup.name}
-        onChange={() => toggleGroup.onChange?.(value)}
+        onChange={() =>
+          toggleGroup.readOnly || readOnly || toggleGroup.onChange?.(value)
+        }
         type='radio'
         value={value}
       />

--- a/packages/react/src/components/toggle-group/toggle-group.stories.tsx
+++ b/packages/react/src/components/toggle-group/toggle-group.stories.tsx
@@ -114,3 +114,46 @@ SecondaryOnlyIcons.args = {
   'data-toggle-group': 'Filtering', // Set data-toggle-group attribute for accessibility
   variant: 'secondary',
 };
+
+export const Disabled = Preview.bind({});
+Disabled.args = {
+  'data-toggle-group': 'Filtering', // Set data-toggle-group attribute for accessibility
+  defaultValue: 'innboks',
+  disabled: true,
+};
+
+export const Readonly = Preview.bind({});
+Readonly.args = {
+  'data-toggle-group': 'Filtering', // Set data-toggle-group attribute for accessibility
+  defaultValue: 'innboks',
+  readOnly: true,
+};
+
+export const OnlyOneDisabled: StoryFn<typeof ToggleGroup> = ({
+  readOnly,
+  disabled,
+  ...args
+}) => {
+  return (
+    <ToggleGroup {...args}>
+      <ToggleGroup.Item value='innboks'>Innboks</ToggleGroup.Item>
+      <ToggleGroup.Item value='utkast'>Utkast</ToggleGroup.Item>
+      <ToggleGroup.Item readOnly={readOnly} disabled={disabled} value='arkiv'>
+        Arkiv
+      </ToggleGroup.Item>
+      <ToggleGroup.Item value='sendt'>Sendt</ToggleGroup.Item>
+    </ToggleGroup>
+  );
+};
+OnlyOneDisabled.args = {
+  'data-toggle-group': 'Filtering', // Set data-toggle-group attribute for accessibility
+  defaultValue: 'innboks',
+  disabled: true,
+};
+
+export const OnlyOneReadonly = OnlyOneDisabled.bind({});
+OnlyOneReadonly.args = {
+  'data-toggle-group': 'Filtering', // Set data-toggle-group attribute for accessibility
+  defaultValue: 'innboks',
+  readOnly: true,
+};

--- a/packages/react/src/components/toggle-group/toggle-group.test.tsx
+++ b/packages/react/src/components/toggle-group/toggle-group.test.tsx
@@ -121,6 +121,132 @@ describe('ToggleGroup', () => {
     expect(item2).toHaveProperty('checked', true);
   });
 
+  test('not checked when disabled ToggleGroup', async () => {
+    const onChangeMock = vi.fn();
+
+    render(
+      <ToggleGroup
+        data-toggle-group='Label'
+        defaultValue='test1'
+        onChange={onChangeMock}
+        disabled
+      >
+        <ToggleGroup.Item value='test1'>test1</ToggleGroup.Item>
+        <ToggleGroup.Item value='test2'>test2</ToggleGroup.Item>
+      </ToggleGroup>,
+    );
+
+    const item1 = screen.getByRole('radio', {
+      name: 'test1',
+    });
+    const item2 = screen.getByRole('radio', {
+      name: 'test2',
+    });
+
+    expect(item1).toHaveProperty('checked', true);
+    expect(item2).toHaveProperty('checked', false);
+
+    await user.click(item2.parentElement as HTMLLabelElement);
+
+    expect(onChangeMock).toBeCalledTimes(0);
+    expect(item2).toHaveProperty('checked', false);
+  });
+
+  test('not checked when disabled ToggleGroupItem', async () => {
+    const onChangeMock = vi.fn();
+
+    render(
+      <ToggleGroup
+        data-toggle-group='Label'
+        defaultValue='test1'
+        onChange={onChangeMock}
+      >
+        <ToggleGroup.Item value='test1'>test1</ToggleGroup.Item>
+        <ToggleGroup.Item disabled value='test2'>
+          test2
+        </ToggleGroup.Item>
+      </ToggleGroup>,
+    );
+
+    const item1 = screen.getByRole('radio', {
+      name: 'test1',
+    });
+    const item2 = screen.getByRole('radio', {
+      name: 'test2',
+    });
+
+    expect(item1).toHaveProperty('checked', true);
+    expect(item2).toHaveProperty('checked', false);
+
+    await user.click(item2.parentElement as HTMLLabelElement);
+
+    expect(onChangeMock).toBeCalledTimes(0);
+    expect(item2).toHaveProperty('checked', false);
+  });
+
+  test('not checked when readOnly ToggleGroup', async () => {
+    const onChangeMock = vi.fn();
+
+    render(
+      <ToggleGroup
+        data-toggle-group='Label'
+        defaultValue='test1'
+        onChange={onChangeMock}
+        readOnly
+      >
+        <ToggleGroup.Item value='test1'>test1</ToggleGroup.Item>
+        <ToggleGroup.Item value='test2'>test2</ToggleGroup.Item>
+      </ToggleGroup>,
+    );
+
+    const item1 = screen.getByRole('radio', {
+      name: 'test1',
+    });
+    const item2 = screen.getByRole('radio', {
+      name: 'test2',
+    });
+
+    expect(item1).toHaveProperty('checked', true);
+    expect(item2).toHaveProperty('checked', false);
+
+    await user.click(item2.parentElement as HTMLLabelElement);
+
+    expect(onChangeMock).toBeCalledTimes(0);
+    expect(item2).toHaveProperty('checked', false);
+  });
+
+  test('not checked when disabled ToggleGroupItem', async () => {
+    const onChangeMock = vi.fn();
+
+    render(
+      <ToggleGroup
+        data-toggle-group='Label'
+        defaultValue='test1'
+        onChange={onChangeMock}
+      >
+        <ToggleGroup.Item value='test1'>test1</ToggleGroup.Item>
+        <ToggleGroup.Item readOnly value='test2'>
+          test2
+        </ToggleGroup.Item>
+      </ToggleGroup>,
+    );
+
+    const item1 = screen.getByRole('radio', {
+      name: 'test1',
+    });
+    const item2 = screen.getByRole('radio', {
+      name: 'test2',
+    });
+
+    expect(item1).toHaveProperty('checked', true);
+    expect(item2).toHaveProperty('checked', false);
+
+    await user.click(item2.parentElement as HTMLLabelElement);
+
+    expect(onChangeMock).toBeCalledTimes(0);
+    expect(item2).toHaveProperty('checked', false);
+  });
+
   test('if we pass a name, we should have a hidden input with that name', () => {
     const name = 'my-name';
     const { container } = render(

--- a/packages/react/src/components/toggle-group/toggle-group.tsx
+++ b/packages/react/src/components/toggle-group/toggle-group.tsx
@@ -10,6 +10,8 @@ export type ToggleGroupContextProps = {
   defaultValue?: string;
   onChange?: (value: string) => void;
   name?: string;
+  readOnly?: boolean;
+  disabled?: boolean;
 };
 
 export const ToggleGroupContext = createContext<ToggleGroupContextProps>({});
@@ -43,6 +45,17 @@ export type ToggleGroupProps = MergeRight<
      * Toggle group label for accessibility
      */
     'data-toggle-group'?: string;
+    /**
+     * The **`readOnly`** property is a boolean value that reflects the fieldset element's `readOnly` attribute, which indicates whether the control is readOnly.
+     * This property gets passed to all ToggleGroupItem
+     */
+    readOnly?: boolean;
+    /**
+     * The **`disabled`** property of the HTMLFieldSetElement interface is a boolean value that reflects the fieldset element's `disabled` attribute, which indicates whether the control is disabled.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/disabled)
+     */
+    disabled?: boolean;
   }
 >;
 
@@ -66,6 +79,8 @@ export const ToggleGroup = forwardRef<HTMLFieldSetElement, ToggleGroupProps>(
       onChange,
       value,
       variant = 'primary',
+      readOnly,
+      disabled,
       ...rest
     },
     ref,
@@ -93,6 +108,8 @@ export const ToggleGroup = forwardRef<HTMLFieldSetElement, ToggleGroupProps>(
           onChange: onValueChange,
           value,
           variant,
+          readOnly,
+          disabled,
         }}
       >
         <fieldset
@@ -100,6 +117,8 @@ export const ToggleGroup = forwardRef<HTMLFieldSetElement, ToggleGroupProps>(
           data-toggle-group='' // Default to empty string to ensure attribute is present
           data-variant={variant}
           ref={ref}
+          disabled={disabled}
+          data-readonly={readOnly}
           {...rest}
         >
           {children}


### PR DESCRIPTION
Related: #4581

## Summary

Add `disabled` and `readOnly` support to ToggleGroup in react

Primarily react because I am not sure how this should really look like
in css/web 😅

fieldset or input[type=radio] don't support readonly or aria-readonly,
so this is a bit half-assed. But it looks good with the naked eye at
least.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
