### PR TITLE
chore: enable `blockExoticSubdeps`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,3 +32,4 @@ syncInjectedDepsAfterScripts:
   - build:themebuilder
   - build:storybook
 useNodeVersion: 24.15.0
+blockExoticSubdeps: true


### PR DESCRIPTION
Read about this the other day to block use of git and https in sub dependencies.

See no reason as to why we should not enable it.

https://pnpm.io/settings#blockexoticsubdeps