### PR TITLE
fix(www): correct links in errors article

### DIFF
--- a/apps/www/app/content/patterns/en/errors.mdx
+++ b/apps/www/app/content/patterns/en/errors.mdx
@@ -31,7 +31,7 @@ We should be able to show error messages with all types of fields in a form. The
   boxShadow={false}
 />
 
-See [`ValidationMessage`](/en/components/docs/validation-message) for an example of implementation.
+See [`ValidationMessage`](/en/components/docs/validation-message/overview) for an example of implementation.
 
 ### Summary of multiple error messages
 
@@ -58,7 +58,7 @@ Make sure that:
   boxShadow={false}
 />
 
-See [`ErrorSummary`](/en/components/docs/error-summary) for an example of implementation.
+See [`ErrorSummary`](/en/components/docs/error-summary/overview) for an example of implementation.
 
 ### It's best to avoid giving error messages
 

--- a/apps/www/app/content/patterns/no/errors.mdx
+++ b/apps/www/app/content/patterns/no/errors.mdx
@@ -30,7 +30,7 @@ Vi skal kunne vise feilmeldinger sammen med alle typer felt i et skjema. Melding
   alt='Skjermbilde av skjema med en feilmelding. Brukeren har skrevet "fdgdfgfdg" inn i et felt for fødselsnummer. Feilmeldingen sier at Fødselsnummer  skal inneholde 11 siffer.'
   boxShadow={false}
 />
-Se [`ValidationMessage`](/no/components/docs/validation-message) for eksempel på implementasjon.
+Se [`ValidationMessage`](/no/components/docs/validation-message/overview) for eksempel på implementasjon.
 
 ### Oppsummering av flere feilmeldinger
 
@@ -58,7 +58,7 @@ Pass på at
   boxShadow={false}
 />
 
-Se [`ErrorSummary`](/no/components/docs/error-summary) for eksempel på implementasjon.
+Se [`ErrorSummary`](/no/components/docs/error-summary/overview) for eksempel på implementasjon.
 
 ### Det er best om vi kan unngå å gi feilmeldinger
 


### PR DESCRIPTION
ran `test:www-links `and it triggered on these (redirect works anyway but better to have correct)