### PR TITLE
ci(docker): use configured pnpm version in CMD steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN corepack enable
 FROM base AS packages
 COPY . /usr/src/app
 WORKDIR /usr/src/app
+RUN corepack install
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm build
 
@@ -22,7 +23,7 @@ ENV PORT=$PORT HOST=$HOST APP_ENV=$APP_ENV
 RUN pnpm build:www
 RUN pnpm deploy --filter=@web/www --prod /prod/@web/www
 
-FROM base AS www
+FROM packages AS www
 COPY --from=www-build /prod/@web/www /srv/app
 WORKDIR /srv/app
 ENV NODE_ENV=production HOST=0.0.0.0 PORT=8000
@@ -38,7 +39,7 @@ ENV PORT=$PORT HOST=$HOST APP_ENV=$APP_ENV
 RUN pnpm build:themebuilder
 RUN pnpm deploy --filter=@web/themebuilder --prod /prod/@web/themebuilder
 
-FROM base AS themebuilder
+FROM packages AS themebuilder
 COPY --from=themebuilder-build /prod/@web/themebuilder /srv/app
 WORKDIR /srv/app
 ENV NODE_ENV=production HOST=0.0.0.0 PORT=8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,12 @@ ARG APP_ENV
 FROM node:24.14.1-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
-
-FROM base AS packages
 COPY . /usr/src/app
 WORKDIR /usr/src/app
+RUN corepack enable
 RUN corepack install
+
+FROM base AS packages
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm build
 
@@ -23,7 +23,7 @@ ENV PORT=$PORT HOST=$HOST APP_ENV=$APP_ENV
 RUN pnpm build:www
 RUN pnpm deploy --filter=@web/www --prod /prod/@web/www
 
-FROM packages AS www
+FROM base AS www
 COPY --from=www-build /prod/@web/www /srv/app
 WORKDIR /srv/app
 ENV NODE_ENV=production HOST=0.0.0.0 PORT=8000
@@ -39,7 +39,7 @@ ENV PORT=$PORT HOST=$HOST APP_ENV=$APP_ENV
 RUN pnpm build:themebuilder
 RUN pnpm deploy --filter=@web/themebuilder --prod /prod/@web/themebuilder
 
-FROM packages AS themebuilder
+FROM base AS themebuilder
 COPY --from=themebuilder-build /prod/@web/themebuilder /srv/app
 WORKDIR /srv/app
 ENV NODE_ENV=production HOST=0.0.0.0 PORT=8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,13 @@ ARG APP_ENV
 FROM node:24.14.1-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-COPY  ./package.json /usr/src/app
-COPY  ./pnpm-lock.yaml /usr/src/app
-COPY  ./pnpm-workspace.yaml /usr/src/app
 ENV CI=true
+COPY . /usr/src/app
+WORKDIR /usr/src/app
 RUN corepack enable
 RUN corepack install
 
 FROM base AS packages
-COPY . /usr/src/app
 WORKDIR /usr/src/app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm build

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN corepack enable
 RUN corepack install
 
 FROM base AS packages
+WORKDIR /usr/src/app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,10 @@ ARG APP_ENV
 FROM node:24.14.1-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-ENV CI=true
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN corepack enable
-RUN corepack install
 
 FROM base AS packages
 COPY . /usr/src/app
-WORKDIR /usr/src/app
 WORKDIR /usr/src/app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm build

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,13 @@ FROM node:24.14.1-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV CI=true
-COPY . /usr/src/app
-WORKDIR /usr/src/app
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN corepack enable
 RUN corepack install
 
 FROM base AS packages
+COPY . /usr/src/app
+WORKDIR /usr/src/app
 WORKDIR /usr/src/app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm build
@@ -26,7 +27,6 @@ RUN pnpm build:www
 RUN pnpm deploy --filter=@web/www --prod /prod/@web/www
 
 FROM base AS www
-
 COPY --from=www-build /prod/@web/www /srv/app
 WORKDIR /srv/app
 ENV NODE_ENV=production HOST=0.0.0.0 PORT=8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ ARG APP_ENV
 FROM node:24.14.1-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+ENV CI=true
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN corepack enable
+RUN corepack install
 
 FROM base AS packages
 COPY . /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,15 @@ ARG APP_ENV
 FROM node:24.14.1-slim@sha256:b506e7321f176aae77317f99d67a24b272c1f09f1d10f1761f2773447d8da26c AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-COPY . /usr/src/app
-WORKDIR /usr/src/app
+COPY  ./package.json /usr/src/app
+COPY  ./pnpm-lock.yaml /usr/src/app
+COPY  ./pnpm-workspace.yaml /usr/src/app
 ENV CI=true
 RUN corepack enable
-RUN corepack install -g pnpm@10.33.2
+RUN corepack install
 
 FROM base AS packages
+COPY . /usr/src/app
 WORKDIR /usr/src/app
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 RUN pnpm build
@@ -26,6 +28,7 @@ RUN pnpm build:www
 RUN pnpm deploy --filter=@web/www --prod /prod/@web/www
 
 FROM base AS www
+
 COPY --from=www-build /prod/@web/www /srv/app
 WORKDIR /srv/app
 ENV NODE_ENV=production HOST=0.0.0.0 PORT=8000


### PR DESCRIPTION
Looks like its correctly installing the pnpm version in `base` from defined `package.json` so that its correctly available in `themebuilder` and `www` steps. 🤷‍♂️ 

Included the other pnpm configs incase they are needed in the other steps based on `base`.

<img width="957" height="164" alt="image" src="https://github.com/user-attachments/assets/9fec4469-da1f-4b10-947a-22264a75ac63" />
