### PR TITLE
chore: fix type error in code-block

### DIFF
--- a/internal/components/src/code-block/code-block.tsx
+++ b/internal/components/src/code-block/code-block.tsx
@@ -109,11 +109,10 @@ const CodeBlockContent = ({
           <CopyButton text={text} />
         </div>
         <ReactCodeBlock.Code className={cl(classes.codeBlock, className)}>
-          <code>
-            <ReactCodeBlock.LineContent as='span'>
-              <ReactCodeBlock.Token />
-            </ReactCodeBlock.LineContent>
-          </code>
+          {/* @ts-ignore TODO: Children has incorrect type when as is defined */}
+          <ReactCodeBlock.LineContent as='code'>
+            <ReactCodeBlock.Token />
+          </ReactCodeBlock.LineContent>
         </ReactCodeBlock.Code>
       </div>
     </ReactCodeBlock>

--- a/internal/components/src/code-block/code-block.tsx
+++ b/internal/components/src/code-block/code-block.tsx
@@ -109,12 +109,10 @@ const CodeBlockContent = ({
           <CopyButton text={text} />
         </div>
         <ReactCodeBlock.Code className={cl(classes.codeBlock, className)}>
-          <code>
-            {/* @ts-ignore TODO: Children has incorrect type when as is defined */}
-            <ReactCodeBlock.LineContent as='span'>
-              <ReactCodeBlock.Token />
-            </ReactCodeBlock.LineContent>
-          </code>
+          {/* @ts-ignore TODO: Children has incorrect type when as is defined */}
+          <ReactCodeBlock.LineContent as='code'>
+            <ReactCodeBlock.Token />
+          </ReactCodeBlock.LineContent>
         </ReactCodeBlock.Code>
       </div>
     </ReactCodeBlock>

--- a/internal/components/src/code-block/code-block.tsx
+++ b/internal/components/src/code-block/code-block.tsx
@@ -109,10 +109,12 @@ const CodeBlockContent = ({
           <CopyButton text={text} />
         </div>
         <ReactCodeBlock.Code className={cl(classes.codeBlock, className)}>
-          {/* @ts-ignore TODO: Children has incorrect type when as is defined */}
-          <ReactCodeBlock.LineContent as='code'>
-            <ReactCodeBlock.Token />
-          </ReactCodeBlock.LineContent>
+          <code>
+            {/* @ts-ignore TODO: Children has incorrect type when as is defined */}
+            <ReactCodeBlock.LineContent as='span'>
+              <ReactCodeBlock.Token />
+            </ReactCodeBlock.LineContent>
+          </code>
         </ReactCodeBlock.Code>
       </div>
     </ReactCodeBlock>


### PR DESCRIPTION
When `as` is used the wrong type is picked from union in react-code-block.

<img width="1259" height="388" alt="image" src="https://github.com/user-attachments/assets/9e4aa7f7-6d9d-49c1-a339-45a17969ab02" />

Suggest ignoring it for now until we find a better fix for this.