### PR TITLE
fix(www): live-component causing overflow

### DIFF
--- a/apps/www/app/_components/live-component/live-component.module.css
+++ b/apps/www/app/_components/live-component/live-component.module.css
@@ -148,6 +148,11 @@
   z-index: 1;
   --dsc-button-padding: var(--ds-size-2);
 }
+.resetText {
+  @media screen and (max-width: 380px) {
+    display: none;
+  }
+}
 .copy {
   border-top-right-radius: var(--_br);
   padding-inline-end: var(--ds-size-4);

--- a/apps/www/app/_components/live-component/live-components.tsx
+++ b/apps/www/app/_components/live-component/live-components.tsx
@@ -202,7 +202,7 @@ const Editor = ({ live, html, id, hidden, language }: EditorProps) => {
         type='button'
       >
         <aksel.ArrowsCirclepathIcon />
-        {t('live-component.reset')}
+        <span className={classes.resetText}>{t('live-component.reset')}</span>
       </ds.Button>
       <ds.Button
         data-color='neutral'
@@ -217,7 +217,7 @@ const Editor = ({ live, html, id, hidden, language }: EditorProps) => {
           <aksel.FilesIcon aria-hidden />
           <aksel.ClipboardCheckmarkIcon aria-hidden />
         </span>
-        {t('live-component.copy')}
+        <span>{t('live-component.copy')}</span>
       </ds.Button>
       {/* biome-ignore lint/a11y/noStaticElementInteractions: <need to manage keyboard events from here> */}
       <div


### PR DESCRIPTION
resolves #4577 

adds overflow-x: auto to the the preview container. 
Also hide "reset" text in the button row below 380px to make enough room down to past 320px 