### PR TITLE
fix(www): documentation regarding data-floating and toggle-group

### DIFF
--- a/apps/www/app/_components/css-attributes/css-attributes.tsx
+++ b/apps/www/app/_components/css-attributes/css-attributes.tsx
@@ -66,7 +66,7 @@ export function getAttributes(css: string) {
   const globals = ['color', 'size', 'color-scheme'];
 
   const allAttrs = Array.from(
-    css.matchAll(/\[data-([^=\]|$~*\^]+)(?:([|$~*\^]?=)([^\]]+))?\]/g),
+    css.matchAll(/\[data-([^=\]|$~*^]+)(?:([|$~*^]?=)([^\]]+))?\]/g),
   ).map((matches) => ({ [matches[1]]: matches[3] }));
 
   for (const attr of allAttrs) {

--- a/apps/www/app/_components/css-attributes/css-attributes.tsx
+++ b/apps/www/app/_components/css-attributes/css-attributes.tsx
@@ -66,8 +66,8 @@ export function getAttributes(css: string) {
   const globals = ['color', 'size', 'color-scheme'];
 
   const allAttrs = Array.from(
-    css.matchAll(/\[data-([^=\]]+)(?:=([^\]]+))?\]/g),
-  ).map((matches) => ({ [matches[1]]: matches[2] }));
+    css.matchAll(/\[data-([^=\]|$~*\^]+)(?:([|$~*\^]?=)([^\]]+))?\]/g),
+  ).map((matches) => ({ [matches[1]]: matches[3] }));
 
   for (const attr of allAttrs) {
     for (const [key, value] of Object.entries(attr)) {

--- a/apps/www/app/content/components/toggle-group/en/code.mdx
+++ b/apps/www/app/content/components/toggle-group/en/code.mdx
@@ -33,15 +33,15 @@ If you are using `@digdir/designsystemet-web`, you can implement `ToggleGroup` b
 
 ```html
 <fieldset class="ds-toggle-group" data-toggle-group="Text alignment" data-variant="secondary">
-  <label>
+  <label class="ds-button" data-variant="tertiary">
     <input type="radio" name="alignment-two" value="left" checked />
     Leftadjusted
   </label>
-  <label>
+  <label class="ds-button" data-variant="tertiary">
     <input type="radio" name="alignment-two" value="center" />
     Centered
   </label>
-  <label>
+  <label class="ds-button" data-variant="tertiary">
     <input type="radio" name="alignment-two" value="right" />
     Rightadjusted
   </label>

--- a/apps/www/app/content/components/toggle-group/no/code.mdx
+++ b/apps/www/app/content/components/toggle-group/no/code.mdx
@@ -32,15 +32,15 @@ Bruker du `@digdir/designsystemet-web` kan du implementere `ToggleGroup` ved å 
 
 ```html
 <fieldset class="ds-toggle-group" data-toggle-group="Tekstjustering" data-variant="secondary">
-  <label>
+  <label class="ds-button" data-variant="tertiary">
     <input type="radio" name="alignment-two" value="left" checked />
     Venstestilt
   </label>
-  <label>
+  <label class="ds-button" data-variant="tertiary">
     <input type="radio" name="alignment-two" value="center" />
     Midtstilt
   </label>
-  <label>
+  <label class="ds-button" data-variant="tertiary">
     <input type="radio" name="alignment-two" value="right" />
     Høyrestilt
   </label>


### PR DESCRIPTION
## Summary

Fix how `data-floating` is shown on the code documentation pages

And add relevant attributes on the toggle-group HTML example

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)

From:
<img width="1893" height="435" alt="image" src="https://github.com/user-attachments/assets/66ab9840-4b78-47a1-a0cf-768df8febb90" />

To:

<img width="1893" height="435" alt="image" src="https://github.com/user-attachments/assets/13545b1b-eee1-4f23-af3a-197fe2e9e74d" />

PS: This isn't really a good solution as it doesn't really cover the -start and -end suffixes that `@floating-ui/dom` supports [1]. But short of hard coding these, I don't see an obvious solution

PS(2): The commit messages are prettier than this PR description :P

[1]: https://floating-ui.com/docs/tutorial#placements