### PR TITLE
ci: remove visual test skip

### DIFF
--- a/.github/workflows/test-visual.yml
+++ b/.github/workflows/test-visual.yml
@@ -7,23 +7,23 @@ on:
     types: [opened, ready_for_review, synchronize, reopened]
     paths:
       - .github/workflows/test-visual.yml
-      - 'packages/**/*.tsx?'
-      - 'packages/**/*.css'
-      - 'packages/**/package.json'
-      - 'packages/**/*.stories.tsx?'
-      - 'apps/storybook/**'
-      - 'design-tokens/**/*.jsonc?'
+      - "packages/**/*.tsx?"
+      - "packages/**/*.css"
+      - "packages/**/package.json"
+      - "packages/**/*.stories.tsx?"
+      - "apps/storybook/**"
+      - "design-tokens/**/*.jsonc?"
 
   # main gets a push run so chromatic can auto-accept baselines there
   push:
     branches: [main]
     paths:
-      - 'packages/**/*.tsx?'
-      - 'packages/**/*.css'
-      - 'packages/**/package.json'
-      - 'packages/**/*.stories.tsx?'
-      - 'apps/storybook/**'
-      - 'design-tokens/**/*.jsonc?'
+      - "packages/**/*.tsx?"
+      - "packages/**/*.css"
+      - "packages/**/package.json"
+      - "packages/**/*.stories.tsx?"
+      - "apps/storybook/**"
+      - "design-tokens/**/*.jsonc?"
 
 concurrency:
   group: visual-${{ github.event.pull_request.number || github.run_id }}
@@ -62,7 +62,6 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitZeroOnChanges: true
           onlyChanged: true
-          skip: '@(renovate/**|dependabot/**)'
 
   main-visual-tests:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main') }}


### PR DESCRIPTION
we now have a higher Chromatic subscription so enable visual tests for updated dependencies also.