### PR TITLE
docs(alert): web-first

### DIFF
--- a/apps/www/app/content/components/alert/en/accessibility.mdx
+++ b/apps/www/app/content/components/alert/en/accessibility.mdx
@@ -1,6 +1,6 @@
 ## What you need to check
 
-**`Alert` that appears or updates after the page has loaded must be automatically announced by screen readers.**
+**Alert that appears or updates after the page has loaded must be automatically announced by screen readers.**
 
 Use `role="alert"` for critical messages that require immediate attention.
 Use `role="status"` for less critical messages.
@@ -11,9 +11,9 @@ WCAG: [4.1.3 Status messages](https://www.uutilsynet.no/wcag-standarden/413-stat
 
 <Divider/>
 \
-**`Alert` must be placed so that it follows the reading order.**
+**Alert must be placed so that it follows the reading order.**
 
-This means the `Alert` must appear in the DOM in a way that provides a logical reading order for screen readers. If the `Alert` has a heading, the heading level must be correct in the page structure.
+This means the Alert must appear in the DOM in a way that provides a logical reading order for screen readers. If the Alert has a heading, the heading level must be correct in the page structure.
 
 <span data-size="sm"> 
 WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
@@ -21,7 +21,7 @@ WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/wcag-standarden/1
 
 <Divider/>
 \
-**`Alert` text must explain what happened and what it means for the user.**
+**Alert text must explain what happened and what it means for the user.**
 
 Example: “Your changes have been saved” or “An error occurred while saving. Please try again later”. Not just: “Error” or “Warning”.
 
@@ -31,9 +31,9 @@ See the [system notifications pattern](/en/patterns/systemnotifications#language
 
 ## Alert in a live region
 
-If you want the alert to be read out dynamically, you must place the `Alert` inside a live region. The region **must wrap around** the `Alert` component, not be placed on the component itself.
+If you want the alert to be read out dynamically, you must place the alert inside a live region. The region **must wrap around** the alert component, not be placed on the component itself.
 
-Out of the box, `Alert` is presented to screen reader users as regular static content. For alerts that appear dynamically, you can define a *live region* for screen readers yourself, but be aware of the behaviour this introduces. You can read more about this in [MDN's documentation on ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
+Out of the box, alert is presented to screen reader users as regular static content. For alerts that appear dynamically, you can define a *live region* for screen readers yourself, but be aware of the behaviour this introduces. You can read more about this in [MDN's documentation on ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
 
 Pay particular attention to the fact that the live region — that is, the element with the attribute `role="alert"`, `role="status"`, or `aria-live` with the value `"assertive"` or `"polite"` — must exist on the page **before** the alert that is to be read out.
 

--- a/apps/www/app/content/components/alert/en/code.mdx
+++ b/apps/www/app/content/components/alert/en/code.mdx
@@ -3,7 +3,7 @@
 ## Usage
 
 Use the attribute `data-color` to change the type of alert.
-Read bellow for when to use `role` and `aria-live`.
+Read below for when to use `role` and `aria-live`.
 
 [Read about `role` and `aria-live` on the accessibility page for the alert component.](/en/components/docs/alert/accessibility#alert-i-live-region)
 

--- a/apps/www/app/content/components/alert/en/code.mdx
+++ b/apps/www/app/content/components/alert/en/code.mdx
@@ -1,24 +1,8 @@
-<Story story="PreviewEn" />
+<Story story="PreviewEn" language="html" />
 
 ## Usage
-```tsx
-import { Alert } from '@digdir/designsystemet-react';
 
-<Alert>You are using the Alert component!</Alert>;
-```
-
-## Examples
-
-### Changing the alert
-
-In code, you change the type of alert by changing `data-color`.
-The icon is controlled via CSS.
-
-<Story story="VariantsEn" />
-
-## HTML
-
-For HTML, use the class name `ds-alert` and the attribute `data-color` to change the type of alert.
+Use the attribute `data-color` to change the type of alert.
 Read above for when to use `role` and `aria-live`.
 
 [Read about `role` and `aria-live` on the accessibility page for the `Alert` component.](/en/components/docs/alert/accessibility#alert-i-live-region)
@@ -29,8 +13,18 @@ This is an info alert.
 </div>
 ```
 
+
 ## CSS variables and data attributes
 
 <CssVariables />
 
 <CssAttributes />
+
+
+## React
+
+
+```jsx
+<Alert data-color="info">This is a information message.</Alert>
+```
+

--- a/apps/www/app/content/components/alert/en/code.mdx
+++ b/apps/www/app/content/components/alert/en/code.mdx
@@ -18,6 +18,6 @@ Read bellow for when to use `role` and `aria-live`.
 
 
 ```jsx
-<Alert data-color="info">This is a information message.</Alert>
+<Alert data-color="info">This is an information message.</Alert>
 ```
 

--- a/apps/www/app/content/components/alert/en/code.mdx
+++ b/apps/www/app/content/components/alert/en/code.mdx
@@ -3,16 +3,9 @@
 ## Usage
 
 Use the attribute `data-color` to change the type of alert.
-Read above for when to use `role` and `aria-live`.
+Read bellow for when to use `role` and `aria-live`.
 
 [Read about `role` and `aria-live` on the accessibility page for the `Alert` component.](/en/components/docs/alert/accessibility#alert-i-live-region)
-
-```html
-<div class="ds-alert" data-color="info">
-This is an info alert.
-</div>
-```
-
 
 ## CSS variables and data attributes
 

--- a/apps/www/app/content/components/alert/en/code.mdx
+++ b/apps/www/app/content/components/alert/en/code.mdx
@@ -5,7 +5,7 @@
 Use the attribute `data-color` to change the type of alert.
 Read bellow for when to use `role` and `aria-live`.
 
-[Read about `role` and `aria-live` on the accessibility page for the `Alert` component.](/en/components/docs/alert/accessibility#alert-i-live-region)
+[Read about `role` and `aria-live` on the accessibility page for the alert component.](/en/components/docs/alert/accessibility#alert-i-live-region)
 
 ## CSS variables and data attributes
 

--- a/apps/www/app/content/components/alert/en/overview.mdx
+++ b/apps/www/app/content/components/alert/en/overview.mdx
@@ -2,25 +2,25 @@
 search_terms: notification, feedback, warning, message, confirmation, error, warning
 ---
 
-<Story story="PreviewEn" />
+<Story story="PreviewEn" language="html" />
 
-**Use `Alert` when**
+**Use Alert when**
 - you need to show short and informative time-limited messages
 - the information concerns an error that affects only one part of the system or a minor function
 - there are connection issues or API errors that are likely to be resolved by reloading the page
 
-**Avoid `Alert` when**
+**Avoid Alert when**
 - the error prevents further use of the service, use an [error page](/en/patterns/systemnotifications#n%C3%A5r-bruker-vi-feilsider) instead
 - you need to notify the user about an error in a single form field, use the component’s own error message [`ValidationMessage`](/en/components/docs/validation-message/overview)
 - the message is a static info box, use [`Card`](/en/components/docs/card/overview) instead
 - multiple error messages need to be summarised, use [`ErrorSummary`](/en/components/docs/error-summary/overview) instead
 
-For more comprehensive guidelines on how to use alerts in services, see the pattern for [System notifications](/en/patterns/systemnotifications). There you will find examples and recommendations on when to use `Alert`, and when other solutions may be more appropriate.
+For more comprehensive guidelines on how to use alerts in services, see the pattern for [System notifications](/en/patterns/systemnotifications). There you will find examples and recommendations on when to use alert, and when other solutions may be more appropriate.
 
 
 ## Examples
 
-`Alert` can be used for four types of messages: information, success, warning and error.
+Alert can be used for four types of messages: information, success, warning and error.
 
 ### Information
 
@@ -58,16 +58,16 @@ If the title and description repeat the same thing, it is better to use a simple
 
 ### With link
 
-You can have a link in the `Alert` if it helps the user solve the task. But be aware that a link takes the user out of the service, so use links only when absolutely necessary, for example if you want the user to open a form or perform an important task.
+You can have a link in the alert if it helps the user solve the task. But be aware that a link takes the user out of the service, so use links only when absolutely necessary, for example if you want the user to open a form or perform an important task.
 
 <Story story="MedLenkeEn" />
 
 ## Guidelines
-`Alert` is used to display important messages that require attention, but not necessarily action. It can be used to inform the user about the status, changes, or problems in a solution. The message is displayed clearly and visually distinguished from the rest of the content.
+Alert is used to display important messages that require attention, but not necessarily action. It can be used to inform the user about the status, changes, or problems in a solution. The message is displayed clearly and visually distinguished from the rest of the content.
 
 Use the component with caution. Users can confuse alerts with advertising, and thus ignore them. If we use alerts too often, we can exacerbate this problem.
 
-Make sure that `Alert` has the same look and feel across all services and products. This component should be recognizable everywhere, so we should not adjust it.
+Make sure that alert has the same look and feel across all services and products. This component should be recognizable everywhere, so we should not adjust it.
 
 **Suitable for**
 - provide short and informative time-limited notifications

--- a/apps/www/app/content/components/alert/en/overview.mdx
+++ b/apps/www/app/content/components/alert/en/overview.mdx
@@ -10,7 +10,7 @@ search_terms: notification, feedback, warning, message, confirmation, error, war
 - there are connection issues or API errors that are likely to be resolved by reloading the page
 
 **Avoid Alert when**
-- the error prevents further use of the service, use an [error page](/en/patterns/systemnotifications#n%C3%A5r-bruker-vi-feilsider) instead
+- the error prevents further use of the service, use an [error page](/en/patterns/systemnotifications#when-do-we-use-error-pages) instead
 - you need to notify the user about an error in a single form field, use the component’s own error message [validation message](/en/components/docs/validation-message/overview)
 - the message is a static info box, use [card](/en/components/docs/card/overview) instead
 - multiple error messages need to be summarised, use [error summary](/en/components/docs/error-summary/overview) instead

--- a/apps/www/app/content/components/alert/en/overview.mdx
+++ b/apps/www/app/content/components/alert/en/overview.mdx
@@ -11,9 +11,9 @@ search_terms: notification, feedback, warning, message, confirmation, error, war
 
 **Avoid Alert when**
 - the error prevents further use of the service, use an [error page](/en/patterns/systemnotifications#n%C3%A5r-bruker-vi-feilsider) instead
-- you need to notify the user about an error in a single form field, use the component’s own error message [`ValidationMessage`](/en/components/docs/validation-message/overview)
-- the message is a static info box, use [`Card`](/en/components/docs/card/overview) instead
-- multiple error messages need to be summarised, use [`ErrorSummary`](/en/components/docs/error-summary/overview) instead
+- you need to notify the user about an error in a single form field, use the component’s own error message [validation message](/en/components/docs/validation-message/overview)
+- the message is a static info box, use [card](/en/components/docs/card/overview) instead
+- multiple error messages need to be summarised, use [error summary](/en/components/docs/error-summary/overview) instead
 
 For more comprehensive guidelines on how to use alerts in services, see the pattern for [System notifications](/en/patterns/systemnotifications). There you will find examples and recommendations on when to use alert, and when other solutions may be more appropriate.
 
@@ -75,10 +75,10 @@ Make sure that alert has the same look and feel across all services and products
 - inform about connection problems or API errors that are likely to be resolved by reloading the page
 
 **Not suitable for**
-- validate individual form elements, instead use the component's own error message (See [`ValidationMessage`](/en/components/docs/validation-message/overview))
-- summarize multiple error messages in a form, instead use [`ErrorSummary`](/en/components/docs/error-summary/overview)
+- validate individual form elements, instead use the component's own error message (See [validation message](/en/components/docs/validation-message/overview))
+- summarize multiple error messages in a form, instead use [error summary](/en/components/docs/error-summary/overview)
 - display errors that prevent all further use of the service, instead use an error page
-- display static information that should be displayed all the time, instead use [`Card`](/en/components/docs/card/overview)
+- display static information that should be displayed all the time, instead use [card](/en/components/docs/card/overview)
 
 ## Text
 

--- a/apps/www/app/content/components/alert/no/accessibility.mdx
+++ b/apps/www/app/content/components/alert/no/accessibility.mdx
@@ -1,6 +1,6 @@
 ## Dette må du sjekke selv
 
-**`Alert` som vises eller oppdateres etter at siden er lastet skal bli kunngjort automatisk av skjermlesere.**
+**Alert som vises eller oppdateres etter at siden er lastet skal bli kunngjort automatisk av skjermlesere.**
 
 Bruk `role="alert"` for kritiske meldinger som krever umiddelbar oppmerksomhet.  
 Bruk `role="status"` for mindre kritiske meldinger.
@@ -11,10 +11,10 @@ WCAG: [4.1.3 Statusbeskjeder](https://www.uutilsynet.no/wcag-standarden/413-stat
 
 <Divider/>
 \
-**`Alert` skal være plassert slik at den følger leserekkefølgen.**
+**Alert skal være plassert slik at den følger leserekkefølgen.**
 
-Dette betyr at `Alert` skal ligge i DOM på en måte som gir en logisk leserekkefølge for skjermlesere.  
-Hvis `Alert` har en overskrift, skal overskriftsnivået være korrekt i sidestrukturen.
+Dette betyr at alert skal ligge i DOM på en måte som gir en logisk leserekkefølge for skjermlesere.  
+Hvis alert har en overskrift, skal overskriftsnivået være korrekt i sidestrukturen.
 
 <span data-size="sm"> 
 WCAG: [1.3.1 Informasjon og relasjoner](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
@@ -22,7 +22,7 @@ WCAG: [1.3.1 Informasjon og relasjoner](https://www.uutilsynet.no/wcag-standarde
 
 <Divider/>
 \
-**`Alert`-tekst skal forklare hva som har skjedd og hva det betyr for brukeren.**
+**Alert-tekst skal forklare hva som har skjedd og hva det betyr for brukeren.**
 
 Eksempel: “Endringene dine er lagret” eller “Det oppstod en feil ved lagring. Prøv igjen senere”. Ikke bare: “Feil” eller “Advarsel”.
 
@@ -32,9 +32,9 @@ Se [mønsteret for systemvarsler](/no/patterns/systemnotifications#språk) for a
 
 ## Alert i live region
 
-Dersom du vil at varselet skal bli lest opp dynamisk, må du legge `Alert` i en live region. Regionen **skal være rundt** `Alert`-komponenten, ikke på den.
+Dersom du vil at varselet skal bli lest opp dynamisk, må du legge alert i en live region. Regionen **skal være rundt** alert-komponenten, ikke på den.
 
-Ut av boksen blir `Alert` presentert for skjermleserbrukere som vanlig statisk innhold. For varsler som oppstår dynamisk kan du selv definere en *live region* for skjermlesere, men vær oppmerksom på hvilken oppførsel dette medfører. Du kan lese mer om dette i [MDN sin dokumentasjon om ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
+Ut av boksen blir alert presentert for skjermleserbrukere som vanlig statisk innhold. For varsler som oppstår dynamisk kan du selv definere en *live region* for skjermlesere, men vær oppmerksom på hvilken oppførsel dette medfører. Du kan lese mer om dette i [MDN sin dokumentasjon om ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions).
 
 Legg spesielt merke til at live-regionen — altså elementet med attributt `role="alert"`, `role="status"` eller `aria-live` med verdi `"assertive"` eller `"polite"` — må eksistere på siden **før** varselet som skal leses opp.
 

--- a/apps/www/app/content/components/alert/no/code.mdx
+++ b/apps/www/app/content/components/alert/no/code.mdx
@@ -5,7 +5,7 @@
 Bruk attributtet `data-color` for å endre type varsel.
 Les under for når du skal bruke `role` og `aria-live`.
 
-[Les om `role` og `aria-live` på tilgjengeligheitssiden for `Alert`-komponenten.](/no/components/docs/alert/accessibility#alert-i-live-region)
+[Les om `role` og `aria-live` på tilgjengeligheitssiden for alert-komponenten.](/no/components/docs/alert/accessibility#alert-i-live-region)
 
 
 ## CSS variabler og data-attributter

--- a/apps/www/app/content/components/alert/no/code.mdx
+++ b/apps/www/app/content/components/alert/no/code.mdx
@@ -5,7 +5,7 @@
 Bruk attributtet `data-color` for å endre type varsel.
 Les under for når du skal bruke `role` og `aria-live`.
 
-[Les om `role` og `aria-live` på tilgjengeligheitssiden for alert-komponenten.](/no/components/docs/alert/accessibility#alert-i-live-region)
+[Les om `role` og `aria-live` på tilgjengelighetssiden for alert-komponenten.](/no/components/docs/alert/accessibility#alert-i-live-region)
 
 
 ## CSS variabler og data-attributter

--- a/apps/www/app/content/components/alert/no/code.mdx
+++ b/apps/www/app/content/components/alert/no/code.mdx
@@ -3,10 +3,9 @@
 ## Bruk
 
 Bruk attributtet `data-color` for å endre type varsel.
-Les over for når du skal bruke `role` og `aria-live`.
+Les under for når du skal bruke `role` og `aria-live`.
 
 [Les om `role` og `aria-live` på tilgjengeligheitssiden for `Alert`-komponenten.](/no/components/docs/alert/accessibility#alert-i-live-region)
-
 
 
 ## CSS variabler og data-attributter

--- a/apps/www/app/content/components/alert/no/code.mdx
+++ b/apps/www/app/content/components/alert/no/code.mdx
@@ -1,20 +1,13 @@
 <Story story="Preview" language="html" />
 
-
-
-
 ## Bruk
 
-Bruk klassenavnet `ds-alert` og attributtet `data-color` for å endre type varsel.
+Bruk attributtet `data-color` for å endre type varsel.
 Les over for når du skal bruke `role` og `aria-live`.
 
 [Les om `role` og `aria-live` på tilgjengeligheitssiden for `Alert`-komponenten.](/no/components/docs/alert/accessibility#alert-i-live-region)
 
-```html
-<div class="ds-alert" data-color="info">
-  Dette er en info alert.
-</div>
-```
+
 
 ## CSS variabler og data-attributter
 <CssVariables />
@@ -24,4 +17,6 @@ Les over for når du skal bruke `role` og `aria-live`.
 
 ## React
 
-<ReactComponentDocs />
+```jsx
+<Alert data-color="info">Dette er en informasjonsmelding.</Alert>
+```

--- a/apps/www/app/content/components/alert/no/code.mdx
+++ b/apps/www/app/content/components/alert/no/code.mdx
@@ -1,25 +1,11 @@
-<Story story="Preview" />
-<ReactComponentDocs />
+<Story story="Preview" language="html" />
+
+
+
 
 ## Bruk
-```tsx
-import { Alert } from '@digdir/designsystemet-react';
 
-<Alert>You are using the Alert component!</Alert>;
-```
-
-## Eksempel
-
-### Endre varsel
-
-I kode endrer du typen varsel ved å endre `data-color`.
-Ikonet er styrt via CSS.
-
-<Story story="Variants" />
-
-## HTML
-
-For HTML bruker du klassenavnet `ds-alert` og attributtet `data-color` for å endre type varsel.
+Bruk klassenavnet `ds-alert` og attributtet `data-color` for å endre type varsel.
 Les over for når du skal bruke `role` og `aria-live`.
 
 [Les om `role` og `aria-live` på tilgjengeligheitssiden for `Alert`-komponenten.](/no/components/docs/alert/accessibility#alert-i-live-region)
@@ -34,3 +20,8 @@ Les over for når du skal bruke `role` og `aria-live`.
 <CssVariables />
 
 <CssAttributes />
+
+
+## React
+
+<ReactComponentDocs />

--- a/apps/www/app/content/components/alert/no/overview.mdx
+++ b/apps/www/app/content/components/alert/no/overview.mdx
@@ -2,25 +2,25 @@
 search_terms: statusmelding, varsel, advarsel, notifikasjon, systemvarsel, systemmelding, feilmelding, bekreftelse, åtvaring, varslingsmelding, notification, feedback, warning, info, confirmation, error
 ---
 
-<Story story="Preview" />
+<Story story="Preview" language="html" />
 
-**Bruk `Alert` når**
+**Bruk Alert når**
 - det er korte og informative tidsbegrensede varsler
 - det er informasjon om feil som kun påvirker én del av systemet eller en mindre funksjon
 - det oppstår tilkoblingsproblemer eller API-feil som vil løse seg med en ny innlasting av siden
 
-**Unngå `Alert` når**
+**Unngå Alert når**
 - feilen hindrer all videre bruk av tjenesten, bruk [feilside](/no/patterns/systemnotifications#når-bruker-vi-feilsider) i stedet
 - du skal gjøre brukeren oppmerksom på feil i enkeltfelt, bruk heller komponentens egen feilmelding [`ValidationMessage`](/no/components/docs/validation-message/overview)
 - varslene er statiske infobokser, bruk heller [`Card`](/no/components/docs/card/overview)
 - flere feilmeldinger skal oppsummeres, bruk heller [`ErrorSummary`](/no/components/docs/error-summary/overview)
 
-For mer helhetlige retningslinjer for bruk av varsler i tjenester, se mønsteret for [Systemvarsler](/no/patterns/systemnotifications). Der finner du eksempler og anbefalinger for når du skal bruke `Alert`, og når andre løsninger passer bedre.
+For mer helhetlige retningslinjer for bruk av varsler i tjenester, se mønsteret for [Systemvarsler](/no/patterns/systemnotifications). Der finner du eksempler og anbefalinger for når du skal bruke alert, og når andre løsninger passer bedre.
 
 
 ## Eksempel
 
-`Alert` kan brukes til fire ulike budskap: Informasjon, suksess, advarsel og feilmelding.
+Alert kan brukes til fire ulike budskap: Informasjon, suksess, advarsel og feilmelding.
 
 ### Informasjon
 
@@ -50,7 +50,7 @@ Bruk `danger` for å informere om noe som er kritisk eller som hindrer brukeren 
 
 Hvis meldingen er lenger enn en setning kan det være nyttig å bruke en overskrift til å fremheve det viktigste. 
 Dette kan gjøres med [`Heading`](/no/components/docs/heading/overview). 
-Husk å velge riktig overskriftsnivå ut fra plassen `Alert` har i innholdsstrukturen på siden.
+Husk å velge riktig overskriftsnivå ut fra plassen alert har i innholdsstrukturen på siden.
 
 <Story story="WithHeading" />
 
@@ -60,19 +60,19 @@ Dersom tittel og beskrivelse gjentar det samme er det bedre å bruke en enkel se
 
 ### Med lenke
 
-Du kan ha en lenke i `Alert` hvis det hjelper brukeren med å løse oppgaven. 
+Du kan ha en lenke i alert hvis det hjelper brukeren med å løse oppgaven. 
 Men vær obs på at en lenke tar brukeren ut av tjenesten, så bruk lenke kun når det er absolutt nødvendig, for eksempel hvis du vil at brukeren skal åpne et skjema eller utføre en viktig oppgave.
 
 <Story story="MedLenke" />
 
 ## Retningslinjer
 
-`Alert` brukes for å vise viktige meldinger som krever oppmerksomhet, men ikke nødvendigvis handling. Den kan brukes til å informere brukeren om status, endringer eller problemer i en løsning. Meldingen vises tydelig og skiller seg visuelt fra resten av innholdet.
+Alert brukes for å vise viktige meldinger som krever oppmerksomhet, men ikke nødvendigvis handling. Den kan brukes til å informere brukeren om status, endringer eller problemer i en løsning. Meldingen vises tydelig og skiller seg visuelt fra resten av innholdet.
 
 Bruk komponenten varsomt. Brukere kan forveksle varsler med reklame, og dermed overse dem. 
 Hvis vi bruker varsler for ofte, kan vi forverre dette problemet.
 
-Pass på at `Alert` har samme utseende og formspråk i alle tjenester og produkter. 
+Pass på at alert har samme utseende og formspråk i alle tjenester og produkter. 
 Denne komponenten skal være mulig å kjenne igjen overalt, så vi skal unngå å justere den.
 
 ## Tekst

--- a/apps/www/app/content/components/alert/no/overview.mdx
+++ b/apps/www/app/content/components/alert/no/overview.mdx
@@ -11,9 +11,9 @@ search_terms: statusmelding, varsel, advarsel, notifikasjon, systemvarsel, syste
 
 **Unngå Alert når**
 - feilen hindrer all videre bruk av tjenesten, bruk [feilside](/no/patterns/systemnotifications#når-bruker-vi-feilsider) i stedet
-- du skal gjøre brukeren oppmerksom på feil i enkeltfelt, bruk heller komponentens egen feilmelding [`ValidationMessage`](/no/components/docs/validation-message/overview)
-- varslene er statiske infobokser, bruk heller [`Card`](/no/components/docs/card/overview)
-- flere feilmeldinger skal oppsummeres, bruk heller [`ErrorSummary`](/no/components/docs/error-summary/overview)
+- du skal gjøre brukeren oppmerksom på feil i enkeltfelt, bruk heller komponentens egen feilmelding [validation message](/no/components/docs/validation-message/overview)
+- varslene er statiske infobokser, bruk heller [card](/no/components/docs/card/overview)
+- flere feilmeldinger skal oppsummeres, bruk heller [error summary](/no/components/docs/error-summary/overview)
 
 For mer helhetlige retningslinjer for bruk av varsler i tjenester, se mønsteret for [Systemvarsler](/no/patterns/systemnotifications). Der finner du eksempler og anbefalinger for når du skal bruke alert, og når andre løsninger passer bedre.
 
@@ -49,7 +49,7 @@ Bruk `danger` for å informere om noe som er kritisk eller som hindrer brukeren 
 ### Med og uten overskrift
 
 Hvis meldingen er lenger enn en setning kan det være nyttig å bruke en overskrift til å fremheve det viktigste. 
-Dette kan gjøres med [`Heading`](/no/components/docs/heading/overview). 
+Dette kan gjøres med [heading](/no/components/docs/heading/overview). 
 Husk å velge riktig overskriftsnivå ut fra plassen alert har i innholdsstrukturen på siden.
 
 <Story story="WithHeading" />


### PR DESCRIPTION
Should we still have the react chapter when there is nothing special to document there? 🤔 