### PR TITLE
chore: update pnpm approved builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - internal/*
 ignoredBuiltDependencies:
   - '@bundled-es-modules/glob'
+  - '@parcel/watcher'
   - rs-module-lexer
   - sharp
 injectWorkspacePackages: true
@@ -13,7 +14,6 @@ minimumReleaseAgeExclude:
   - "@u-elements/*"
 onlyBuiltDependencies:
   - '@biomejs/biome'
-  - '@parcel/watcher'
   - '@swc/core'
   - esbuild
   - just-pnpm

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - internal/*
 ignoredBuiltDependencies:
   - '@bundled-es-modules/glob'
+  - rs-module-lexer
   - sharp
 injectWorkspacePackages: true
 minimumReleaseAge: 1440
@@ -12,6 +13,7 @@ minimumReleaseAgeExclude:
   - "@u-elements/*"
 onlyBuiltDependencies:
   - '@biomejs/biome'
+  - '@parcel/watcher'
   - '@swc/core'
   - esbuild
   - just-pnpm


### PR DESCRIPTION
- `@parcel/watcher` is used by `vite`.
- `rs-module-lexer` is used by `@custom-elements-manifest/analyzer`.