### PR TITLE
fix(www): address missing prop warnings

### DIFF
--- a/apps/www/app/_components/live-component/live-components.tsx
+++ b/apps/www/app/_components/live-component/live-components.tsx
@@ -188,6 +188,7 @@ const Editor = ({ live, html, id, hidden, language }: EditorProps) => {
         value={showHTML.toString()}
         onChange={(v) => setShowHTML(v === 'true')}
         data-color='neutral'
+        data-toggle-group='language'
       >
         <ds.ToggleGroup.Item value='false'>React</ds.ToggleGroup.Item>
         <ds.ToggleGroup.Item value='true'>HTML</ds.ToggleGroup.Item>

--- a/apps/www/app/content/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/apps/www/app/content/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -87,7 +87,7 @@ export const ListOnlyEn = () => (
 );
 
 export const BackOnly = () => (
-  <Breadcrumbs>
+  <Breadcrumbs aria-label='Brødsmulesti'>
     <Breadcrumbs.Link href='#' aria-label='Tilbake til Nivå 3'>
       Nivå 3
     </Breadcrumbs.Link>
@@ -95,7 +95,7 @@ export const BackOnly = () => (
 );
 
 export const BackOnlyEn = () => (
-  <Breadcrumbs>
+  <Breadcrumbs aria-label='Breadcrumbs menu'>
     <Breadcrumbs.Link href='#' aria-label='Back to Level 3'>
       Level 3
     </Breadcrumbs.Link>
@@ -103,7 +103,7 @@ export const BackOnlyEn = () => (
 );
 
 export const LongItems = () => (
-  <Breadcrumbs>
+  <Breadcrumbs aria-label='Brødsmulesti'>
     <Breadcrumbs.Link
       href='#'
       aria-label='Tilbake til helsesertifikat for sjømat'
@@ -145,7 +145,7 @@ export const LongItems = () => (
 );
 
 export const LongItemsEn = () => (
-  <Breadcrumbs>
+  <Breadcrumbs aria-label='Breadcrumbs menu'>
     <Breadcrumbs.Link
       href='#'
       aria-label='Back to health certificate for seafood'

--- a/apps/www/app/content/components/pagination/pagination.stories.tsx
+++ b/apps/www/app/content/components/pagination/pagination.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 export const Preview = () => {
   return (
-    <Pagination>
+    <Pagination aria-label='pagineringsmeny'>
       <Pagination.List>
         <Pagination.Item>
           <Pagination.Button aria-label='Forrige side' data-variant='tertiary'>
@@ -49,7 +49,7 @@ export const Preview = () => {
 
 export const PreviewEn = () => {
   return (
-    <Pagination>
+    <Pagination aria-label='Pagination menu'>
       <Pagination.List>
         <Pagination.Item>
           <Pagination.Button aria-label='Previous page' data-variant='tertiary'>
@@ -151,7 +151,7 @@ export const WithAnchorEn = () => {
   });
 
   return (
-    <Pagination aria-label='Sidenavigering'>
+    <Pagination aria-label='Pagination menu'>
       <Pagination.List>
         <Pagination.Item>
           <Pagination.Button
@@ -191,7 +191,7 @@ export const WithAnchorEn = () => {
 
 export const Mobile = () => {
   return (
-    <Pagination>
+    <Pagination aria-label='Pagination menu'>
       <Pagination.List>
         <Pagination.Item>
           <Pagination.Button
@@ -226,7 +226,7 @@ export const Mobile = () => {
 
 export const MobileEn = () => {
   return (
-    <Pagination>
+    <Pagination aria-label='Pagination menu'>
       <Pagination.List>
         <Pagination.Item>
           <Pagination.Button


### PR DESCRIPTION
web package triggers console warnings for missing aria-labels etc. Navigated to each component page to check, found warnings in breadcrumbs and pagination (+ live-component needed data-toggle-group text)
