### PR TITLE
fix: allow passing `variant` prop to all checkboxes / radios through use...Group hook

### DIFF
--- a/.changeset/fuzzy-zoos-rhyme.md
+++ b/.changeset/fuzzy-zoos-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**useCheckboxGroup** and **useRadioGroup**: these hooks now accept all `CheckboxProps` / `RadioProps` that don't conflict with the hooks' own props. This can be used to easily set common props like `variant` for all the checkboxes or radios in the group.

--- a/.changeset/fuzzy-zoos-rhyme.md
+++ b/.changeset/fuzzy-zoos-rhyme.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet-react": patch
 ---
 
-**useCheckboxGroup** and **useRadioGroup**: these hooks now accept all `CheckboxProps` / `RadioProps` that don't conflict with the hooks' own props. This can be used to easily set common props like `variant` for all the checkboxes or radios in the group.
+**useCheckboxGroup** and **useRadioGroup**: these hooks now also accept the prop `variant`, which sets the variant for all the checkboxes or radios in the group.

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ next-env.d.ts
 # jest/vitest test reports
 test-report.xml
 __screenshots__
+.vitest-attachments
 
 packages/cli/temp
 

--- a/apps/www/app/content/components/checkbox/checkbox.stories.tsx
+++ b/apps/www/app/content/components/checkbox/checkbox.stories.tsx
@@ -25,7 +25,9 @@ export const OneOption = () => (
 );
 
 export const Group = () => {
-  const [value, setValue] = useState<string[]>(['epost']);
+  const { getCheckboxProps } = useCheckboxGroup({
+    value: ['epost'],
+  });
 
   return (
     <Fieldset>
@@ -35,48 +37,17 @@ export const Group = () => {
       <Fieldset.Description>
         Velg alle alternativene som er relevante for deg.
       </Fieldset.Description>
-      <Checkbox
-        label='E-post'
-        value='epost'
-        checked={value.includes('epost')}
-        onChange={(e) => {
-          if (e.target.checked) {
-            setValue([...value, 'epost']);
-          } else {
-            setValue(value.filter((v) => v !== 'epost'));
-          }
-        }}
-      />
-      <Checkbox
-        label='Telefon'
-        value='telefon'
-        checked={value.includes('telefon')}
-        onChange={(e) => {
-          if (e.target.checked) {
-            setValue([...value, 'telefon']);
-          } else {
-            setValue(value.filter((v) => v !== 'telefon'));
-          }
-        }}
-      />
-      <Checkbox
-        label='SMS'
-        value='sms'
-        checked={value.includes('sms')}
-        onChange={(e) => {
-          if (e.target.checked) {
-            setValue([...value, 'sms']);
-          } else {
-            setValue(value.filter((v) => v !== 'sms'));
-          }
-        }}
-      />
+      <Checkbox label='E-post' {...getCheckboxProps('epost')} />
+      <Checkbox label='Telefon' {...getCheckboxProps('telefon')} />
+      <Checkbox label='SMS' {...getCheckboxProps('sms')} />
     </Fieldset>
   );
 };
 
 export const GroupEn = () => {
-  const [value, setValue] = useState<string[]>(['epost']);
+  const { getCheckboxProps } = useCheckboxGroup({
+    value: ['email'],
+  });
 
   return (
     <Fieldset>
@@ -84,42 +55,9 @@ export const GroupEn = () => {
       <Fieldset.Description>
         Select all the options that are relevant to you.
       </Fieldset.Description>
-      <Checkbox
-        label='E-mail'
-        value='email'
-        checked={value.includes('email')}
-        onChange={(e) => {
-          if (e.target.checked) {
-            setValue([...value, 'email']);
-          } else {
-            setValue(value.filter((v) => v !== 'email'));
-          }
-        }}
-      />
-      <Checkbox
-        label='Phone'
-        value='phone'
-        checked={value.includes('phone')}
-        onChange={(e) => {
-          if (e.target.checked) {
-            setValue([...value, 'phone']);
-          } else {
-            setValue(value.filter((v) => v !== 'phone'));
-          }
-        }}
-      />
-      <Checkbox
-        label='Text message'
-        value='text'
-        checked={value.includes('text')}
-        onChange={(e) => {
-          if (e.target.checked) {
-            setValue([...value, 'text']);
-          } else {
-            setValue(value.filter((v) => v !== 'text'));
-          }
-        }}
-      />
+      <Checkbox label='E-mail' {...getCheckboxProps('email')} />
+      <Checkbox label='Phone' {...getCheckboxProps('phone')} />
+      <Checkbox label='Text message' {...getCheckboxProps('text')} />
     </Fieldset>
   );
 };
@@ -351,7 +289,10 @@ export const InTableEn = () => {
 };
 
 export const Outline = () => {
-  const [value, setValue] = useState<string[]>(['drift']);
+  const { getCheckboxProps } = useCheckboxGroup({
+    value: ['drift'],
+    variant: 'outline',
+  });
 
   return (
     <Fieldset>
@@ -361,38 +302,23 @@ export const Outline = () => {
       </Fieldset.Description>
       <Checkbox
         label='Driftsmeldinger'
-        value='drift'
         description='Varsler ved planlagt vedlikehold og driftsavvik.'
-        variant='outline'
-        checked={value.includes('drift')}
-        onChange={(e) => {
-          if (e.target.checked) {
-            setValue([...value, 'drift']);
-          } else {
-            setValue(value.filter((v) => v !== 'drift'));
-          }
-        }}
+        {...getCheckboxProps('drift')}
       />
       <Checkbox
         label='Påminnelser'
-        value='paminnelse'
         description='Varsler om frister og oppgaver som krever handling.'
-        variant='outline'
-        checked={value.includes('paminnelse')}
-        onChange={(e) => {
-          if (e.target.checked) {
-            setValue([...value, 'påminnelse']);
-          } else {
-            setValue(value.filter((v) => v !== 'påminnelse'));
-          }
-        }}
+        {...getCheckboxProps('paminnelse')}
       />
     </Fieldset>
   );
 };
 
 export const OutlineEn = () => {
-  const [value, setValue] = useState<string[]>(['operations']);
+  const { getCheckboxProps } = useCheckboxGroup({
+    value: ['operations'],
+    variant: 'outline',
+  });
 
   return (
     <Fieldset>
@@ -404,31 +330,13 @@ export const OutlineEn = () => {
       </Fieldset.Description>
       <Checkbox
         label='Service updates'
-        value='operations'
         description='Alerts about planned maintenance and service disruptions.'
-        variant='outline'
-        checked={value.includes('operations')}
-        onChange={(e) => {
-          if (e.target.checked) {
-            setValue([...value, 'operations']);
-          } else {
-            setValue(value.filter((v) => v !== 'operations'));
-          }
-        }}
+        {...getCheckboxProps('operations')}
       />
       <Checkbox
         label='Reminders'
-        value='reminders'
         description='Alerts about deadlines and tasks that need your attention.'
-        variant='outline'
-        checked={value.includes('reminders')}
-        onChange={(e) => {
-          if (e.target.checked) {
-            setValue([...value, 'reminders']);
-          } else {
-            setValue(value.filter((v) => v !== 'reminders'));
-          }
-        }}
+        {...getCheckboxProps('reminders')}
       />
     </Fieldset>
   );

--- a/apps/www/app/content/components/radio/radio.stories.tsx
+++ b/apps/www/app/content/components/radio/radio.stories.tsx
@@ -1,6 +1,7 @@
 import {
   Fieldset,
   Radio,
+  useRadioGroup,
   ValidationMessage,
 } from '@digdir/designsystemet-react';
 
@@ -9,6 +10,11 @@ export const Preview = () => {
 };
 
 export const Group = () => {
+  const { getRadioProps } = useRadioGroup({
+    name: 'kontakt',
+    value: 'epost',
+  });
+
   return (
     <Fieldset>
       <Fieldset.Legend>Hvordan ønsker du at vi kontakter deg?</Fieldset.Legend>
@@ -19,26 +25,28 @@ export const Group = () => {
       <Radio
         label='E-post'
         description='Vi bruker e-postadressen du har oppgitt tidligere (navn@epost.no)'
-        value='epost'
-        name='kontakt'
+        {...getRadioProps('epost')}
       />
       <Radio
         label='SMS'
         description='Vi bruker telefonnummeret du har oppgitt tidligere (99 99 99 99)'
-        value='sms'
-        name='kontakt'
+        {...getRadioProps('sms')}
       />
       <Radio
         label='Brev'
         description='Levering kan ta 3-5 virkedager, avhengig av posttjenesten.'
-        value='brev'
-        name='kontakt'
+        {...getRadioProps('brev')}
       />
     </Fieldset>
   );
 };
 
 export const GroupEn = () => {
+  const { getRadioProps } = useRadioGroup({
+    name: 'contact',
+    value: 'email',
+  });
+
   return (
     <Fieldset>
       <Fieldset.Legend>How would you like us to contact you?</Fieldset.Legend>
@@ -49,20 +57,17 @@ export const GroupEn = () => {
       <Radio
         label='Email'
         description='We will use the email address you provided earlier (name@example.com)'
-        value='email'
-        name='contact'
+        {...getRadioProps('email')}
       />
       <Radio
         label='SMS'
         description='We will use the phone number you provided earlier (99 99 99 99)'
-        value='sms'
-        name='contact'
+        {...getRadioProps('sms')}
       />
       <Radio
         label='Letter'
         description='Delivery may take 3-5 working days, depending on the postal service.'
-        value='letter'
-        name='contact'
+        {...getRadioProps('letter')}
       />
     </Fieldset>
   );
@@ -159,6 +164,11 @@ export const InlineEn = () => {
 };
 
 export const Outline = () => {
+  const { getRadioProps } = useRadioGroup({
+    name: 'course-level',
+    variant: 'outline',
+  });
+
   return (
     <Fieldset>
       <Fieldset.Legend>Hvilket kursnivå passer deg best?</Fieldset.Legend>
@@ -166,31 +176,30 @@ export const Outline = () => {
         Velg nivået som beskriver din erfaring med temaet.
       </Fieldset.Description>
       <Radio
-        variant='outline'
         label='Nybegynner'
         description='Passer for deg som er helt ny og ønsker en rolig introduksjon.'
-        value='beginner'
-        name='course-level'
+        {...getRadioProps('beginner')}
       />
       <Radio
-        variant='outline'
         label='Viderekommen'
         description='Passer for deg som kjenner grunnleggende begreper og vil gå dypere.'
-        value='intermediate'
-        name='course-level'
+        {...getRadioProps('intermediate')}
       />
       <Radio
         label='Ekspert'
-        variant='outline'
         description='Passer for deg som ønsker avanserte temaer og praktiske case.'
-        value='expert'
-        name='course-level'
+        {...getRadioProps('expert')}
       />
     </Fieldset>
   );
 };
 
 export const OutlineEn = () => {
+  const { getRadioProps } = useRadioGroup({
+    name: 'course-level',
+    variant: 'outline',
+  });
+
   return (
     <Fieldset>
       <Fieldset.Legend>Which course level fits you best?</Fieldset.Legend>
@@ -198,25 +207,19 @@ export const OutlineEn = () => {
         Choose the level that best describes your experience with the topic.
       </Fieldset.Description>
       <Radio
-        variant='outline'
         label='Beginner'
         description='Best for you if you are completely new and want a gentle introduction.'
-        value='beginner'
-        name='course-level'
+        {...getRadioProps('beginner')}
       />
       <Radio
-        variant='outline'
         label='Intermediate'
         description='Best for you if you know the basics and want to go deeper.'
-        value='intermediate'
-        name='course-level'
+        {...getRadioProps('intermediate')}
       />
       <Radio
-        variant='outline'
         label='Expert'
         description='Best for you if you want advanced topics and hands-on cases.'
-        value='expert'
-        name='course-level'
+        {...getRadioProps('expert')}
       />
     </Fieldset>
   );

--- a/packages/react/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/checkbox.stories.tsx
@@ -177,7 +177,7 @@ export const ReadOnly = {
 
 export const Disabled = {
   args: {
-    ...Preview.args,
+    ...Group.args,
     name: 'my-disabled',
     disabled: true,
   },

--- a/packages/react/src/utilities/hooks/use-checkbox-group/use-checkbox-group.test.tsx
+++ b/packages/react/src/utilities/hooks/use-checkbox-group/use-checkbox-group.test.tsx
@@ -127,6 +127,20 @@ describe('CheckboxGroup', () => {
     expect(checkbox2).toHaveAttribute('aria-invalid', 'true');
     expect(error).toBeVisible();
   });
+  test('has passed variant to Checkbox children', () => {
+    render(<CheckboxGroup variant='outline' />);
+    const labels = ['Test 1', 'Test 2'];
+    const checkboxes = labels.map((label) => screen.getByLabelText(label));
+    const fields = checkboxes
+      .map((checkbox) => checkbox.parentElement)
+      .filter((x) => x !== null);
+
+    expect(fields).toHaveLength(labels.length);
+    for (const field of fields) {
+      expect(field.nodeName).toBe('DS-FIELD');
+      expect(field).toHaveAttribute('data-variant', 'outline');
+    }
+  });
   test('has correct Checkbox checked when value is used', () => {
     render(<CheckboxGroup value={['test1']} />);
 

--- a/packages/react/src/utilities/hooks/use-checkbox-group/use-checkbox-group.ts
+++ b/packages/react/src/utilities/hooks/use-checkbox-group/use-checkbox-group.ts
@@ -7,49 +7,49 @@ import type {
 } from 'react';
 import { useEffect, useId, useRef, useState } from 'react';
 import type { CheckboxProps } from '../../../components';
-import type { MergeRight } from '../../types';
 
-export type UseCheckboxGroupProps = MergeRight<
-  CheckboxProps,
-  {
-    /**
-     * Disables all checkboxes in the group.
-     */
-    disabled?: boolean;
-    /**
-     * Error message for the group.
-     * If set, all checkboxes will have `aria-invalid` set to `true`.
-     */
-    error?: ReactNode;
-    /**
-     * Name of the group.
-     * If not set, a random id will be generated.
-     */
-    name?: string;
-    /**
-     * Makes all checkboxes in the group read-only.
-     * If set, all checkboxes will have `aria-readonly` set to `true`.
-     */
-    readOnly?: boolean;
-    /**
-     * Initial value of the group
-     * @default []
-     */
-    value?: string[];
-    /**
-     * Makes all checkboxes in the group required.
-     * If set, all checkboxes will have `required` set to `true`.
-     */
-    required?: boolean;
-    /**
-     * Callback that is called when the value of the group changes.
-     * @param nextValue string[]
-     * @param currentValue string[]
-     * @returns void
-     */
-    onChange?: (nextValue: string[], currentValue: string[]) => void;
-  }
->;
+export type UseCheckboxGroupProps = {
+  /**
+   * Disables all checkboxes in the group.
+   */
+  disabled?: boolean;
+  /**
+   * Error message for the group.
+   * If set, all checkboxes will have `aria-invalid` set to `true`.
+   */
+  error?: ReactNode;
+  /**
+   * Name of the group.
+   * If not set, a random id will be generated.
+   */
+  name?: string;
+  /**
+   * Makes all checkboxes in the group read-only.
+   * If set, all checkboxes will have `aria-readonly` set to `true`.
+   */
+  readOnly?: boolean;
+  /**
+   * Initial value of the group
+   * @default []
+   */
+  value?: string[];
+  /**
+   * Makes all checkboxes in the group required.
+   * If set, all checkboxes will have `required` set to `true`.
+   */
+  required?: boolean;
+  /**
+   * Callback that is called when the value of the group changes.
+   * @param nextValue string[]
+   * @param currentValue string[]
+   * @returns void
+   */
+  onChange?: (nextValue: string[], currentValue: string[]) => void;
+  /**
+   * If outline, all checkboxes in the group will have a border
+   */
+  variant?: CheckboxProps['variant'];
+};
 
 /**
  * Get anything that is set on a checkbox, but
@@ -156,7 +156,7 @@ export function useCheckboxGroup(
      */
     getCheckboxProps: (propsOrValue?: string | GetCheckboxProps) => {
       let groupProps:
-        | Omit<CheckboxProps, 'aria-label' | 'aria-labelledby'>
+        | Omit<UseCheckboxGroupProps, 'onChange' | 'error'>
         | undefined;
       if (props) {
         const { onChange, error, ...rest } = props;

--- a/packages/react/src/utilities/hooks/use-checkbox-group/use-checkbox-group.ts
+++ b/packages/react/src/utilities/hooks/use-checkbox-group/use-checkbox-group.ts
@@ -7,45 +7,49 @@ import type {
 } from 'react';
 import { useEffect, useId, useRef, useState } from 'react';
 import type { CheckboxProps } from '../../../components';
+import type { MergeRight } from '../../types';
 
-export type UseCheckboxGroupProps = {
-  /**
-   * Disables all checkboxes in the group.
-   */
-  disabled?: boolean;
-  /**
-   * Error message for the group.
-   * If set, all checkboxes will have `aria-invalid` set to `true`.
-   */
-  error?: ReactNode;
-  /**
-   * Name of the group.
-   * If not set, a random id will be generated.
-   */
-  name?: string;
-  /**
-   * Makes all checkboxes in the group read-only.
-   * If set, all checkboxes will have `aria-readonly` set to `true`.
-   */
-  readOnly?: boolean;
-  /**
-   * Initial value of the group
-   * @default []
-   */
-  value?: string[];
-  /**
-   * Makes all checkboxes in the group required.
-   * If set, all checkboxes will have `required` set to `true`.
-   */
-  required?: boolean;
-  /**
-   * Callback that is called when the value of the group changes.
-   * @param nextValue string[]
-   * @param currentValue string[]
-   * @returns void
-   */
-  onChange?: (nextValue: string[], currentValue: string[]) => void;
-};
+export type UseCheckboxGroupProps = MergeRight<
+  CheckboxProps,
+  {
+    /**
+     * Disables all checkboxes in the group.
+     */
+    disabled?: boolean;
+    /**
+     * Error message for the group.
+     * If set, all checkboxes will have `aria-invalid` set to `true`.
+     */
+    error?: ReactNode;
+    /**
+     * Name of the group.
+     * If not set, a random id will be generated.
+     */
+    name?: string;
+    /**
+     * Makes all checkboxes in the group read-only.
+     * If set, all checkboxes will have `aria-readonly` set to `true`.
+     */
+    readOnly?: boolean;
+    /**
+     * Initial value of the group
+     * @default []
+     */
+    value?: string[];
+    /**
+     * Makes all checkboxes in the group required.
+     * If set, all checkboxes will have `required` set to `true`.
+     */
+    required?: boolean;
+    /**
+     * Callback that is called when the value of the group changes.
+     * @param nextValue string[]
+     * @param currentValue string[]
+     * @returns void
+     */
+    onChange?: (nextValue: string[], currentValue: string[]) => void;
+  }
+>;
 
 /**
  * Get anything that is set on a checkbox, but
@@ -151,7 +155,14 @@ export function useCheckboxGroup(
      * <Checkbox {...getCheckboxProps({ value: 'all', allowIndeterminate: true })} />
      */
     getCheckboxProps: (propsOrValue?: string | GetCheckboxProps) => {
-      const props =
+      let groupProps:
+        | Omit<CheckboxProps, 'aria-label' | 'aria-labelledby'>
+        | undefined;
+      if (props) {
+        const { onChange, error, ...rest } = props;
+        groupProps = rest;
+      }
+      const checkboxProps =
         typeof propsOrValue === 'string'
           ? { value: propsOrValue }
           : propsOrValue || {};
@@ -161,7 +172,7 @@ export function useCheckboxGroup(
         ref: forwardedRef = undefined,
         value = '',
         ...rest
-      } = props;
+      } = checkboxProps;
 
       const handleRef = (element: HTMLInputElement | null) => {
         if (element) {
@@ -209,6 +220,7 @@ export function useCheckboxGroup(
       };
 
       return {
+        ...groupProps,
         ...rest,
         'aria-describedby':
           `${error ? errorId : ''} ${rest['aria-describedby'] || ''}`.trim() ||

--- a/packages/react/src/utilities/hooks/use-radio-group/use-radio-group.test.tsx
+++ b/packages/react/src/utilities/hooks/use-radio-group/use-radio-group.test.tsx
@@ -121,6 +121,20 @@ describe('RadioGroup', () => {
     expect(radio3).toHaveAttribute('aria-invalid', 'true');
     expect(error).toBeVisible();
   });
+  test('has passed variant to Radio children', () => {
+    render(<RadioGroup variant='outline' />);
+    const labels = ['Test 1', 'Test 2', 'Test 3'];
+    const radios = labels.map((label) => screen.getByLabelText(label));
+    const fields = radios
+      .map((radio) => radio.parentElement)
+      .filter((x) => x !== null);
+
+    expect(fields).toHaveLength(labels.length);
+    for (const field of fields) {
+      expect(field.nodeName).toBe('DS-FIELD');
+      expect(field).toHaveAttribute('data-variant', 'outline');
+    }
+  });
   test('has correct Radio checked when value is used', () => {
     render(<RadioGroup value='test1' />);
 

--- a/packages/react/src/utilities/hooks/use-radio-group/use-radio-group.ts
+++ b/packages/react/src/utilities/hooks/use-radio-group/use-radio-group.ts
@@ -78,16 +78,17 @@ type useRadioGroupReturn = {
  *   value: '',
  * });
  */
-export function useRadioGroup({
-  error,
-  readOnly,
-  required,
-  disabled,
-  name,
-  onChange,
-  value: initalValue = '',
-}: UseRadioGroupProps = {}): useRadioGroupReturn {
-  const [groupValue, setGroupValue] = useState(initalValue);
+export function useRadioGroup(props?: UseRadioGroupProps): useRadioGroupReturn {
+  const {
+    error,
+    readOnly,
+    required,
+    disabled,
+    name,
+    onChange,
+    value: initialValue = '',
+  } = props || {};
+  const [groupValue, setGroupValue] = useState(initialValue);
   const errorId = useId();
   const namedId = useId();
   const radioGroupName = name || namedId;

--- a/packages/react/src/utilities/hooks/use-radio-group/use-radio-group.ts
+++ b/packages/react/src/utilities/hooks/use-radio-group/use-radio-group.ts
@@ -7,27 +7,31 @@ import type {
 } from 'react';
 import { useId, useState } from 'react';
 import type { RadioProps } from '../../../components';
+import type { MergeRight } from '../../types';
 
-export type UseRadioGroupProps = {
-  /** Set disabled state of all radios */
-  disabled?: boolean;
-  /** Shared error message for all radios */
-  error?: ReactNode;
-  /** Name of all radios.
-   * @default string of auto-generated name
-   */
-  name?: string;
-  /** Set read only state of all radios */
-  readOnly?: boolean;
-  /** Set required state of all radios */
-  required?: boolean;
-  /**
-   * Initial value of the group
-   */
-  value?: string;
-  /** Callback when selected radios changes */
-  onChange?: (nextValue: string, prevValue: string) => void;
-};
+export type UseRadioGroupProps = MergeRight<
+  RadioProps,
+  {
+    /** Set disabled state of all radios */
+    disabled?: boolean;
+    /** Shared error message for all radios */
+    error?: ReactNode;
+    /** Name of all radios.
+     * @default string of auto-generated name
+     */
+    name?: string;
+    /** Set read only state of all radios */
+    readOnly?: boolean;
+    /** Set required state of all radios */
+    required?: boolean;
+    /**
+     * Initial value of the group
+     */
+    value?: string;
+    /** Callback when selected radios changes */
+    onChange?: (nextValue: string, prevValue: string) => void;
+  }
+>;
 
 /**
  * Get anything that is set on a radio, but
@@ -106,11 +110,18 @@ export function useRadioGroup({
      * <Radio label="Option 1" {...getRadioProps('option-1')} />
      */
     getRadioProps: (propsOrValue: string | GetRadioProps) => {
-      const props =
+      let groupProps:
+        | Omit<RadioProps, 'aria-label' | 'aria-labelledby'>
+        | undefined;
+      if (props) {
+        const { onChange, error, ...rest } = props;
+        groupProps = rest;
+      }
+      const radioProps =
         typeof propsOrValue === 'string'
           ? { value: propsOrValue }
           : propsOrValue;
-      const { ref: forwardedRef = undefined, value = '', ...rest } = props;
+      const { ref: forwardedRef = undefined, value = '', ...rest } = radioProps;
 
       const handleRef = (element: HTMLInputElement | null) => {
         if (element) {
@@ -138,6 +149,7 @@ export function useRadioGroup({
       };
 
       return {
+        ...groupProps,
         ...rest,
         name: radioGroupName,
         'aria-describedby':

--- a/packages/react/src/utilities/hooks/use-radio-group/use-radio-group.ts
+++ b/packages/react/src/utilities/hooks/use-radio-group/use-radio-group.ts
@@ -7,31 +7,31 @@ import type {
 } from 'react';
 import { useId, useState } from 'react';
 import type { RadioProps } from '../../../components';
-import type { MergeRight } from '../../types';
 
-export type UseRadioGroupProps = MergeRight<
-  RadioProps,
-  {
-    /** Set disabled state of all radios */
-    disabled?: boolean;
-    /** Shared error message for all radios */
-    error?: ReactNode;
-    /** Name of all radios.
-     * @default string of auto-generated name
-     */
-    name?: string;
-    /** Set read only state of all radios */
-    readOnly?: boolean;
-    /** Set required state of all radios */
-    required?: boolean;
-    /**
-     * Initial value of the group
-     */
-    value?: string;
-    /** Callback when selected radios changes */
-    onChange?: (nextValue: string, prevValue: string) => void;
-  }
->;
+export type UseRadioGroupProps = {
+  /** Set disabled state of all radios */
+  disabled?: boolean;
+  /** Shared error message for all radios */
+  error?: ReactNode;
+  /** Name of all radios.
+   * @default string of auto-generated name
+   */
+  name?: string;
+  /** Set read only state of all radios */
+  readOnly?: boolean;
+  /** Set required state of all radios */
+  required?: boolean;
+  /**
+   * Initial value of the group
+   */
+  value?: string;
+  /** Callback when selected radios changes */
+  onChange?: (nextValue: string, prevValue: string) => void;
+  /**
+   * If outline, all radios in the group will have a border
+   */
+  variant?: RadioProps['variant'];
+};
 
 /**
  * Get anything that is set on a radio, but
@@ -112,7 +112,7 @@ export function useRadioGroup(props?: UseRadioGroupProps): useRadioGroupReturn {
      */
     getRadioProps: (propsOrValue: string | GetRadioProps) => {
       let groupProps:
-        | Omit<RadioProps, 'aria-label' | 'aria-labelledby'>
+        | Omit<UseRadioGroupProps, 'onChange' | 'error'>
         | undefined;
       if (props) {
         const { onChange, error, ...rest } = props;


### PR DESCRIPTION
## Summary

**useCheckboxGroup** and **useRadioGroup**: these hooks now also accept the prop `variant`, which sets the variant for all the checkboxes or radios in the group.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
