### PR TITLE
fix(card): roll back text-decoration-thickness to how it was in 1.11.1

### DIFF
--- a/.changeset/mean-cycles-stick.md
+++ b/.changeset/mean-cycles-stick.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Card**: ensure underline on link in heading has same thickness as in version 1.11.1

--- a/packages/css/src/card.css
+++ b/packages/css/src/card.css
@@ -48,7 +48,7 @@
     & > .ds-card__block > :is(h1, h2, h3, h4, h5, h6) {
       text-decoration-line: underline;
       text-decoration-style: solid;
-      text-decoration-thickness: 0.0625em; /* 1px ish */
+      text-decoration-thickness: max(1px, 0.0625rem, 0.1025em); /* 2px ish */
       text-underline-offset: 0.27em; /* 5px ish */
 
       & > a {


### PR DESCRIPTION
## Summary

In version 1.12.0 the underline thickness for links in a Card heading was reduced from ~2.35px to ~1px. This reverts that change.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
