### PR TITLE
feat(www): add rss and atom feeds to blog

### DIFF
--- a/apps/www/app/layouts/blog/layout.tsx
+++ b/apps/www/app/layouts/blog/layout.tsx
@@ -1,12 +1,15 @@
-import { Heading, Paragraph } from '@digdir/designsystemet-react';
-import { useTranslation } from 'react-i18next';
+import { Heading, Link, Paragraph } from '@digdir/designsystemet-react';
+import { Trans, useTranslation } from 'react-i18next';
 import { Outlet } from 'react-router';
 import classes from './layout.module.css';
 
 export { ErrorBoundary } from '~/root';
 
 export default function Layout() {
-  const { t } = useTranslation();
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation();
 
   return (
     <div className='l-content-container' id='main'>
@@ -14,7 +17,12 @@ export default function Layout() {
         <Heading data-size='lg' level={1}>
           {t('blog.title')}
         </Heading>
-        <Paragraph data-size='lg'>{t('blog.description')}</Paragraph>
+        <Paragraph data-size='lg'>
+          <Trans t={t} i18nKey={'blog.description'}>
+            <Link href={`/${language}/blog/feed.rss`}>RSS</Link>
+            <Link href={`/${language}/blog/feed.atom`}>Atom</Link>
+          </Trans>
+        </Paragraph>
       </div>
       <div className={classes.main}>
         <Outlet />

--- a/apps/www/app/locales/en.ts
+++ b/apps/www/app/locales/en.ts
@@ -70,7 +70,7 @@ export default {
     tag: 'Blog',
     title: 'Blog',
     description:
-      'Here you will find stories, experiences, and updates from Designsystemet. A place to learn from each other and stay up to date.',
+      'Here you will find stories, experiences, and updates from Designsystemet. A place to learn from each other and stay up to date. You can subscribe to this blog through <0>RSS</0> or <1>Atom</1>',
     write: {
       title: 'Want to write for the blog?',
       description:

--- a/apps/www/app/locales/no.ts
+++ b/apps/www/app/locales/no.ts
@@ -69,7 +69,7 @@ export default {
     tag: 'Bloggen',
     title: 'Bloggen',
     description:
-      'Her finner du historier, erfaringer og oppdateringer fra designsystemet. Et sted for å lære av hverandre og holde deg oppdatert.',
+      'Her finner du historier, erfaringer og oppdateringer fra designsystemet. Et sted for å lære av hverandre og holde deg oppdatert. Du kan abonnere på bloggen gjennom <0>RSS</0> eller <1>Atom</1>',
     write: {
       title: 'Vil du skrive for bloggen?',
       description:


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

Adds RSS and Atom links on the blog page

Centered to be symmetrical with the heading and paragraph
Using buttons because simple links looked a bit weird and "empty" or "naked"
Lastly, hardcoded text. "RSS" and "Atom" is the same across languages as far as I'm aware

If anyone got tips for design let me know /shrug

closes: #4530

<img width="2557" height="8010" alt="image" src="https://github.com/user-attachments/assets/ee1458db-f8b2-4e6b-a04e-f7a6d9e4ce27" />


## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
