### PR TITLE
docs: move consent storage sections to Forberedelser

### DIFF
--- a/apps/www/app/content/patterns/no/consent-banner.mdx
+++ b/apps/www/app/content/patterns/no/consent-banner.mdx
@@ -30,6 +30,16 @@ Vurder også hvilke teknologier som er nødvendige og hvilke som er valgfrie.
 
 Se [Datatilsynets veileder om informasjonskapsler og andre sporingsteknologier](https://www.datatilsynet.no/personvern-pa-ulike-omrader/internett-og-apper/bruk-av-informasjonskapsler-og-andre-sporingsteknologier/) om når samtykke er nødvendig. Du finner også informasjon på [Nkoms side om informasjonskapsler](https://nkom.no/internett/informasjonskapsler-cookies), og om strengt nødvendige teknologier i [ekomloven § 3-15](https://lovdata.no/lov/2024-12-13-76/§3-15).
 
+### Lagring av samtykke
+Det trengs ikke eget samtykke for å lagre selve samtykkesvaret. Det regnes som en strengt nødvendig informasjonskapsel, siden du er pålagt å be om samtykke og det er nødvendig å lagre svaret for å oppfylle dette.
+
+Utover det bør du lagre så lite som mulig:
+- Lagre minst mulig data, og i kortest mulig tid. For eksempel: data fra en A/B-test trenger ikke lagres etter at testen er avsluttet og retningen er valgt.
+- Ikke lagre standardverdier. Hvis norsk er standardspråket på nettstedet, trenger du ikke lagre dette på brukernes enhet – lagre kun når brukerne avviker fra standarden.
+
+### Deling av samtykke på tvers av tjenester
+Hvis du skal dele samtykket på tvers av tjenester, må brukerne oppleve de aktuelle sidene som en del av det samme nettstedet. Samtykkebanneret må i tillegg inneholde informasjon om alt brukeren gir tillatelse til å lese eller lagre i alle tjenestene som deler banneret.
+
 ## Design og opplevelse
 
 ### Hvis du kan ha ett spørsmål
@@ -183,16 +193,6 @@ Samtykkebanneret skal følge vanlig fokusrekkefølge i DOM-en. La brukerne navig
 - Banneret bør ligge før «hopp til hovedinnhold»-lenken. Da blir banneret lettere å oppdage for tastaturbrukere, samtidig som brukerne fortsatt kan hoppe videre til hovedinnholdet etter banneret.
 - Pass på at fokus ikke blir fanget inne i banneret. Siden må fungere uten at man interagerer med samtykkebanneret.
 
-### Lagre samtykket
-Det trengs ikke eget samtykke for å lagre selve samtykkesvaret. Det regnes som en strengt nødvendig informasjonskapsel, siden du er pålagt å be om samtykke og det er nødvendig å lagre svaret for å oppfylle dette.
-
-Utover det bør du lagre så lite som mulig:
-- Lagre minst mulig data, og i kortest mulig tid. For eksempel: data fra en A/B-test trenger ikke lagres etter at testen er avsluttet og retningen er valgt.
-- Ikke lagre standardverdier. Hvis norsk er standardspråket på nettstedet, trenger du ikke lagre dette på brukernes enhet – lagre kun når brukerne avviker fra standarden.
-
-### Dele et samtykke på tvers av tjenester
-Hvis du skal dele samtykket på tvers av tjenester, må brukerne oppleve de aktuelle sidene som en del av det samme nettstedet. Samtykkebanneret må i tillegg inneholde informasjon om alt brukeren gir tillatelse til å lese eller lagre i alle tjenestene som deler banneret.
-      
 ## Kilder og relevant informasjon
 
 - [Samtykke til bruk av informasjonskapsler og andre sporingsteknologier hos Datatilsynet](https://www.datatilsynet.no/personvern-pa-ulike-omrader/internett-og-apper/bruk-av-informasjonskapsler-og-andre-sporingsteknologier/)


### PR DESCRIPTION
## Summary
- Move «Lagring av samtykke» and «Deling av samtykke på tvers av tjenester» from the Kode section to Forberedelser