### PR TITLE
fix(Popover): correct fallback offset value to 8px when no arrow

### DIFF
--- a/.changeset/heavy-pots-knock.md
+++ b/.changeset/heavy-pots-knock.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**Popover**: Correct the fallback offset floating value to 8px when no arrow is present

--- a/.changeset/heavy-pots-knock.md
+++ b/.changeset/heavy-pots-knock.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet-web": patch
 ---
 
-**Popover**: Correct the fallback offset floating value to 8px when no arrow is present
+**Popover, Dropdown, Tooltip, Suggestion**: Correct the fallback offset floating value to 8px when no arrow is present

--- a/packages/web/src/popover/popover.ts
+++ b/packages/web/src/popover/popover.ts
@@ -54,7 +54,7 @@ function handleToggle(
     strategy: 'absolute',
     placement,
     middleware: [
-      offset(arrowSize || 0), // Add space for arrow or default to 8px
+      offset(arrowSize || 8), // Add space for arrow or default to 8px
       shift({
         padding,
         limiter: limitShift({ offset: { mainAxis: shiftLimit } }), // Prevent from shifing away from source


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

<!-- Explain in short what this PR does -->

If the popover/tooltip/some other element depending on `popover.ts` is created with custom styles not using a `::before` pseudo-element, the shift-param currently ends up being 0, even though the comment at the same line implies that it should default to `8px`. This fixes that.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
