### PR TITLE
chore: update node engines to 24.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800",
   "engines": {
-    "node": ">=24.15.0",
+    "node": ">=24.16.0",
     "runtime": {
       "name": "node",
-      "version": "^24.15.0",
+      "version": "^24.16.0",
       "onFail": "download"
     }
   },

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,14 @@
       "matchStrings": ["{ 'currentValue': useNodeVersion }"],
       "datasourceTemplate": "node-version",
       "depNameTemplate": "node"
+    },
+    {
+      "customType": "jsonata",
+      "fileFormat": "json",
+      "managerFilePatterns": ["/^package.json$/"],
+      "matchStrings": ["engines.runtime[name = 'node'].{ 'currentValue': version }"],
+      "datasourceTemplate": "node-version",
+      "depNameTemplate": "node"
     }
   ]
 }


### PR DESCRIPTION
- updated node engines to 24.16.0
- added matcher for renovate to update engines.runtime