### PR TITLE
docs: change default `<story>` language to html

### DIFF
--- a/apps/www/app/_components/mdx-components/mdx-components.tsx
+++ b/apps/www/app/_components/mdx-components/mdx-components.tsx
@@ -168,7 +168,7 @@ export const MDXComponents = ({
   );
 };
 
-const Story = ({ story, ...rest }: LiveComponentProps) => {
+const Story = ({ story, language = 'html', ...rest }: LiveComponentProps) => {
   const { stories } = useLoaderData();
   if (!stories) return null;
 
@@ -179,6 +179,7 @@ const Story = ({ story, ...rest }: LiveComponentProps) => {
   return (
     <LiveComponent
       story={`${foundStory.code}\n\nrender(<${foundStory.name} />)`}
+      language={language}
       {...rest}
     />
   );

--- a/apps/www/app/content/components/dropdown/en/code.mdx
+++ b/apps/www/app/content/components/dropdown/en/code.mdx
@@ -1,4 +1,4 @@
-<Story story="Preview" language="html"/>
+<Story story="Preview" />
 
 ## Usage
 

--- a/apps/www/app/content/components/dropdown/en/code.mdx
+++ b/apps/www/app/content/components/dropdown/en/code.mdx
@@ -57,7 +57,7 @@ When using `@digdir/designsystemet-react` we extend `@types/react-dom` to accept
 
 You must then add `popovertarget={id}` to `Dropdown`, and `id` to `Dropdown`.
 
-<Story story="WithoutTrigger" />
+<Story story="WithoutTrigger" language="react"/>
 
 ### Controlled
 
@@ -65,7 +65,7 @@ If you submit `open`, then you use `Dropdown` controlled. You can use `onClose` 
 
 Note that we do not use `onClick` on the trigger, the dropdown handles this internally and sends to `onOpen` and `onClose`.
 
-<Story story="ControlledEn" />
+<Story story="ControlledEn" language="react"/>
 
 ### Props
 

--- a/apps/www/app/content/components/dropdown/no/code.mdx
+++ b/apps/www/app/content/components/dropdown/no/code.mdx
@@ -1,4 +1,4 @@
-<Story story="Preview"  />
+<Story story="Preview" />
 
 ## Bruk
 

--- a/apps/www/app/content/components/dropdown/no/code.mdx
+++ b/apps/www/app/content/components/dropdown/no/code.mdx
@@ -1,4 +1,4 @@
-<Story story="Preview" language="html" />
+<Story story="Preview"  />
 
 ## Bruk
 

--- a/apps/www/app/content/components/dropdown/no/overview.mdx
+++ b/apps/www/app/content/components/dropdown/no/overview.mdx
@@ -2,7 +2,7 @@
 search_terms: nedtrekksmeny, rullegardinmeny, valgmeny, valmeny, veljar, popup, select, menu, listbox, popup, dropdownmenu, options
 ---
 
-<Story story="Preview"  />
+<Story story="Preview" />
 
 **Bruk dropdown når**
 - du vil tilby flere alternativer uten at de tar mye plass i grensesnittet

--- a/apps/www/app/content/components/dropdown/no/overview.mdx
+++ b/apps/www/app/content/components/dropdown/no/overview.mdx
@@ -2,7 +2,7 @@
 search_terms: nedtrekksmeny, rullegardinmeny, valgmeny, valmeny, veljar, popup, select, menu, listbox, popup, dropdownmenu, options
 ---
 
-<Story story="Preview" language="html" />
+<Story story="Preview"  />
 
 **Bruk dropdown når**
 - du vil tilby flere alternativer uten at de tar mye plass i grensesnittet

--- a/apps/www/app/content/components/table/no/code.mdx
+++ b/apps/www/app/content/components/table/no/code.mdx
@@ -82,7 +82,7 @@ Merk at vi legger på `type="button"` for å unngå at knappen oppfører seg som
 ### Klikkbar rad
 Du kan legge på `data-clickdelegatefor` på en `<tr>` for å delegere klikk-hendelser til et element i raden, for eksempel en `<a>`-tag.
 
-<Story story="HTMLClickableRows" language="html" />
+<Story story="HTMLClickableRows"  />
 
 
 ## CSS variabler og data-attributter

--- a/apps/www/app/content/components/table/no/code.mdx
+++ b/apps/www/app/content/components/table/no/code.mdx
@@ -82,7 +82,7 @@ Merk at vi legger på `type="button"` for å unngå at knappen oppfører seg som
 ### Klikkbar rad
 Du kan legge på `data-clickdelegatefor` på en `<tr>` for å delegere klikk-hendelser til et element i raden, for eksempel en `<a>`-tag.
 
-<Story story="HTMLClickableRows"  />
+<Story story="HTMLClickableRows" />
 
 
 ## CSS variabler og data-attributter


### PR DESCRIPTION
Now that we are going web-first it makes sense that the default language for `<story>` is `html`.
This will also help us reduce having to set `langauge='html'` on overview and a11y pages.