### PR TITLE
chore: change default release to snapshot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       snapshot:
         description: "Create snapshot release"
         type: boolean
-        default: false
+        default: true
       tag:
         description: "npm tag (for snapshot releases)"
         type: choice


### PR DESCRIPTION
Changing default release to be a snapshot to reduce risk for "production build" being published by mistake (and having to deprecate all wrongly published packages).