### PR TITLE
fix(www): prevent error-summary focus on load

### DIFF
--- a/apps/www/app/_components/live-component/live-components.tsx
+++ b/apps/www/app/_components/live-component/live-components.tsx
@@ -58,6 +58,7 @@ export type LiveComponentProps = {
   story: string;
   layout?: 'row' | 'column' | 'centered' | 'block';
   language?: Language;
+  startAsInert?: boolean /*to prevent focus on load of error-summary stories*/;
 };
 
 //copied from https://github.com/FormidableLabs/react-live/blob/master/packages/react-live/src/components/Live/LiveContext.ts
@@ -298,6 +299,7 @@ export const LiveComponent = ({
   story,
   layout = 'centered',
   language = 'react',
+  startAsInert,
 }: LiveComponentProps) => {
   const location = useLocation();
   const { t } = useTranslation();
@@ -363,8 +365,14 @@ export const LiveComponent = ({
         data-layout={layout}
       >
         <LivePreview
+          inert={startAsInert}
           data-color-scheme={previewColorScheme}
           className={classes['live-preview']}
+          ref={(el: HTMLDivElement | null) => {
+            if (el && startAsInert)
+              /*500 has been tested to work in firefox & chrome*/
+              setTimeout(() => el?.removeAttribute('inert'), 500);
+          }}
         />
         <LiveError className={cl('ds-alert', classes['live-preview-error'])} />
         <ds.Button

--- a/apps/www/app/_components/mdx-components/mdx-components.tsx
+++ b/apps/www/app/_components/mdx-components/mdx-components.tsx
@@ -166,7 +166,12 @@ export const MDXComponents = ({
   );
 };
 
-const Story = ({ story, layout, language }: LiveComponentProps) => {
+const Story = ({
+  story,
+  layout,
+  language,
+  startAsInert,
+}: LiveComponentProps) => {
   const { stories } = useLoaderData();
   if (!stories) return null;
 
@@ -179,6 +184,7 @@ const Story = ({ story, layout, language }: LiveComponentProps) => {
       story={`${foundStory.code}\n\nrender(<${foundStory.name} />)`}
       layout={layout}
       language={language}
+      startAsInert={startAsInert}
     />
   );
 };

--- a/apps/www/app/content/components/error-summary/en/code.mdx
+++ b/apps/www/app/content/components/error-summary/en/code.mdx
@@ -32,7 +32,7 @@ In order for `ErrorSummary.Link` to navigate to the fields with errors, the fiel
 
 ### Moving focus
 
-Below is an example where we move focus to `ErrorSummary` when it becomes visible.
+Below is an example of how focus is automatically moved to `ErrorSummary` when it becomes visible.
 
 <Story story="ShowHideEn" layout="column" startAsInert />
 

--- a/apps/www/app/content/components/error-summary/en/code.mdx
+++ b/apps/www/app/content/components/error-summary/en/code.mdx
@@ -1,4 +1,4 @@
-<Story story="PreviewEn" />
+<Story story="PreviewEn" startAsInert />
 <ReactComponentDocs />
 
 ## Usage
@@ -28,13 +28,13 @@ import { ErrorSummary } from '@digdir/designsystemet-react';
 
 In order for `ErrorSummary.Link` to navigate to the fields with errors, the fields must have a unique `id` that matches the `href` in the link.
 
-<Story story="WithFormEn" layout="column" />
+<Story story="WithFormEn" layout="column" startAsInert />
 
 ### Moving focus
 
 Below is an example where we move focus to `ErrorSummary` when it becomes visible.
 
-<Story story="ShowHideEn" layout="column" />
+<Story story="ShowHideEn" layout="column" startAsInert />
 
 ## HTML
 

--- a/apps/www/app/content/components/error-summary/en/overview.mdx
+++ b/apps/www/app/content/components/error-summary/en/overview.mdx
@@ -2,7 +2,7 @@
 search_terms: errors, validation, errorlist
 ---
 
-<Story story="PreviewEn" />
+<Story story="PreviewEn" startAsInert />
 
 **Use `ErrorSummary` when**
 - you need to present a clear overview of the errors that must be corrected before a form can be submitted
@@ -18,7 +18,7 @@ search_terms: errors, validation, errorlist
 
 In the example below, each link in the `ErrorSummary` lets you navigate directly to the field containing an error.
 
-<Story story="WithFormEn" layout="column" />
+<Story story="WithFormEn" layout="column" startAsInert />
 
 ## Guidelines
 

--- a/apps/www/app/content/components/error-summary/en/overview.mdx
+++ b/apps/www/app/content/components/error-summary/en/overview.mdx
@@ -34,10 +34,9 @@ You can read more about this in the [article on error messages](/en/patterns/err
 
 ### Visibility
 
-The summary should not be visible before the user has taken an action that triggers an error. It should become visible only after the user performs an action that results in errors.
+The summary should not be visible before the user has taken an action that triggers an error. It should become visible only after the user performs an action that results in errors. The summary automatically receives focus when it becomes visible and when its content changes.
 
-- If validation happens continuously (for example using `onBlur` on each field), wait to show `ErrorSummary` until the user attempts to submit the form.  
-- It is important that the component receives focus when it appears, so the user notices that there are errors or missing information.  
+- If validation happens continuously (for example using `onBlur` on each field), wait to show `ErrorSummary` until the user attempts to submit the form.   
 - Error messages must link directly to the relevant field.  
 - If the error applies to several fields, for example when two fields are validated together, link to the first instance of the error.
 

--- a/apps/www/app/content/components/error-summary/error-summary.stories.tsx
+++ b/apps/www/app/content/components/error-summary/error-summary.stories.tsx
@@ -1,5 +1,5 @@
 import { Button, ErrorSummary, Textfield } from '@digdir/designsystemet-react';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 export const Preview = () => {
   return (

--- a/apps/www/app/content/components/error-summary/error-summary.stories.tsx
+++ b/apps/www/app/content/components/error-summary/error-summary.stories.tsx
@@ -127,13 +127,6 @@ export const WithFormEn = () => {
 
 export const ShowHide = () => {
   const [show, setShow] = useState(false);
-  const summaryRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (show) {
-      summaryRef.current?.focus();
-    }
-  }, [show]);
 
   return (
     <>
@@ -149,7 +142,7 @@ export const ShowHide = () => {
         </Button>
       </div>
       {show && (
-        <ErrorSummary ref={summaryRef}>
+        <ErrorSummary>
           <ErrorSummary.Heading>
             For å gå videre må du rette opp følgende feil:
           </ErrorSummary.Heading>
@@ -173,13 +166,6 @@ export const ShowHide = () => {
 
 export const ShowHideEn = () => {
   const [show, setShow] = useState(false);
-  const summaryRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (show) {
-      summaryRef.current?.focus();
-    }
-  }, [show]);
 
   return (
     <>
@@ -195,7 +181,7 @@ export const ShowHideEn = () => {
         </Button>
       </div>
       {show && (
-        <ErrorSummary ref={summaryRef}>
+        <ErrorSummary>
           <ErrorSummary.Heading>
             To proceed, you must correct the following errors:
           </ErrorSummary.Heading>

--- a/apps/www/app/content/components/error-summary/no/code.mdx
+++ b/apps/www/app/content/components/error-summary/no/code.mdx
@@ -1,4 +1,4 @@
-<Story story="Preview" />
+<Story story="Preview" startAsInert />
 <ReactComponentDocs />
 
 ## Bruk
@@ -28,13 +28,13 @@ import { ErrorSummary } from '@digdir/designsystemet-react';
 
 For å at `ErrorSummary.Link` skal navigere til feltene med feil, må feltene ha en unik `id` som samsvarer med `href` i lenken.
 
-<Story story="WithForm" layout="column" />
+<Story story="WithForm" layout="column" startAsInert />
 
 ### Flytte fokus
 
 Under er et eksempel der vi flytter fokus til `ErrorSummary` når den blir synlig.
 
-<Story story="ShowHide" layout="column" />
+<Story story="ShowHide" layout="column" startAsInert />
 
 ## HTML
 

--- a/apps/www/app/content/components/error-summary/no/code.mdx
+++ b/apps/www/app/content/components/error-summary/no/code.mdx
@@ -32,7 +32,7 @@ For å at `ErrorSummary.Link` skal navigere til feltene med feil, må feltene ha
 
 ### Flytte fokus
 
-Under er et eksempel der vi flytter fokus til `ErrorSummary` når den blir synlig.
+Under er et eksempel som viser hvordan fokus automatisk flyttes til `ErrorSummary` når den blir synlig.
 
 <Story story="ShowHide" layout="column" startAsInert />
 

--- a/apps/www/app/content/components/error-summary/no/overview.mdx
+++ b/apps/www/app/content/components/error-summary/no/overview.mdx
@@ -2,7 +2,7 @@
 search_terms: feilsammendrag, feilliste, feilmeldinger, feilmeldingar, validering, feil
 ---
 
-<Story story="Preview" />
+<Story story="Preview" startAsInert />
 
 **Bruk `ErrorSummary` når**
 - du skal vise en tydelig oversikt over hvilke feil som må rettes før de kan sende inn et skjema
@@ -18,7 +18,7 @@ search_terms: feilsammendrag, feilliste, feilmeldinger, feilmeldingar, validerin
 
 I eksempelet under kan du trykke på hver lenke i `ErrorSummary` for å navigere til det aktuelle feltet med feil.
 
-<Story story="WithForm" layout="column" />
+<Story story="WithForm" layout="column" startAsInert />
 
 ## Retningslinjer
 

--- a/apps/www/app/content/components/error-summary/no/overview.mdx
+++ b/apps/www/app/content/components/error-summary/no/overview.mdx
@@ -32,9 +32,8 @@ I noen tilfeller kan det likevel være bedre å vise oppsummeringen i toppen, de
 
 ### Synlighet
 
-Oppsummeringen skal ikke være synlig uten at brukeren foretar seg noe. Den skal bli synlig først når brukeren har utført en handling som utløser feil.
-- Hvis vi validerer fortløpende (for eksempel ved `onBlur` på hvert felt), venter vi med å vise ErrorSummary til brukeren prøver å sende inn skjemaet.
-- Det er viktig at komponenten får fokus når den blir vist, slik at brukeren får med seg at det er feil eller mangler i skjemaet.
+Oppsummeringen skal ikke være synlig uten at brukeren foretar seg noe. Den skal bli synlig først når brukeren har utført en handling som utløser feil. Oppsummeringen får automatisk fokus når den vises, og når innholdet endres.
+- Hvis vi validerer fortløpende (for eksempel ved `onBlur` på hvert felt), venter vi med å vise ErrorSummary til brukeren prøver å sende inn skjemaet. 
 - Feilmeldingene skal lenke direkte til feltet det gjelder.
 - Hvis feilen gjelder flere felt, for eksempel når to felt valideres på tvers, lenker vi til det første tilfellet av feilen.
 


### PR DESCRIPTION
implemented as a new `startAsInert` attribute on `Story` (default false)

Also updated the `ErrorSummary` docs to reflect the changes made in the web package where it automatically recieve focus now
