### PR TITLE
ci: disable coderabbit review status

### DIFF
--- a/coderabbit.yaml
+++ b/coderabbit.yaml
@@ -5,11 +5,12 @@ language: en-US
 early_access: false
 tone_instructions: "Please check documentation in English (en-US), Norwegian Bokmål (nb-NO), and Norwegian Nynorsk (nn-NO)."
 reviews:
+  review_status: false
   profile: "chill"
   poem: false
   high_level_summary: true
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     base_branches:
       - "main"


### PR DESCRIPTION
disable the review comment and auto-review so we need to prompt for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic reviews
  * Disabled review status feature

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/digdir/designsystemet/pull/4882)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->