### PR TITLE
fix(label): remove default value for weight prop

### DIFF
--- a/.changeset/fancy-buckets-do.md
+++ b/.changeset/fancy-buckets-do.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet-react": patch
 ---
 
-**Label**: Remove default value for `weight` prop
+**Label**: Removed unneeded default value for `weight` prop.

--- a/.changeset/fancy-buckets-do.md
+++ b/.changeset/fancy-buckets-do.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Label**: Remove default value for `weight` prop

--- a/packages/react/src/components/label/label.tsx
+++ b/packages/react/src/components/label/label.tsx
@@ -7,7 +7,6 @@ import type { DefaultProps } from '../../types';
 export type LabelProps = {
   /**
    * Adjusts font weight. Use this when you have a label hierarchy, such as checkboxes/radios in a fieldset
-   * @default 'medium'
    */
   weight?: 'regular' | 'medium' | 'semibold';
   /**
@@ -25,7 +24,7 @@ export type LabelProps = {
  * <Label data-size='lg' weight='medium'>Label</Label>
  */
 export const Label = forwardRef<HTMLLabelElement, LabelProps>(function Label(
-  { className, weight = 'medium', asChild, ...rest },
+  { className, weight, asChild, ...rest },
   ref,
 ) {
   const Component = asChild ? Slot : 'label';


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

This removes the default value for `weight` in the Label component in React, allowing downstream consumers to override the default weight for Label by simply overriding CSS.

The motivation for this change is that we want to use font-weight "semibold" as the default for labels, as "medium" is a bit too thin for our needs.

Here is an example for overriding the default weight, that works for both `<label class="ds-label">` and `<Label>`:

```css
.ds-label {
  font-weight: var(--ds-font-weight-semibold);

  &[data-weight="medium"] {
    font-weight: var(--ds-font-weight-medium);
  }
}
```

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
