### PR TITLE
fix(link): remove duplicated non-collapsing margin by reverting icon selector to the same as v1.11.1

### DIFF
--- a/.changeset/nine-pets-vanish.md
+++ b/.changeset/nine-pets-vanish.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Link**: Spacing for icons in links are now the same as in version 1.11.1

--- a/packages/css/src/link.css
+++ b/packages/css/src/link.css
@@ -35,11 +35,11 @@
   /*
    * Ensure proper spacing if there is svg or img and span.
    */
-  &:has(> span):has(> :is(img, svg)) {
-    & > :first-child {
+  &:has(> span) > :is(img, svg) {
+    &:first-child {
       margin-inline-end: var(--ds-size-1);
     }
-    & > :last-child {
+    &:last-child {
       margin-inline-start: var(--ds-size-1);
     }
   }


### PR DESCRIPTION
## Summary

The current selector for adding spacing to icons in links has a bug where both the icon and the text gets a margin, which means the spacing is twice what is intended.

This PR changes the selector to target the icon in the same way as in v1.11.1, which means the spacing is now the same as it was in that version.

I don't know why this selector was changed in 1.12.0 in the first place, but from then onward it didn't actually add spacing to the icon until #4707 (unreleased) which introduced a different bug: the icon then got twice the spacing it had in v1.11.1. 

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
