### PR TITLE
fix(Suggestion): better handle async React rendering u-datalist

### DIFF
--- a/.changeset/crisp-terms-fix.md
+++ b/.changeset/crisp-terms-fix.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Suggestion:** Better handle React async rendering child `<u-datalist>` element

--- a/packages/react/src/components/tabs/tabs-tab.tsx
+++ b/packages/react/src/components/tabs/tabs-tab.tsx
@@ -25,7 +25,6 @@ export const TabsTab = forwardRef<DSTabElement, TabsTabProps>(function TabsTab(
     useContext(Context);
 
   return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: ds-tabs IS interactive
     <ds-tab
       aria-controls={rest['aria-controls'] ?? getPrefixedValue?.(value)}
       data-value={value}

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -9,7 +9,7 @@ import './readonly/readonly';
 import './toggle-group/toggle-group';
 import './tooltip/tooltip';
 
-export * from '@u-elements/u-datalist'; // Re-export u-datalist since this is a pure polyfill and not custom Designsystemet elements
+export * from '@u-elements/u-datalist'; // Re-export u-datalist since this is a pure polyfill and not custom Designsystemet elements, should run before suggestion
 export * from './breadcrumbs/breadcrumbs';
 export * from './error-summary/error-summary';
 export * from './field/field';

--- a/packages/web/src/suggestion/suggestion.ts
+++ b/packages/web/src/suggestion/suggestion.ts
@@ -32,11 +32,14 @@ export class DSSuggestionElement extends UHTMLComboboxElement {
 }
 
 // A non-empty placeholder attribute is required to activate the :placeholder-shown pseudo selector used in our chevron styling
-const render = ({ control, list }: DSSuggestionElement) => {
+const render = (self: DSSuggestionElement) => {
+  const { control, list } = self;
+  const datalist = list || self.querySelector('u-datalist'); // Fallback to u-datalist since React can render the ds-suggestion before u-datalist is connected
+
   if (control && !control.placeholder) attr(control, 'placeholder', ' '); // .control comes from UHTMLComboboxElement
   if (control) attr(control, 'popovertarget', useId(list) || null);
-  if (list) attr(list, 'popover', 'manual'); // Ensure popover attribute is set on the list
-  if (list) attr(list, 'data-is-floating', 'true'); // identifier for css to toggle opacity when it is placed by floating-ui.
+  if (datalist) attr(datalist, 'popover', 'manual'); // Ensure popover attribute is set on the list
+  if (datalist) attr(datalist, 'data-is-floating', 'true'); // identifier for css to toggle opacity when it is placed by floating-ui.
 };
 
 // Since showPopover({ source }) is not supported in all browsers yet:
@@ -48,4 +51,5 @@ const polyfillToggleSource = (event: Partial<ToggleEvent>) => {
     self.list?.dispatchEvent(new CustomEvent('ds-toggle-source', { detail }));
 };
 
+// Ensure u-datalist is defined before ds-suggestion
 customElements.define('ds-suggestion', DSSuggestionElement);


### PR DESCRIPTION
React might render `ds-suggestion` before `u-datalist` is properly connected, causing initial `ds-suggestion` render to not find the list. This PR fixes the issue with a fallback to find the `u-datalist` element ☺️ 