### PR TITLE
fix(SuggestionInput): remove unsupported props

### DIFF
--- a/.changeset/quiet-birds-attend.md
+++ b/.changeset/quiet-birds-attend.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet-react": minor
 ---
 
-**SuggestionInput:** Remove unsupported props `role` and `data-indeterminate` that would break `Suggestion`
+**SuggestionInput:** Remove unsupported props `role` and `data-indeterminate` that would break `Suggestion`

--- a/.changeset/quiet-birds-attend.md
+++ b/.changeset/quiet-birds-attend.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": minor
+---
+
+**SuggestionInput:** Remove unsupported props `role` and `data-indeterminate` that would break `Suggestion`

--- a/packages/react/src/components/suggestion/suggestion-input.tsx
+++ b/packages/react/src/components/suggestion/suggestion-input.tsx
@@ -2,7 +2,10 @@ import { forwardRef, useContext, useEffect } from 'react';
 import { Input, type InputProps } from '../input/input';
 import { SuggestionContext } from './suggestion';
 
-export type SuggestionInputProps = InputProps;
+export type SuggestionInputProps = Omit<
+  InputProps,
+  'role' | 'data-indeterminate'
+>;
 
 // Make React support popovertarget attribute
 // https://github.com/facebook/react/issues/27479


### PR DESCRIPTION
When reviewing #4867 with @eirikbacker we discovered some props that would break `Suggestion` if used.

Remove them from props to avoid misuse.