### PR TITLE
fix(Popover): width in firefox

### DIFF
--- a/.changeset/nine-masks-drum.md
+++ b/.changeset/nine-masks-drum.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-react": patch
+"@digdir/designsystemet-web": patch
+---
+
+**Popover:** now correctly calculates width of source element also in Firefox

--- a/packages/web/src/popover/popover.ts
+++ b/packages/web/src/popover/popover.ts
@@ -66,7 +66,7 @@ function handleToggle(
             size({
               apply({ availableHeight }) {
                 if (overscroll === 'fit')
-                  el.style.width = `${source.clientWidth}px`;
+                  el.style.width = `${source.offsetWidth}px`; // Use offsetWidth to include padding, matching the width of the source element
                 el.style.maxHeight = `${Math.max(50, availableHeight - padding * 2)}px`;
               },
             }),


### PR DESCRIPTION
- ✅ Fix: `Popover` now correctly calculates width of source element also in Firefox