### PR TITLE
fix(www): add missing css variables and attributes documentation for alert, avatar, and badge

### DIFF
--- a/apps/www/app/content/components/alert/en/code.mdx
+++ b/apps/www/app/content/components/alert/en/code.mdx
@@ -28,3 +28,9 @@ Read above for when to use `role` and `aria-live`.
 This is an info alert.
 </div>
 ```
+
+## CSS variables and data attributes
+
+<CssVariables />
+
+<CssAttributes />

--- a/apps/www/app/content/components/avatar/en/code.mdx
+++ b/apps/www/app/content/components/avatar/en/code.mdx
@@ -96,3 +96,7 @@ Avatar uses the class name `ds-avatar` on a `<span>` with `role="img"`.
 ```
 
 ## CSS variables and data attributes
+
+<CssVariables />
+
+<CssAttributes />

--- a/apps/www/app/content/components/badge/en/code.mdx
+++ b/apps/www/app/content/components/badge/en/code.mdx
@@ -66,3 +66,7 @@ You can also set `data-overlap="circle"` on it to get circular overlap.
 ```
 
 ## CSS variables and data attributes
+
+<CssVariables />
+
+<CssAttributes />


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

add missing css variables and attributes documentation for alert, avatar, and badge

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)

As far as I can tell these were just missing by accident /shrug