### PR TITLE
fix(Card): don't require `class="ds-link"` on links, since that wasn't recommended until recently

### DIFF
--- a/.changeset/smart-geese-sleep.md
+++ b/.changeset/smart-geese-sleep.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Card**: when using a link in a Card, ensure plain `<a>` tags without `class="ds-link"` also get the correct focus styling.

--- a/packages/css/src/card.css
+++ b/packages/css/src/card.css
@@ -53,6 +53,7 @@
       & > a {
         text-decoration: none;
         color: inherit;
+        @composes ds-focus from './base.css';
       }
     }
   }


### PR DESCRIPTION

## Summary

Ensures Cards with `<a>` in a heading element get the correct focus styling, even when `class="ds-link"` is omitted.

We [used to recommend](https://github.com/digdir/designsystemet/blob/48e991ddae92e30cc3a07dba95cecb46f5aec50b/packages/react/src/components/card/card.stories.tsx#L141-L147) using plain `<a>` elements without `class="ds-link"`, so there will be plenty of usages like that in the wild.

[Before - tab through the links and see that the first link has wrong focus style](https://66fe736b9d639fe6801bf130-odusfgclhn.chromatic.com/iframe.html?id=komponenter-card--with-link&viewMode=story&globals=viewport.width%3A1200)

[After - the focus styles are now the same](https://66fe736b9d639fe6801bf130-pmcjavvspb.chromatic.com/iframe.html?id=komponenter-card--with-link&viewMode=story)

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
