### PR TITLE
chore: ignore @floating-ui/react in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>digdir/renovate-config"],
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "ignoreDeps": ["@floating-ui/react"]
 }


### PR DESCRIPTION
We only use this in `Combobox` which is deprecated and planned to be removed.

Updating this dependency breaks `Combobox` and thus we want to ignore updates for it untill its removed along with `@floating-ui/react`.