### PR TITLE
fix(card): ds-focus when link/button

### DIFF
--- a/.changeset/odd-terms-dress.md
+++ b/.changeset/odd-terms-dress.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**card**: use designsystemet focus outline when card itself is a link or button

--- a/packages/css/src/card.css
+++ b/packages/css/src/card.css
@@ -43,6 +43,7 @@
   &:where(a, button, [role='button'], [data-clickdelegatefor]) {
     cursor: pointer;
     text-decoration: none;
+    @composes ds-focus from './base.css';
 
     & > :is(h1, h2, h3, h4, h5, h6),
     & > .ds-card__block > :is(h1, h2, h3, h4, h5, h6) {


### PR DESCRIPTION
resolves #4762 

This is when asChild is used to make card a button or link. There was only the browser default outline.