### PR TITLE
fix(www): various links should point to the same language the page is written in

### DIFF
--- a/apps/www/app/content/blog/en/cba.mdx
+++ b/apps/www/app/content/blog/en/cba.mdx
@@ -25,7 +25,7 @@ The Cost-Benefit Analysis is based on a **conservative assumption of a 25 per ce
 
 
 <Card data-color='success' variant="tinted" asChild>
-    <Link href='/no/intro/gains' style={{
+    <Link href='/en/intro/gains' style={{
       display: "flex",
       alignItems: "center",
       gap: "0.75rem",
@@ -68,6 +68,7 @@ The full Cost–Benefit Analysis (CBA), including methodology, figures and asses
     <span data-size='lg' data-color='success'>
       Cost–Benefit Analysis (CBA):  
       Designsystemet as a shared solution
+      (norwegian only)
     </span>
   </Link>
 </Card>

--- a/apps/www/app/content/components/alert/en/overview.mdx
+++ b/apps/www/app/content/components/alert/en/overview.mdx
@@ -99,4 +99,4 @@ Here is a list of the types of information that a notification should contain:
 - Help them fix the problem themselves
     - Example: "Please try again."
 
-For more guidance on how to write clear and effective alert text, see the language recommendations in the [System notifications pattern](/no/patterns/systemnotifications#språk).
+For more guidance on how to write clear and effective alert text, see the language recommendations in the [System notifications pattern](/en/patterns/systemnotifications#language).

--- a/apps/www/app/content/components/card/card.stories.tsx
+++ b/apps/www/app/content/components/card/card.stories.tsx
@@ -323,7 +323,7 @@ export const AsGridImageEn = () => {
       <Card.Block>
         <Heading>
           <Link
-            href='/no/blog/why-we-need-a-common-design-system'
+            href='/en/blog/why-we-need-a-common-design-system'
             target='_blank'
             rel='noopener noreferrer'
           >

--- a/apps/www/app/content/components/dropdown/no/code.mdx
+++ b/apps/www/app/content/components/dropdown/no/code.mdx
@@ -2,7 +2,7 @@
 
 ## Bruk
 
-Dropdown er bygget på vår [popover-komponent](/no/components/docs/popover), og bruker [native popover-api (mozilla.org)](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover/code) i HTML.
+Dropdown er bygget på vår [popover-komponent](/no/components/docs/popover/overview), og bruker [native popover-api (mozilla.org)](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover/code) i HTML.
 
 Merk deg at elementet med `popover="manual"` bruker to klasser, `ds-popover` og `ds-dropdown`.
 Du velger selv om du vil bruke `popover="manual"` eller bare `popover` for å åpne dropdownen.

--- a/apps/www/app/content/components/link/link.dodont.tsx
+++ b/apps/www/app/content/components/link/link.dodont.tsx
@@ -51,7 +51,7 @@ export const DontIcon2 = () => {
 
 export const DoIcon2En = () => {
   return (
-    <Link href='/no/patterns/external-links/'>
+    <Link href='/en/patterns/external-links/'>
       <span>Labelling links</span>
     </Link>
   );
@@ -59,7 +59,7 @@ export const DoIcon2En = () => {
 
 export const DontIcon2En = () => {
   return (
-    <Link href='/no/patterns/external-links/'>
+    <Link href='/en/patterns/external-links/'>
       <span>Read more</span>
     </Link>
   );

--- a/apps/www/app/content/components/radio/no/overview.mdx
+++ b/apps/www/app/content/components/radio/no/overview.mdx
@@ -8,7 +8,7 @@ search_terms: radioknapp, radiovalg, radiobutton, enkeltvalg, valg, alternativ, 
 - brukeren skal velge ett av flere alternativer i skjemaer
 
 **Unngå `Radio` når**
-- brukeren skal kunne velge flere alternativer, bruk heller [`Checkbox`](/en/components/docs/checkbox/overview)
+- brukeren skal kunne velge flere alternativer, bruk heller [`Checkbox`](/no/components/docs/checkbox/overview)
 
 ## Eksempel
 
@@ -27,7 +27,7 @@ Hvis brukeren prøver å gå videre uten å svare på et obligatorisk spørsmål
 <Story story="WithError" />
 
 ## Retningslinjer
-Vi bruker `Radio` når vi skal gi brukerne mulighet til å velge kun ett alternativ. Skal de kunne velge flere, bruker du [`Checkbox`](/en/components/docs/checkbox/overview).
+Vi bruker `Radio` når vi skal gi brukerne mulighet til å velge kun ett alternativ. Skal de kunne velge flere, bruker du [`Checkbox`](/no/components/docs/checkbox/overview).
 
 Vi bør ikke ha mer enn syv alternativer i en gruppe. Trenger vi å gi brukerne flere valg, bør vi heller bruke [`Suggestion`](/no/components/docs/suggestion/overview) eller [`Select`](/no/components/docs/select/overview). Hvis vi bare skal gi brukerne ett valg, kan en [`Switch`](/no/components/docs/switch/overview) eller [`Checkbox`](/no/components/docs/checkbox/overview) passe bedre.
 

--- a/apps/www/app/content/fundamentals/en/code/setup.mdx
+++ b/apps/www/app/content/fundamentals/en/code/setup.mdx
@@ -68,7 +68,7 @@ import { Button } from '@digdir/designsystemet-react';
 
 Import `@digdir/designsystemet-css`.
 
-Read more about [CSS](/no/fundamentals/code/css).
+Read more about [CSS](/en/fundamentals/code/css).
 
 <ds-tabs class="ds-tabs" data-wide-content>
   <ds-tablist>
@@ -102,7 +102,7 @@ This can be easily overridden in your own theme or in your global CSS file.
 
 The Designsystemet is designed to be themable, so it is important to import your theme after importing `@digdir/designsystemet-css`.
 
-[Build your own theme](/no/fundamentals/start-here/own-theme) or use the default theme; `@digdir/designsystemet-css/theme`.
+[Build your own theme](/en/fundamentals/start-here/own-theme) or use the default theme; `@digdir/designsystemet-css/theme`.
 
 
 <ds-tabs class="ds-tabs" data-wide-content>
@@ -130,7 +130,7 @@ The Designsystemet is designed to be themable, so it is important to import your
 You are now ready to use the Designsystemet in code! 
 
 
-All components have their own page in the [component documentation](/no/components), we recommend that you read through these to see how you can use the components.
+All components have their own page in the [component documentation](/en/components), we recommend that you read through these to see how you can use the components.
 
 It is also recommended that you read through the accessibility page.
 

--- a/apps/www/app/content/fundamentals/en/theme/multiple-themes.mdx
+++ b/apps/www/app/content/fundamentals/en/theme/multiple-themes.mdx
@@ -10,10 +10,10 @@ published: true
 order: 10
 ---
 
-It is possible to have multiple themes in the same project if you use [config file](/no/fundamentals/code/cli-config).
+It is possible to have multiple themes in the same project if you use [config file](/en/fundamentals/code/cli-config).
 Below we will go through two ways to do it.
 
-**This page assumes that you have read "[Build your theme](/no/fundamentals/start-here/own-theme)".**
+**This page assumes that you have read "[Build your theme](/en/fundamentals/start-here/own-theme)".**
 
 ## Same color names
 If you have two themes that will be switched between in the same interface, you'll likely use the same color names in both themes.

--- a/apps/www/app/content/fundamentals/no/theme/typography.mdx
+++ b/apps/www/app/content/fundamentals/no/theme/typography.mdx
@@ -11,7 +11,7 @@ order: 40
 search_terms: tekst, headings, fonts, typography
 ---
 
-For å presentere tekst på korrekt måte er det laget stiler som har ulike kombinasjoner av størrelse, fontvekt og linjehøyde. Det er også laget et sett med typografi-komponenter som innkapsler disse stilene, slik at de enkelt kan brukes i ulike sammenhenger. Beskrivelse av hvordan typografi-komponenter brukes finner du i komponentartikkelen [Typography](/en/components/docs/heading/overview).
+For å presentere tekst på korrekt måte er det laget stiler som har ulike kombinasjoner av størrelse, fontvekt og linjehøyde. Det er også laget et sett med typografi-komponenter som innkapsler disse stilene, slik at de enkelt kan brukes i ulike sammenhenger. Beskrivelse av hvordan typografi-komponenter brukes finner du i komponentartikkelen [Typography](/no/components/docs/heading/overview).
 
 ## Font-family
 

--- a/apps/www/app/content/intro/en/about-the-design-system.mdx
+++ b/apps/www/app/content/intro/en/about-the-design-system.mdx
@@ -92,7 +92,7 @@ Designsystemet consists of multiple building blocks and tools. You can use what 
   Design Tokens are variables for colors, typography, spacing, sizes, and shapes. They are theme-based, meaning they reflect your brand via the preferences you set in the [Theme Builder](/en/fundamentals/start-here/own-theme). The color system ensures text and background always have sufficient contrast—no matter your brand colors. Token structure supports multiple themes and modes (light, dark, contrast, etc.). Tokens keep design and code in sync—this is where the magic happens.
 
 - **UI components**  
-  Designsystemet offers essential components worth sharing across services. They are available in [Figma](https://www.figma.com/@designsystemet), [CSS](/en/fundamentals/code/css), [React](/en/fundamentals/code/react), and can also be used together with [other frameworks](/no/fundamentals/code/other-frameworks). Usage guidelines are included and continuously updated as we learn more.
+  Designsystemet offers essential components worth sharing across services. They are available in [Figma](https://www.figma.com/@designsystemet), [CSS](/en/fundamentals/code/css), [React](/en/fundamentals/code/react), and can also be used together with [other frameworks](/en/fundamentals/code/other-frameworks). Usage guidelines are included and continuously updated as we learn more.
 
 - **Theme Builder**  
   The [Theme Builder](https://theme.designsystemet.no/en) helps you customize Designsystemet to match your organization’s brand. After configuration, you copy a code snippet and paste it into your terminal. In just minutes, all components reflect your brand colors.

--- a/apps/www/app/content/patterns/en/button-placement-and-order.mdx
+++ b/apps/www/app/content/patterns/en/button-placement-and-order.mdx
@@ -154,7 +154,7 @@ If “Next” is placed to the right of “Previous”, it may be tempting to ch
 
 ## Relevant sources
 * [1] [Simplicity Wins over Abundance of Choice (baymard.com)](https://baymard.com/learn/button-design)
-* [2] [Understanding vision impairment](https://designsystemet.no/no/best-practices/accessibility/understanding-vision-impairment)
+* [2] [Understanding vision impairment](/en/best-practices/accessibility/understanding-vision-impairment)
 * [3] [Disabled states (nav.no)](https://aksel.nav.no/god-praksis/artikler/deaktiverte-tilstander)
 * [4] [Proximity Principle in Visual Design (nngroup.com)](https://www.nngroup.com/articles/gestalt-proximity/)
 * [5] [Understanding SC 2.4.3: Focus Order (w3.org)](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html)

--- a/apps/www/public/robots.txt
+++ b/apps/www/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=no
 Disallow: /
 Sitemap: https://designsystemet.no/sitemap.xml


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

Links on english pages should point to english pages, and links on norwegian pages should point to norwegian pages
Otherwise it gets disorienting quickly when navigating the page
(even if you can read both languages >.<)

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
