### PR TITLE
feat(www): make dodont available in patterns

### DIFF
--- a/apps/www/app/_components/mdx-components/mdx-components.tsx
+++ b/apps/www/app/_components/mdx-components/mdx-components.tsx
@@ -203,7 +203,7 @@ const DoDontComponent = ({
   const { dodont } = useLoaderData() as {
     dodont?: { name: string; code: string }[] | null;
   };
-  if (!dodont) return null;
+  if (!dodont) return <Alert lang='en'>Do/Dont not found: {story}</Alert>;
 
   const foundStory = dodont.find((s) => s.name === story);
   if (!foundStory) return <Alert lang='en'>Do/Dont not found: {story}</Alert>;

--- a/apps/www/app/_components/mdx-components/mdx-components.tsx
+++ b/apps/www/app/_components/mdx-components/mdx-components.tsx
@@ -36,7 +36,7 @@ import {
   TypographyVariablesTable,
 } from '@internal/components';
 import { getMDXComponent } from 'mdx-bundler/dist/client';
-import { type ComponentType, type JSX, useMemo } from 'react';
+import { type ComponentType, type JSX, type ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link as RRLink, useLoaderData } from 'react-router';
 import { ColorInfoTable } from '~/_components/color-info-table/color-info-table';
@@ -44,6 +44,7 @@ import { Contributors } from '~/_components/contributors/contributors';
 import { Image } from '~/_components/image/image';
 import { ResponsiveIframe } from '~/_components/responsive-iframe/responsive-iframe';
 import { CssVariables } from '../css-variables/css-variables';
+import { DoDont } from '../do-dont/do-dont';
 import {
   LiveComponent,
   type LiveComponentProps,
@@ -156,6 +157,7 @@ export const MDXComponents = ({
           components={{
             ...defaultComponents,
             Story: Story,
+            DoDont: DoDontComponent,
             ...components,
           }}
         />
@@ -186,5 +188,33 @@ const Story = ({
       language={language}
       startAsInert={startAsInert}
     />
+  );
+};
+
+const DoDontComponent = ({
+  story,
+  children,
+  layout,
+}: {
+  story: string;
+  layout?: 'row' | 'column' | 'centered';
+  children?: ReactNode;
+}) => {
+  const { dodont } = useLoaderData() as {
+    dodont?: { name: string; code: string }[] | null;
+  };
+  if (!dodont) return null;
+
+  const foundStory = dodont.find((s) => s.name === story);
+  if (!foundStory) return <Alert lang='en'>Do/Dont not found: {story}</Alert>;
+  const variant = story.toLowerCase().includes('dont') ? 'dont' : 'do';
+  return (
+    <DoDont
+      layout={layout}
+      variant={variant}
+      code={`${foundStory.code}\n\nrender(<${foundStory.name} />)`}
+    >
+      {children}
+    </DoDont>
   );
 };

--- a/apps/www/app/routes/components/component.tsx
+++ b/apps/www/app/routes/components/component.tsx
@@ -1,15 +1,10 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
-import {
-  Alert,
-  Button,
-  Heading,
-  Paragraph,
-} from '@digdir/designsystemet-react';
+import { Button, Heading, Paragraph } from '@digdir/designsystemet-react';
 import { PencilLineIcon } from '@navikt/aksel-icons';
 import cl from 'clsx/lite';
-import type { ComponentType, ReactNode } from 'react';
+import type { ComponentType } from 'react';
 import type { ComponentDoc } from 'react-docgen-typescript';
 import { useTranslation } from 'react-i18next';
 import { NavLink, redirect, useRouteLoaderData } from 'react-router';
@@ -21,7 +16,6 @@ import {
   CssVariables,
   getCssVariables,
 } from '~/_components/css-variables/css-variables';
-import { DoDont } from '~/_components/do-dont/do-dont';
 import { EditPageOnGithub } from '~/_components/edit-page-on-github/edit-page-on-github';
 import { IconFrame } from '~/_components/icon-frame/icon-frame';
 import { LiveComponent } from '~/_components/live-component/live-components';
@@ -229,7 +223,6 @@ export default function Components({
           <MDXComponents
             code={mdxCode}
             components={{
-              DoDont: DoDontComponent as unknown as ComponentType<unknown>,
               ReactComponentDocs:
                 PropsTable as unknown as ComponentType<unknown>,
               CssVariables: CssVars as unknown as ComponentType<unknown>,
@@ -249,35 +242,6 @@ export default function Components({
     </>
   );
 }
-
-const DoDontComponent = ({
-  story,
-  children,
-  layout,
-}: {
-  story: string;
-  layout?: 'row' | 'column' | 'centered';
-  children?: ReactNode;
-}) => {
-  const data =
-    useRouteLoaderData<Route.ComponentProps['loaderData']>('components-page');
-  if (!data) return null;
-
-  const { dodont } = data;
-
-  const foundStory = dodont.find((s) => s.name === story);
-  if (!foundStory) return <Alert lang='en'>Do/Dont not found: {story}</Alert>;
-  const variant = story.toLowerCase().includes('dont') ? 'dont' : 'do';
-  return (
-    <DoDont
-      layout={layout}
-      variant={variant}
-      code={`${foundStory.code}\n\nrender(<${foundStory.name} />)`}
-    >
-      {children}
-    </DoDont>
-  );
-};
 
 const PropsTable = () => {
   const data =

--- a/apps/www/app/routes/patterns/page.tsx
+++ b/apps/www/app/routes/patterns/page.tsx
@@ -36,6 +36,10 @@ export async function loader({ params }: Route.LoaderArgs) {
     path: join('patterns', params.lang, `${file}.stories.tsx`),
   });
 
+  const dodont = await getStories({
+    path: join('patterns', params.lang, `${file}.dodont.tsx`),
+  });
+
   // Bundle the MDX content
   const result = await generateFromMdx(fileContent);
 
@@ -46,6 +50,7 @@ export async function loader({ params }: Route.LoaderArgs) {
     lang: params.lang,
     toc: result.toc,
     stories,
+    dodont,
   };
 }
 


### PR DESCRIPTION
Now dodont can be used same way as stories in patterns
if you want dodont stories in errors.mdx, create a file called `errors.dodont.tsx` in the same folder

with content just like stories 

```
import { Button } from '@digdir/designsystemet-react';

export const DoIcon = () => {
  return ([code for this]);
};
export const DontIcon = () => {
  return ([code for that]);
};
```

In the mdx file:
```
<div className="dodont-row">
  <DoDont story="DoIcon">
    Berre bruk eitt ikon per knapp.
  </DoDont>
  <DoDont story="DontIcon">
    Ikkje bruk fleire ikon i same knapp.
  </DoDont>
</div>
```