### PR TITLE
fix(error-summary): set `role="group"` to allow use of aria labelling attrs

### DIFF
--- a/.changeset/moody-berries-itch.md
+++ b/.changeset/moody-berries-itch.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**Error summary**: Now only sets `aria-labelledby` based on heading element if `aria-label` or `aria-labelledby` is not already set, and logs a warning if neither of these are set and no heading element is present.

--- a/.changeset/true-insects-joke.md
+++ b/.changeset/true-insects-joke.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**Error summary**: Set `role="group"` since the implicit role "generic" does not allow `aria-labelledby`, which is used in the component

--- a/packages/web/src/error-summary/error-summary.ts
+++ b/packages/web/src/error-summary/error-summary.ts
@@ -7,6 +7,7 @@ import {
   onMutation,
   QUICK_EVENT,
   useId,
+  warn,
 } from '../utils/utils';
 
 declare global {
@@ -20,6 +21,7 @@ export class DSErrorSummaryElement extends DSElement {
 
   connectedCallback() {
     on(this, 'animationend', this, QUICK_EVENT); // Using animationend to detect when element is visible
+    attr(this, 'role', 'group');
     attr(this, 'tabindex', '-1');
     this._unmutate = onMutation(this, render, {
       childList: true,
@@ -38,8 +40,21 @@ export class DSErrorSummaryElement extends DSElement {
 }
 
 const render = (self: DSErrorSummaryElement) => {
+  const label = attr(self, 'aria-label')?.trim();
+  let labelledBy = attr(self, 'aria-labelledby')?.trim();
   const heading = self.querySelector('h2,h3,h4,h5,h6');
-  if (heading) attr(self, 'aria-labelledby', useId(heading));
+  if (heading && !label && !labelledBy) {
+    attr(self, 'aria-labelledby', useId(heading));
+  }
+
+  labelledBy = attr(self, 'aria-labelledby')?.trim();
+  if (!label && !labelledBy) {
+    warn(
+      'Missing accessible name on:',
+      self,
+      '\nAdd a heading (h2–h6), or set aria-label or aria-labelledby to provide an accessible name for screen readers.',
+    );
+  }
 };
 
 customElements.define('ds-error-summary', DSErrorSummaryElement);

--- a/packages/web/src/error-summary/error-summary.ts
+++ b/packages/web/src/error-summary/error-summary.ts
@@ -41,14 +41,12 @@ export class DSErrorSummaryElement extends DSElement {
 
 const render = (self: DSErrorSummaryElement) => {
   const label = attr(self, 'aria-label')?.trim();
-  let labelledBy = attr(self, 'aria-labelledby')?.trim();
+  const labelledBy = attr(self, 'aria-labelledby')?.trim();
   const heading = self.querySelector('h2,h3,h4,h5,h6');
   if (heading && !label && !labelledBy) {
     attr(self, 'aria-labelledby', useId(heading));
   }
-
-  labelledBy = attr(self, 'aria-labelledby')?.trim();
-  if (!label && !labelledBy) {
+  if (!heading && !label && !labelledBy) {
     warn(
       'Missing accessible name on:',
       self,


### PR DESCRIPTION
## Summary

Error summary sets `aria-labelledby` when it contains a heading, but the implicit role `generic` [does not allow this aria-attribute](https://www.w3.org/TR/wai-aria-1.2/#generic). The accessibility checker ARC Toolkit reports this as a violation of _WCAG 4.1.2 Name, Role, Value_.

This PR sets the element to have the [`group` role](https://www.w3.org/TR/wai-aria-1.2/#group) instead. It also logs a warning if the error summary ends up with no `aria-label` or `aria-labelledby`, and only auto-sets `aria-labelledby` if there was no `aria-label` or `aria-labelledby` already.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
